### PR TITLE
UIQM-61 005 should not be an editable field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (in progress)
 
+* [UIQM-61](https://issues.folio.org/browse/UIQM-61) Make field 005 not editable
+
 ## [2.0.0](https://github.com/folio-org/ui-quick-marc/tree/v2.0.0) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-quick-marc/compare/v1.1.0...v2.0.0)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -9,30 +9,32 @@ export const isLastRecord = recordRow => {
   );
 };
 
+const READ_ONLY_ROWS = new Set(['001', '005']);
+
 export const isReadOnly = recordRow => (
-  recordRow.tag === '001' || isLastRecord(recordRow)
+  READ_ONLY_ROWS.has(recordRow.tag) || isLastRecord(recordRow)
 );
 
-const INDICATOR_EXEPTION_ROWS = [LEADER_TAG, '001', '002', '003', '004', '005', '006', '007', '008', '009'];
+const INDICATOR_EXEPTION_ROWS = new Set([LEADER_TAG, '001', '002', '003', '004', '005', '006', '007', '008', '009']);
 
-export const hasIndicatorException = recordRow => INDICATOR_EXEPTION_ROWS.includes(recordRow.tag);
+export const hasIndicatorException = recordRow => INDICATOR_EXEPTION_ROWS.has(recordRow.tag);
 
-const ADD_EXCEPTION_ROWS = [LEADER_TAG, '001', '003', '005', '008'];
+const ADD_EXCEPTION_ROWS = new Set([LEADER_TAG, '001', '003', '005', '008']);
 
-export const hasAddException = recordRow => ADD_EXCEPTION_ROWS.includes(recordRow.tag);
+export const hasAddException = recordRow => ADD_EXCEPTION_ROWS.has(recordRow.tag);
 
-const DELETE_EXCEPTION_ROWS = [LEADER_TAG, '001', '003', '005', '008'];
+const DELETE_EXCEPTION_ROWS = new Set([LEADER_TAG, '001', '003', '005', '008']);
 
 export const hasDeleteException = recordRow => (
-  DELETE_EXCEPTION_ROWS.includes(recordRow.tag) || isLastRecord(recordRow)
+  DELETE_EXCEPTION_ROWS.has(recordRow.tag) || isLastRecord(recordRow)
 );
 
-const MOVE_EXCEPTION_ROWS = [LEADER_TAG, '001', '005', '008'];
+const MOVE_EXCEPTION_ROWS = new Set([LEADER_TAG, '001', '005', '008']);
 
 export const hasMoveException = (recordRow, sibling) => (
   !sibling
-  || MOVE_EXCEPTION_ROWS.includes(recordRow.tag)
-  || MOVE_EXCEPTION_ROWS.includes(sibling.tag)
+  || MOVE_EXCEPTION_ROWS.has(recordRow.tag)
+  || MOVE_EXCEPTION_ROWS.has(sibling.tag)
 );
 
 export const isMaterialCharsRecord = recordRow => recordRow.tag === '006';

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
@@ -8,6 +8,10 @@ describe('QuickMarcEditorRows utils', () => {
       expect(utils.isReadOnly({ tag: '001' })).toBeTruthy();
     });
 
+    it('should be true for tag 005 (Date and Time of Latest Transaction)', () => {
+      expect(utils.isReadOnly({ tag: '005' })).toBeTruthy();
+    });
+
     it('should be true for record end', () => {
       expect(utils.isReadOnly({ tag: '999', indicators: ['f', 'f'] })).toBeTruthy();
     });


### PR DESCRIPTION
UIQM-61 005 should not be an editable field

## Purpose
The 005 field is a system-generated field, it is a [Date and Time of Latest Transaction](https://www.loc.gov/marc/bibliographic/bd005.html).
Users should not be allowed to manually edit it.


## Approach
The field in the form is made read-only

#### TODOS and Open Questions
Maybe we should not pass the 005 field (and all other read-only fields) in the update request too.
Because making it read-only in the form gives no guarantee it can not be changed (using dev-tools in browser, for example).
But for now this won't work correctly: the PUT request takes the record in full, and if the field is not in it -it's being removed on server

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
