### PR TITLE
UIQM-76: Change Delete field confirmation [Cancel] button behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [UIQM-75](https://issues.folio.org/browse/UIQM-75) Update stripes-cli to v2
 * [UIIN-1407](https://issues.folio.org/browse/UIIN-1407) Add Duplicate MARC bib record view
 * [UIQM-68](https://issues.folio.org/browse/UIQM-68) Permission: Duplicate and create a new MARC bibliographic record
+* [UIQM-76](https://issues.folio.org/browse/UIQM-76) Restore deleted fields when cancelling Save & close.
 
 ## [2.0.1](https://github.com/folio-org/ui-quick-marc/tree/v2.0.1) (2020-11-11)
 [Full Changelog](https://github.com/folio-org/ui-quick-marc/compare/v2.0.0...v2.0.1)

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -16,12 +16,15 @@ jest.mock('@folio/stripes/components', () => ({
 
 jest.mock('./QuickMarcEditorRows', () => {
   return {
-    QuickMarcEditorRows: ({ setDeletedRecordsCount }) => (
+    QuickMarcEditorRows: ({ setDeletedRecords }) => (
       <>
         <span>QuickMarcEditorRows</span>
         <button
           type="button"
-          onClick={() => setDeletedRecordsCount(1)}
+          onClick={() => setDeletedRecords({
+            index: 1,
+            record: {},
+          })}
         >
           Delete row
         </button>

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -36,7 +36,7 @@ const QuickMarcEditorRows = ({
   fields,
   type,
   subtype,
-  setDeletedRecordsCount,
+  setDeletedRecords,
   mutators: {
     addRecord,
     deleteRecord,
@@ -50,9 +50,17 @@ const QuickMarcEditorRows = ({
   }, [addRecord]);
 
   const deleteRow = useCallback(({ target }) => {
-    deleteRecord({ index: parseInt(target.dataset.index, 10) });
-    setDeletedRecordsCount(prevDeletedItems => prevDeletedItems + 1);
-  }, [deleteRecord, setDeletedRecordsCount]);
+    const index = parseInt(target.dataset.index, 10);
+
+    deleteRecord({ index });
+    setDeletedRecords((prevDeletedRecords) => [
+      ...prevDeletedRecords,
+      {
+        index,
+        record: fields[index],
+      },
+    ]);
+  }, [deleteRecord, setDeletedRecords, fields]);
 
   const moveRow = useCallback(({ target }) => {
     moveRecord({
@@ -243,7 +251,7 @@ QuickMarcEditorRows.propTypes = {
     indicators: PropTypes.arrayOf(PropTypes.string),
     content: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   })),
-  setDeletedRecordsCount: PropTypes.func.isRequired,
+  setDeletedRecords: PropTypes.func.isRequired,
   mutators: PropTypes.shape({
     addRecord: PropTypes.func.isRequired,
     deleteRecord: PropTypes.func.isRequired,

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -46,7 +46,7 @@ const values = [
   },
 ];
 
-const setDeletedRecordsCount = jest.fn();
+const setDeletedRecords = jest.fn();
 
 const renderQuickMarcEditorRows = ({ fields }) => (render(
   <MemoryRouter>
@@ -63,7 +63,7 @@ const renderQuickMarcEditorRows = ({ fields }) => (render(
             moveRecord: jest.fn(),
           }}
           subtype="test"
-          setDeletedRecordsCount={setDeletedRecordsCount}
+          setDeletedRecords={setDeletedRecords}
         />
       )}
     />
@@ -137,7 +137,7 @@ describe('Given Quick Marc Editor Rows', () => {
       fireEvent.click(deleteIcon1[1]);
       fireEvent.click(deleteIcon2[1]);
 
-      expect(setDeletedRecordsCount).toHaveBeenCalledTimes(2);
+      expect(setDeletedRecords).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -193,6 +193,14 @@ export const reorderRecords = (index, indexToSwitch, state) => {
   return records;
 };
 
+export const restoreRecordAtIndex = (index, record, state) => {
+  const records = [...state.formState.values.records];
+
+  records.splice(index, 0, record);
+
+  return records;
+};
+
 const getRecordsTrackChanges = (records) => {
   const trackCHanges = {
     lastRecordPosition: undefined,

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -91,6 +91,40 @@ describe('QuickMarcEditor utils', () => {
     });
   });
 
+  describe('restoreRecordAtIndex', () => {
+    it('should return records with new row', () => {
+      const state = {
+        formState: {
+          values: {
+            records: [
+              {
+                tag: '010',
+                content: '$a fss $b asd',
+              },
+              {
+                tag: '011',
+                content: '$a fss $b asd',
+              },
+              {
+                tag: '012',
+                content: '$a fss $b asd',
+              },
+            ],
+          },
+        },
+      };
+
+      const insertIndex = 1;
+      const insertedRecord = {
+        tag: '013',
+        content: '$a fss $b asd',
+      };
+      const newRecords = utils.restoreRecordAtIndex(insertIndex, insertedRecord, state);
+
+      expect(newRecords[1]).toBe(insertedRecord);
+    });
+  });
+
   describe('validateLeader', () => {
     it('should not return error message when leader is valid', () => {
       expect(


### PR DESCRIPTION
## Description
Change Delete field confirmation button behavior. Deleting rows and cancelling confirmation dialog will now restore deleted fields and keep other changes

## Issues
[UIQM-76](https://issues.folio.org/browse/UIQM-76)