### PR TITLE
UIQM-94: Display person who last edited quickMARC record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [3.1.0](in progress)
 * [UIQM-86](https://issues.folio.org/browse/UIQM-86) Auto-populate a subfield section with leading $a when no leading subfield is present
+* [UIQM-94](https://issues.folio.org/browse/UIQM-94) Display person who last edited quickMARC record.
 
 ## [3.0.1](https://github.com/folio-org/ui-quick-marc/tree/v3.0.1) (2021-04-01)
 * [UIQM-83](https://issues.folio.org/browse/UIQM-83) Do not duplicate fields with empty content

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -176,6 +176,8 @@ const QuickMarcEditor = ({
               <QuickMarcRecordInfo
                 status={initialValues?.updateInfo?.recordState}
                 updateDate={initialValues?.updateInfo?.updateDate}
+                updatedBy={initialValues?.updateInfo?.updatedBy}
+                isEditAction={action === QUICK_MARC_ACTIONS.EDIT}
               />
             )}
             footer={paneFooter}

--- a/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.js
+++ b/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.js
@@ -16,7 +16,28 @@ import {
 
 import styles from './QuickMarcRecordInfo.css';
 
-export const QuickMarcRecordInfo = ({ status, updateDate }) => {
+export const QuickMarcRecordInfo = ({
+  isEditAction,
+  status,
+  updateDate,
+  updatedBy,
+}) => {
+  const getSourceLabel = () => {
+    const source = updatedBy
+      ? `${updatedBy.lastName}, ${updatedBy.firstName}`
+      : <FormattedMessage id="ui.quick-marc.meta.source.system" />;
+
+    return (
+      <>
+        <span>&nbsp;&bull;&nbsp;</span>
+        <FormattedMessage
+          id="stripes-components.metaSection.source"
+          values={{ source }}
+        />
+      </>
+    );
+  };
+
   return (
     <div
       className={styles.quickMarcRecordInfoWrapper}
@@ -40,13 +61,19 @@ export const QuickMarcRecordInfo = ({ status, updateDate }) => {
           </>
         )
       }
+      {isEditAction && getSourceLabel()}
     </div>
   );
 };
 
 QuickMarcRecordInfo.propTypes = {
+  isEditAction: PropTypes.bool.isRequired,
   status: PropTypes.string,
   updateDate: PropTypes.string,
+  updatedBy: PropTypes.shape({
+    firstName: PropTypes.string,
+    lastName: PropTypes.string,
+  }),
 };
 
 QuickMarcRecordInfo.defaultProps = {

--- a/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.test.js
+++ b/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.test.js
@@ -6,25 +6,48 @@ import '@folio/stripes-acq-components/test/jest/__mock__';
 import { QuickMarcRecordInfo } from './QuickMarcRecordInfo';
 import { RECORD_STATUS_CURRENT } from './constants';
 
-const renderQuickMarcRecordInfo = () => render(
+jest.mock('react-intl', () => ({
+  ...jest.requireActual('react-intl'),
+  FormattedMessage: jest.fn(({ id, values }) => (
+    <>
+      <span>{id}</span>
+      {values && <span>{Object.values(values).join(' ')}</span>}
+    </>
+  )),
+}));
+
+const renderQuickMarcRecordInfo = (props = {}) => render(
   <QuickMarcRecordInfo
+    isEditAction
     status={RECORD_STATUS_CURRENT}
     updateDate="2020-07-14T12:20:10.000"
+    updatedBy={{
+      firstName: 'John',
+      lastName: 'Doe',
+    }}
+    {...props}
   />,
 );
 
 describe('Given Quick Marc Record Info', () => {
   afterEach(cleanup);
 
-  it('Than it should display record status', () => {
+  it('Then it should display record status', () => {
     const { getByText } = renderQuickMarcRecordInfo();
 
     expect(getByText('ui-quick-marc.record.status.current', { exact: false })).toBeDefined();
   });
 
-  it('Than it should display record updated date', () => {
+  it('Then it should display record updated date', () => {
     const { getByText } = renderQuickMarcRecordInfo();
 
     expect(getByText('stripes-components.metaSection.recordLastUpdated', { exact: false })).toBeDefined();
+  });
+
+  it('Then it should display person who last edited', () => {
+    const { getByText } = renderQuickMarcRecordInfo();
+
+    expect(getByText('stripes-components.metaSection.source', { exact: false })).toBeDefined();
+    expect(getByText('Doe, John', { exact: false })).toBeDefined();
   });
 });

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -1,5 +1,6 @@
 {
   "meta.title": "Quick MARC",
+  "meta.source.system": "System",
 
   "permission.quick-marc-editor.all": "quickMARC: View, edit MARC bibliographic record",
   "permission.quick-marc-editor.duplicate": "quickMARC: Derive new MARC bibliographic record",


### PR DESCRIPTION
### UIQM-94: Frontend - Edit quickMARC | Display <last name>> , <<first name>> of person who last edited quickMARC record

## Purpose
Add source label in pane sub title component for Edit Page

Issue: [UIQM-94](https://issues.folio.org/browse/UIQM-94)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.

## Screenshots

![image](https://user-images.githubusercontent.com/55701515/115267863-54598b00-a142-11eb-8eae-c5a7fe66def8.png)
