### PR TITLE
UIQM-72: Fix translation message

### DIFF
--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -119,7 +119,7 @@
 
   "record.delete.confirmLabel": "Continue with save",
   "record.delete.title": "Delete fields",
-  "record.delete.message": "By selecting <b>Continue with save</b>, then <b>{count}</b> will be deleted and this record will be update. Are you sure you want to continue?",
+  "record.delete.message": "By selecting <b>Continue with save</b>, then <b>{count} field(s)</b> will be deleted and this record will be updated. Are you sure you want to continue?",
 
   "record.save.success.processing": "This record has successfully saved and is in process. Changes may not appear immediately.",
   "record.save.error.illegalFixedLength": "Record not saved. Please check the character length of the fixed fields.",


### PR DESCRIPTION
## Purpose
Fix translation message in the Delete modal.
Related issue: [UIQM-72](https://issues.folio.org/browse/UIQM-72) (updated in comments)

## Screenshot
![Screenshot 2021-02-12 at 21 44 00](https://user-images.githubusercontent.com/60929399/107815202-b8935380-6d7b-11eb-8e24-9536653c534e.png)


