### PR TITLE
UIQM-72: Change delete row behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## (in progress)
 * [UIQM-67](https://issues.folio.org/browse/UIQM-61) Update display of record status
+* [UIQM-72](https://issues.folio.org/browse/UIQM-72) Change delete row behavior
 
 ## [2.0.1](https://github.com/folio-org/ui-quick-marc/tree/v2.0.1) (2020-11-11)
 [Full Changelog](https://github.com/folio-org/ui-quick-marc/compare/v2.0.0...v2.0.1)

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   },
   "dependencies": {
     "@folio/stripes-acq-components": "^2.1.0",
-    "@folio/react-intl-safe-html": "^3.0.0",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.1",
     "lodash": "^4.17.5",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@folio/stripes-acq-components": "^2.1.0",
+    "@folio/react-intl-safe-html": "^3.0.0",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.1",
     "lodash": "^4.17.5",

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -51,14 +51,15 @@ const QuickMarcEditor = ({
   const [isDeleteModalOpened, setIsDeleteModalOpened] = useState(false);
   const [deletedRecords, setDeletedRecords] = useState(0);
 
-  const confirmSubmit = (props) => {
+  const confirmSubmit = useCallback((props) => {
     if (deletedRecords) {
       setIsDeleteModalOpened(true);
+
       return;
     }
 
     handleSubmit(props);
-  };
+  }, [deletedRecords]);
 
   const paneFooter = useMemo(() => {
     const start = (
@@ -86,7 +87,7 @@ const QuickMarcEditor = ({
         renderStart={start}
         renderEnd={end}
       />
-    )
+    );
   }, [onClose, confirmSubmit, pristine, submitting]);
 
   const confirmModalMessage = () => (
@@ -192,6 +193,7 @@ QuickMarcEditor.propTypes = {
   initialValues: PropTypes.object.isRequired,
   form: PropTypes.shape({
     mutators: PropTypes.object.isRequired,
+    reset: PropTypes.func.isRequired,
   }),
 };
 

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -17,7 +17,6 @@ import {
   PaneFooter,
   Button,
 } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import { FormSpy } from 'react-final-form';
 
@@ -49,17 +48,17 @@ const QuickMarcEditor = ({
 }) => {
   const [records, setRecords] = useState([]);
   const [isDeleteModalOpened, setIsDeleteModalOpened] = useState(false);
-  const [deletedRecords, setDeletedRecords] = useState(0);
+  const [deletedRecordsCount, setDeletedRecordsCount] = useState(0);
 
   const confirmSubmit = useCallback((props) => {
-    if (deletedRecords) {
+    if (deletedRecordsCount) {
       setIsDeleteModalOpened(true);
 
       return;
     }
 
     handleSubmit(props);
-  }, [deletedRecords]);
+  }, [deletedRecordsCount]);
 
   const paneFooter = useMemo(() => {
     const start = (
@@ -91,9 +90,9 @@ const QuickMarcEditor = ({
   }, [onClose, confirmSubmit, pristine, submitting]);
 
   const confirmModalMessage = () => (
-    <SafeHTMLMessage
+    <FormattedMessage
       id="ui-quick-marc.record.delete.message"
-      values={{ count: deletedRecords }}
+      values={{ count: deletedRecordsCount }}
     />
   );
 
@@ -104,7 +103,7 @@ const QuickMarcEditor = ({
 
   const onCancelModal = () => {
     setIsDeleteModalOpened(false);
-    setDeletedRecords(0);
+    setDeletedRecordsCount(0);
     reset();
   };
 
@@ -160,7 +159,7 @@ const QuickMarcEditor = ({
                   mutators={mutators}
                   type={initialValues?.leader[6]}
                   subtype={initialValues?.leader[7]}
-                  setDeletedRecords={setDeletedRecords}
+                  setDeletedRecordsCount={setDeletedRecordsCount}
                 />
               </Col>
             </Row>

--- a/src/QuickMarcEditor/QuickMarcEditorRows/BytesField/BytesField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/BytesField/BytesField.js
@@ -10,6 +10,8 @@ import {
   Select,
 } from '@folio/stripes/components';
 
+import { FIXED_FIELD_MAX_LENGTH } from '../../../common/constants';
+
 import styles from './BytesField.css';
 
 export const SUBFIELD_TYPES = {
@@ -47,7 +49,7 @@ const renderSubField = (name, config) => {
                             ariaLabel={ariaLabel}
                             name={`${fieldName}[${idx}]`}
                             component={TextField}
-                            maxlength={1}
+                            maxlength={FIXED_FIELD_MAX_LENGTH}
                             disabled={config.disabled}
                             className={styles.fixedFieldSubFieldByte}
                             hasClearIcon={false}
@@ -87,6 +89,8 @@ const renderSubField = (name, config) => {
     );
   }
 
+  const getMaxLengthByType = () => (config.type === SUBFIELD_TYPES.BYTE ? FIXED_FIELD_MAX_LENGTH : undefined);
+
   return (
     <FormattedMessage id={`ui-quick-marc.record.fixedField.${config.name}`}>
       {ariaLabel => (
@@ -97,7 +101,7 @@ const renderSubField = (name, config) => {
           label={label}
           component={TextField}
           disabled={config.disabled}
-          maxlength={config.type === SUBFIELD_TYPES.BYTE ? 1 : undefined}
+          maxlength={getMaxLengthByType()}
           className={styles[`bytesFieldSubField${config.type}`]}
           hasClearIcon={false}
           data-testid={`fixed-field-${config.type}`}

--- a/src/QuickMarcEditor/QuickMarcEditorRows/BytesField/BytesField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/BytesField/BytesField.js
@@ -89,7 +89,7 @@ const renderSubField = (name, config) => {
     );
   }
 
-  const getMaxLengthByType = () => (config.type === SUBFIELD_TYPES.BYTE ? FIXED_FIELD_MAX_LENGTH : undefined);
+  const getMaxLengthByType = config.type === SUBFIELD_TYPES.BYTE ? FIXED_FIELD_MAX_LENGTH : undefined;
 
   return (
     <FormattedMessage id={`ui-quick-marc.record.fixedField.${config.name}`}>
@@ -101,7 +101,7 @@ const renderSubField = (name, config) => {
           label={label}
           component={TextField}
           disabled={config.disabled}
-          maxlength={getMaxLengthByType()}
+          maxlength={getMaxLengthByType}
           className={styles[`bytesFieldSubField${config.type}`]}
           hasClearIcon={false}
           data-testid={`fixed-field-${config.type}`}

--- a/src/QuickMarcEditor/QuickMarcEditorRows/IndicatorField/IndicatorField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/IndicatorField/IndicatorField.js
@@ -1,8 +1,12 @@
-import React, { useCallback } from 'react';
+import React, {
+  useCallback,
+} from 'react';
 
 import {
   TextField,
 } from '@folio/stripes/components';
+
+import { INDICATOR_FIELD_MAX_LENGTH } from '../../../common/constants';
 
 export const IndicatorField = (props) => {
   const selectContent = useCallback(({ target }) => {
@@ -13,7 +17,7 @@ export const IndicatorField = (props) => {
     <TextField
       {...props}
       onFocus={selectContent}
-      maxlength={1}
+      maxlength={INDICATOR_FIELD_MAX_LENGTH}
       data-testid="indicator-field"
     />
   );

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.css
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.css
@@ -1,5 +1,3 @@
-@import "@folio/stripes-components/lib/variables.css";
-
 .quickMarcEditorRow {
   display: flex;
   padding: 8px;
@@ -8,10 +6,6 @@
 
   &:nth-child(odd) {
     background: rgba(0, 0, 0, .03);
-  }
-
-  &.quickMarcFocusedRow {
-    background: var(--color-fill-focus);
   }
 }
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -53,7 +53,7 @@ const QuickMarcEditorRows = ({
   const deleteRow = useCallback(({ target }) => {
     deleteRecord({ index: +target.dataset.index });
     setDeletedRecords(prevDeletedItems => prevDeletedItems + 1);
-  }, [deleteRecord]);
+  }, [deleteRecord, setDeletedRecords]);
 
   const moveRow = useCallback(({ target }) => {
     moveRecord({
@@ -124,7 +124,6 @@ const QuickMarcEditorRows = ({
                   fullWidth
                   disabled={isDisabled || !idx}
                   hasClearIcon={false}
-                />
                 />
               </div>
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -13,7 +13,6 @@ import {
 } from '@folio/stripes/components';
 
 import { ContentField } from './ContentField';
-
 import { IndicatorField } from './IndicatorField';
 import { MaterialCharsFieldFactory } from './MaterialCharsField';
 import { PhysDescriptionFieldFactory } from './PhysDescriptionField';
@@ -24,11 +23,11 @@ import {
   hasAddException,
   hasDeleteException,
   hasMoveException,
-
   isMaterialCharsRecord,
   isPhysDescriptionRecord,
   isFixedFieldRow,
 } from './utils';
+import { TAG_FIELD_MAX_LENGTH } from '../../common/constants';
 
 import styles from './QuickMarcEditorRows.css';
 
@@ -37,7 +36,7 @@ const QuickMarcEditorRows = ({
   fields,
   type,
   subtype,
-  setDeletedRecords,
+  setDeletedRecordsCount,
   mutators: {
     addRecord,
     deleteRecord,
@@ -47,18 +46,18 @@ const QuickMarcEditorRows = ({
   const intl = useIntl();
 
   const addNewRow = useCallback(({ target }) => {
-    addRecord({ index: +target.dataset.index });
+    addRecord({ index: parseInt(target.dataset.index, 10) });
   }, [addRecord]);
 
   const deleteRow = useCallback(({ target }) => {
-    deleteRecord({ index: +target.dataset.index });
-    setDeletedRecords(prevDeletedItems => prevDeletedItems + 1);
-  }, [deleteRecord, setDeletedRecords]);
+    deleteRecord({ index: parseInt(target.dataset.index, 10) });
+    setDeletedRecordsCount(prevDeletedItems => prevDeletedItems + 1);
+  }, [deleteRecord, setDeletedRecordsCount]);
 
   const moveRow = useCallback(({ target }) => {
     moveRecord({
       index: +target.dataset.index,
-      indexToSwitch: +target.dataset.indexToSwitch,
+      indexToSwitch: parseInt(target.dataset.indexToSwitch, 10),
     });
   }, [moveRecord]);
 
@@ -119,7 +118,7 @@ const QuickMarcEditorRows = ({
                   ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.field' })}
                   name={`${name}[${idx}].tag`}
                   component={TextField}
-                  maxLength={3}
+                  maxLength={TAG_FIELD_MAX_LENGTH}
                   marginBottom0
                   fullWidth
                   disabled={isDisabled || !idx}
@@ -244,7 +243,7 @@ QuickMarcEditorRows.propTypes = {
     indicators: PropTypes.arrayOf(PropTypes.string),
     content: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   })),
-  setDeletedRecords: PropTypes.func.isRequired,
+  setDeletedRecordsCount: PropTypes.func.isRequired,
   mutators: PropTypes.shape({
     addRecord: PropTypes.func.isRequired,
     deleteRecord: PropTypes.func.isRequired,

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -1,16 +1,16 @@
-import React, { useCallback, useState } from 'react';
+import React, {
+  useCallback,
+} from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
-import { FormattedMessage } from 'react-intl';
+import {
+  useIntl,
+} from 'react-intl';
 
 import {
   TextField,
   IconButton,
-  ConfirmationModal,
 } from '@folio/stripes/components';
-import {
-  useModalToggle,
-} from '@folio/stripes-acq-components';
 
 import { ContentField } from './ContentField';
 
@@ -37,37 +37,23 @@ const QuickMarcEditorRows = ({
   fields,
   type,
   subtype,
+  setDeletedRecords,
   mutators: {
     addRecord,
     deleteRecord,
     moveRecord,
   },
 }) => {
-  const [isRemoveModalOpened, toggleRemoveModal] = useModalToggle();
-  const [removeIndex, setRemoveIndex] = useState();
-  const [focusedRowIndex, setFocusedRowIndex] = useState();
+  const intl = useIntl();
 
   const addNewRow = useCallback(({ target }) => {
     addRecord({ index: +target.dataset.index });
   }, [addRecord]);
 
-  const showDeleteConfirmation = useCallback(({ target }) => {
-    setRemoveIndex(+target.dataset.index);
-    toggleRemoveModal();
-    setFocusedRowIndex(+target.dataset.index);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setRemoveIndex]);
-
-  const confirmDeletion = useCallback(() => {
-    deleteRecord({ index: removeIndex });
-    toggleRemoveModal();
-    setFocusedRowIndex(null);
-  }, [deleteRecord, toggleRemoveModal, removeIndex]);
-
-  const closeDeleteConfirmation = useCallback(() => {
-    toggleRemoveModal();
-    setFocusedRowIndex(null);
-  }, [toggleRemoveModal]);
+  const deleteRow = useCallback(({ target }) => {
+    deleteRecord({ index: +target.dataset.index });
+    setDeletedRecords(prevDeletedItems => prevDeletedItems + 1);
+  }, [deleteRecord]);
 
   const moveRow = useCallback(({ target }) => {
     moveRecord({
@@ -86,7 +72,6 @@ const QuickMarcEditorRows = ({
           const withDeleteRowAction = hasDeleteException(recordRow);
           const withMoveUpRowAction = hasMoveException(recordRow, fields[idx - 1]);
           const withMoveDownRowAction = hasMoveException(recordRow, fields[idx + 1]);
-          const isFocusedRow = focusedRowIndex === idx;
 
           const isMaterialCharsField = isMaterialCharsRecord(recordRow);
           const isPhysDescriptionField = isPhysDescriptionRecord(recordRow);
@@ -96,82 +81,66 @@ const QuickMarcEditorRows = ({
           return (
             <div
               key={idx}
-              className={`${styles.quickMarcEditorRow} ${isFocusedRow ? styles.quickMarcFocusedRow : ''}`}
-              data-test-quick-marc-editor-row
+              className={styles.quickMarcEditorRow}
               data-testid="quick-marc-editorid"
             >
               <div className={styles.quickMarcEditorMovingRow}>
                 {
                   !withMoveUpRowAction && (
-                    <FormattedMessage id="ui-quick-marc.record.moveUpRow">
-                      {ariaLabel => (
-                        <IconButton
-                          title={ariaLabel}
-                          ariaLabel={ariaLabel}
-                          data-test-move-up-row
-                          data-index={idx}
-                          data-index-to-switch={idx - 1}
-                          icon="arrow-up"
-                          onClick={moveRow}
-                        />
-                      )}
-                    </FormattedMessage>
+                    <IconButton
+                      title={intl.formatMessage({ id: 'ui-quick-marc.record.moveUpRow' })}
+                      ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.moveUpRow' })}
+                      data-test-move-up-row
+                      data-index={idx}
+                      data-index-to-switch={idx - 1}
+                      icon="arrow-up"
+                      onClick={moveRow}
+                    />
                   )
                 }
                 {
                   !withMoveDownRowAction && (
-                    <FormattedMessage id="ui-quick-marc.record.moveDownRow">
-                      {ariaLabel => (
-                        <IconButton
-                          title={ariaLabel}
-                          ariaLabel={ariaLabel}
-                          data-test-move-down-row
-                          data-index={idx}
-                          data-index-to-switch={idx + 1}
-                          icon="arrow-down"
-                          onClick={moveRow}
-                        />
-                      )}
-                    </FormattedMessage>
+                    <IconButton
+                      title={intl.formatMessage({ id: 'ui-quick-marc.record.moveDownRow' })}
+                      ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.moveDownRow' })}
+                      data-test-move-down-row
+                      data-index={idx}
+                      data-index-to-switch={idx + 1}
+                      icon="arrow-down"
+                      onClick={moveRow}
+                    />
                   )
                 }
               </div>
 
               <div className={styles.quickMarcEditorRowTag}>
-                <FormattedMessage id="ui-quick-marc.record.field">
-                  {ariaLabel => (
-                    <Field
-                      dirty={false}
-                      ariaLabel={ariaLabel}
-                      name={`${name}[${idx}].tag`}
-                      component={TextField}
-                      maxlength={3}
-                      marginBottom0
-                      fullWidth
-                      disabled={isDisabled || !idx}
-                      hasClearIcon={false}
-                    />
-                  )}
-                </FormattedMessage>
+                <Field
+                  dirty={false}
+                  ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.field' })}
+                  name={`${name}[${idx}].tag`}
+                  component={TextField}
+                  maxLength={3}
+                  marginBottom0
+                  fullWidth
+                  disabled={isDisabled || !idx}
+                  hasClearIcon={false}
+                />
+                />
               </div>
 
               <div className={styles.quickMarcEditorRowIndicator}>
                 {
                   withIndicators && (
-                    <FormattedMessage id="ui-quick-marc.record.indicator">
-                      {ariaLabel => (
-                        <Field
-                          dirty={false}
-                          ariaLabel={ariaLabel}
-                          name={`${name}[${idx}].indicators[0]`}
-                          component={IndicatorField}
-                          marginBottom0
-                          fullWidth
-                          disabled={isDisabled}
-                          hasClearIcon={false}
-                        />
-                      )}
-                    </FormattedMessage>
+                    <Field
+                      dirty={false}
+                      ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.indicator' })}
+                      name={`${name}[${idx}].indicators[0]`}
+                      component={IndicatorField}
+                      marginBottom0
+                      fullWidth
+                      disabled={isDisabled}
+                      hasClearIcon={false}
+                    />
                   )
                 }
               </div>
@@ -179,20 +148,16 @@ const QuickMarcEditorRows = ({
               <div className={styles.quickMarcEditorRowIndicator}>
                 {
                   withIndicators && (
-                    <FormattedMessage id="ui-quick-marc.record.indicator">
-                      {ariaLabel => (
-                        <Field
-                          dirty={false}
-                          ariaLabel={ariaLabel}
-                          name={`${name}[${idx}].indicators[1]`}
-                          component={IndicatorField}
-                          marginBottom0
-                          fullWidth
-                          disabled={isDisabled}
-                          hasClearIcon={false}
-                        />
-                      )}
-                    </FormattedMessage>
+                    <Field
+                      dirty={false}
+                      ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.indicator' })}
+                      name={`${name}[${idx}].indicators[1]`}
+                      component={IndicatorField}
+                      marginBottom0
+                      fullWidth
+                      disabled={isDisabled}
+                      hasClearIcon={false}
+                    />
                   )
                 }
               </div>
@@ -224,18 +189,14 @@ const QuickMarcEditorRows = ({
 
                 {
                   isContentField && (
-                    <FormattedMessage id="ui-quick-marc.record.subfield">
-                      {ariaLabel => (
-                        <Field
-                          dirty={false}
-                          ariaLabel={ariaLabel}
-                          name={`${name}[${idx}].content`}
-                          component={ContentField}
-                          marginBottom0
-                          disabled={isDisabled}
-                        />
-                      )}
-                    </FormattedMessage>
+                    <Field
+                      dirty={false}
+                      aria-label={intl.formatMessage({ id: 'ui-quick-marc.record.subfield' })}
+                      name={`${name}[${idx}].content`}
+                      component={ContentField}
+                      marginBottom0
+                      disabled={isDisabled}
+                    />
                   )
                 }
               </div>
@@ -243,34 +204,26 @@ const QuickMarcEditorRows = ({
               <div className={styles.quickMarcEditorActions}>
                 {
                   !withAddRowAction && (
-                    <FormattedMessage id="ui-quick-marc.record.addField">
-                      {ariaLabel => (
-                        <IconButton
-                          title={ariaLabel}
-                          ariaLabel={ariaLabel}
-                          data-test-add-row
-                          data-index={idx}
-                          icon="plus-sign"
-                          onClick={addNewRow}
-                        />
-                      )}
-                    </FormattedMessage>
+                    <IconButton
+                      title={intl.formatMessage({ id: 'ui-quick-marc.record.addField' })}
+                      ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.addField' })}
+                      data-test-add-row
+                      data-index={idx}
+                      icon="plus-sign"
+                      onClick={addNewRow}
+                    />
                   )
                 }
                 {
                   !withDeleteRowAction && (
-                    <FormattedMessage id="ui-quick-marc.record.deleteField">
-                      {ariaLabel => (
-                        <IconButton
-                          title={ariaLabel}
-                          ariaLabel={ariaLabel}
-                          data-test-remove-row
-                          data-index={idx}
-                          icon="trash"
-                          onClick={showDeleteConfirmation}
-                        />
-                      )}
-                    </FormattedMessage>
+                    <IconButton
+                      title={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
+                      ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
+                      data-testid={`data-test-remove-row-${idx}`}
+                      data-index={idx}
+                      icon="trash"
+                      onClick={deleteRow}
+                    />
                   )
                 }
               </div>
@@ -278,17 +231,6 @@ const QuickMarcEditorRows = ({
           );
         })
       }
-      {isRemoveModalOpened && (
-        <ConfirmationModal
-          id="delete-row-confirmation"
-          confirmLabel={<FormattedMessage id="ui-quick-marc.record.delete.confirmLabel" />}
-          heading={<FormattedMessage id="ui-quick-marc.record.delete.title" />}
-          message={<FormattedMessage id="ui-quick-marc.record.delete.message" />}
-          onCancel={closeDeleteConfirmation}
-          onConfirm={confirmDeletion}
-          open
-        />
-      )}
     </>
   );
 };
@@ -303,6 +245,7 @@ QuickMarcEditorRows.propTypes = {
     indicators: PropTypes.arrayOf(PropTypes.string),
     content: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   })),
+  setDeletedRecords: PropTypes.func.isRequired,
   mutators: PropTypes.shape({
     addRecord: PropTypes.func.isRequired,
     deleteRecord: PropTypes.func.isRequired,

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -46,7 +46,7 @@ const values = [
   },
 ];
 
-const setDeletedRecords = jest.fn();
+const setDeletedRecordsCount = jest.fn();
 
 const renderQuickMarcEditorRows = ({ fields }) => (render(
   <MemoryRouter>
@@ -63,7 +63,7 @@ const renderQuickMarcEditorRows = ({ fields }) => (render(
             moveRecord: jest.fn(),
           }}
           subtype="test"
-          setDeletedRecords={setDeletedRecords}
+          setDeletedRecordsCount={setDeletedRecordsCount}
         />
       )}
     />
@@ -137,7 +137,7 @@ describe('Given Quick Marc Editor Rows', () => {
       fireEvent.click(deleteIcon1[1]);
       fireEvent.click(deleteIcon2[1]);
 
-      expect(setDeletedRecords).toHaveBeenCalledTimes(2);
+      expect(setDeletedRecordsCount).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { render, cleanup } from '@testing-library/react';
+import {
+  render,
+  cleanup,
+  fireEvent,
+} from '@testing-library/react';
 import { Form } from 'react-final-form';
 
 import '@folio/stripes-acq-components/test/jest/__mock__';
@@ -42,6 +46,8 @@ const values = [
   },
 ];
 
+const setDeletedRecords = jest.fn();
+
 const renderQuickMarcEditorRows = ({ fields }) => (render(
   <MemoryRouter>
     <Form
@@ -56,6 +62,8 @@ const renderQuickMarcEditorRows = ({ fields }) => (render(
             deleteRecord: jest.fn(),
             moveRecord: jest.fn(),
           }}
+          subtype="test"
+          setDeletedRecords={setDeletedRecords}
         />
       )}
     />
@@ -110,5 +118,26 @@ describe('Given Quick Marc Editor Rows', () => {
     isFixedRowSpy.mockRestore();
     isMaterialCharsRecordSpy.mockRestore();
     isPhysDescriptionRecordSpy.mockRestore();
+  });
+
+  describe('Deleting rows', () => {
+    it('should call setDeletedRecords 2 times', () => {
+      const { getAllByTestId } = renderQuickMarcEditorRows({
+        fields: {
+          map: cb => values.map((value, idx) => cb(`records[${idx}]`, idx)),
+          value: values,
+        },
+      });
+
+      const testIdx1 = 0;
+      const testIdx2 = 1;
+      const deleteIcon1 = getAllByTestId(`data-test-remove-row-${testIdx1}`);
+      const deleteIcon2 = getAllByTestId(`data-test-remove-row-${testIdx2}`);
+
+      fireEvent.click(deleteIcon1[1]);
+      fireEvent.click(deleteIcon2[1]);
+
+      expect(setDeletedRecords).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/common/constants/index.js
+++ b/src/common/constants/index.js
@@ -1,1 +1,2 @@
 export * from './api';
+export * from './restrictions';

--- a/src/common/constants/restrictions.js
+++ b/src/common/constants/restrictions.js
@@ -1,0 +1,3 @@
+export const TAG_FIELD_MAX_LENGTH = 3;
+export const INDICATOR_FIELD_MAX_LENGTH = 1;
+export const FIXED_FIELD_MAX_LENGTH = 1;

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -117,9 +117,9 @@
   "record.error.title.empty": "Record cannot be saved without field 245.",
   "record.error.tag.length": "Record cannot be saved. Each field must contain three characters in the first text box of each row.",
 
-  "record.delete.confirmLabel": "Yes",
-  "record.delete.title": "Delete field",
-  "record.delete.message": "Are you sure you want to delete this field?",
+  "record.delete.confirmLabel": "Continue with save",
+  "record.delete.title": "Delete fields",
+  "record.delete.message": "By selecting <b>Continue with save</b>, then <b>{count}</b> will be deleted and this record will be update. Are you sure you want to continue?",
 
   "record.save.success.processing": "This record has successfully saved and is in process. Changes may not appear immediately.",
   "record.save.error.illegalFixedLength": "Record not saved. Please check the character length of the fixed fields.",

--- a/translations/ui-quick-marc/zh_CN.json
+++ b/translations/ui-quick-marc/zh_CN.json
@@ -122,5 +122,5 @@
     "record.status.progress": "进行中",
     "record.status.error": "错误",
     "record.save.error.illegalFixedLength": "记录未保存。请检查定长字段的字符长度。",
-    "record.status": "Record status:"
+    "record.status": "记录状态："
 }


### PR DESCRIPTION
### UIQM-72: Edit quickMARC bibliographic record: Change delete row behavior

## Purpose
Change delete row behavior - remove deleting modal on each delete action, but show confirmation modal after clicking `Save and close` button.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
