### PR TITLE
UIQM-67: Update display of record status in quickMARC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-quick-marc
 
 ## (in progress)
+* [UIQM-67](https://issues.folio.org/browse/UIQM-61) Update display of record status
 
 ## [2.0.1](https://github.com/folio-org/ui-quick-marc/tree/v2.0.1) (2020-11-11)
 [Full Changelog](https://github.com/folio-org/ui-quick-marc/compare/v2.0.0...v2.0.1)

--- a/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.css
+++ b/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.css
@@ -1,7 +1,5 @@
 .quickMarcRecordInfoWrapper {
   & > span {
-    vertical-align: middle;
-    display: inline-block;
-    margin-right: 10px;
+    margin: 0 3px;
   }
 }

--- a/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.js
+++ b/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.js
@@ -5,14 +5,12 @@ import {
 } from 'react-intl';
 
 import {
-  Badge,
   FormattedDate,
   FormattedTime,
 } from '@folio/stripes/components';
 
 import {
   RECORD_STATUS_CURRENT,
-  RECORD_STATUS_COLORS,
   RECORD_STATUS_LABELS,
 } from './constants';
 
@@ -24,13 +22,13 @@ export const QuickMarcRecordInfo = ({ status, updateDate }) => {
       className={styles.quickMarcRecordInfoWrapper}
       data-test-quick-marc-record-info
     >
-      <Badge color={RECORD_STATUS_COLORS[status]}>
-        {RECORD_STATUS_LABELS[status]}
-      </Badge>
-
+      <FormattedMessage id="ui-quick-marc.record.status" />
+      {" "}
+      {RECORD_STATUS_LABELS[status]}
       {
         Boolean(updateDate) && (
-          <span>
+          <>
+            <span>&nbsp;&bull;&nbsp;</span>
             <FormattedMessage
               id="stripes-components.metaSection.recordLastUpdated"
               values={{
@@ -38,7 +36,7 @@ export const QuickMarcRecordInfo = ({ status, updateDate }) => {
                 time: <FormattedTime value={updateDate} />,
               }}
             />
-          </span>
+          </>
         )
       }
     </div>

--- a/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.js
+++ b/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.js
@@ -23,7 +23,6 @@ export const QuickMarcRecordInfo = ({ status, updateDate }) => {
       data-test-quick-marc-record-info
     >
       <FormattedMessage id="ui-quick-marc.record.status" />
-      {" "}
       {RECORD_STATUS_LABELS[status]}
       {
         Boolean(updateDate) && (

--- a/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.test.js
+++ b/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.test.js
@@ -6,12 +6,12 @@ import '@folio/stripes-acq-components/test/jest/__mock__';
 import { QuickMarcRecordInfo } from './QuickMarcRecordInfo';
 import { RECORD_STATUS_CURRENT } from './constants';
 
-const renderQuickMarcRecordInfo = () => (render(
+const renderQuickMarcRecordInfo = () => render(
   <QuickMarcRecordInfo
     status={RECORD_STATUS_CURRENT}
     updateDate="2020-07-14T12:20:10.000"
   />,
-));
+);
 
 describe('Given Quick Marc Record Info', () => {
   afterEach(cleanup);
@@ -19,7 +19,7 @@ describe('Given Quick Marc Record Info', () => {
   it('Than it should display record status', () => {
     const { getByText } = renderQuickMarcRecordInfo();
 
-    expect(getByText('ui-quick-marc.record.status.current')).toBeDefined();
+    expect(getByText('ui-quick-marc.record.status.current', { exact: false })).toBeDefined();
   });
 
   it('Than it should display record updated date', () => {

--- a/src/QuickMarcEditor/QuickMarcRecordInfo/constants.js
+++ b/src/QuickMarcEditor/QuickMarcRecordInfo/constants.js
@@ -5,12 +5,6 @@ export const RECORD_STATUS_CURRENT = 'ACTUAL';
 export const RECORD_STATUS_PROGRESS = 'IN_PROGRESS';
 export const RECORD_STATUS_ERROR = 'ERROR';
 
-export const RECORD_STATUS_COLORS = {
-  [RECORD_STATUS_CURRENT]: 'primary',
-  [RECORD_STATUS_PROGRESS]: 'primary',
-  [RECORD_STATUS_ERROR]: 'red',
-};
-
 export const RECORD_STATUS_LABELS = {
   [RECORD_STATUS_CURRENT]: <FormattedMessage id="ui-quick-marc.record.status.current" />,
   [RECORD_STATUS_PROGRESS]: <FormattedMessage id="ui-quick-marc.record.status.progress" />,

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -5,6 +5,7 @@
 
   "record.edit.title": "Edit MARC record - {title}",
 
+  "record.status": "Record status:",
   "record.status.current": "Current",
   "record.status.progress": "In progress",
   "record.status.error": "Error",


### PR DESCRIPTION
### UIQM-67 Update display of status at top of record in quickMARC

## Purpose
Update record status displaying.

Issue [UIQM-67](https://issues.folio.org/browse/UIQM-67)

## Screenshot
![image](https://user-images.githubusercontent.com/55701515/104708327-3c7b0100-5726-11eb-84e9-bf845df7cc2f.png)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
