### PR TITLE
UIQM-80: Change permission name FROM quickMARC: Duplicate and create a new MARC bibliographic record TO quickMARC: Derive new MARC bibliographic record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UIIN-1407](https://issues.folio.org/browse/UIIN-1407) Add Duplicate MARC bib record view
 * [UIQM-68](https://issues.folio.org/browse/UIQM-68) Permission: Duplicate and create a new MARC bibliographic record
 * [UIQM-76](https://issues.folio.org/browse/UIQM-76) Restore deleted fields when cancelling Save & close.
+* [UIQM-80](https://issues.folio.org/browse/UIQM-80) Rename permission name from Duplicate to Derive new MARC bib record
 
 ## [2.0.1](https://github.com/folio-org/ui-quick-marc/tree/v2.0.1) (2020-11-11)
 [Full Changelog](https://github.com/folio-org/ui-quick-marc/compare/v2.0.0...v2.0.1)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       },
       {
         "permissionName": "ui-quick-marc.quick-marc-editor.duplicate",
-        "displayName": "quickMARC: Duplicate and create a new MARC bibliographic record",
+        "displayName": "quickMARC: Derive new MARC bibliographic record",
         "subPermissions": [
           "records-editor.records.item.get",
           "records-editor.records.item.post",

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -2,7 +2,7 @@
   "meta.title": "Quick MARC",
 
   "permission.quick-marc-editor.all": "quickMARC: View, edit",
-  "permission.quick-marc-editor.duplicate": "quickMARC: Duplicate and create a new MARC bibliographic record",
+  "permission.quick-marc-editor.duplicate": "quickMARC: Derive new MARC bibliographic record",
 
   "record.edit.title": "Edit MARC record - {title}",
   "record.duplicate.title": "Create a new MARC bib record",


### PR DESCRIPTION
## Description
Change permission name FROM `quickMARC: Duplicate and create a new MARC bibliographic record` to `quickMARC: Derive new MARC bibliographic record`

## Issues
[UIQM-80](https://issues.folio.org/browse/UIQM-80)