### PR TITLE
UIQM-128: Blank subfield created at beginning of MARC field when a whitespace is the leading character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [UIQM-104](https://issues.folio.org/browse/UIQM-104) Update 007 Type dropdown to display category of material values.
 * [UIQM-118](https://issues.folio.org/browse/UIQM-118) MARC record does NOT open after saving an invalid field.
 * [UIQM-120](https://issues.folio.org/browse/UIQM-120) Fix bug with saving 006 field with type 's'.
+* [UIQM-128](https://issues.folio.org/browse/UIQM-128) Remove leading spaces at the beginning when adding MARC field.
 
 ## [3.1.0](https://github.com/folio-org/ui-quick-marc/tree/v3.1.0) (2021-06-17)
 * [UIQM-86](https://issues.folio.org/browse/UIQM-86) Auto-populate a subfield section with leading $a when no leading subfield is present

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -315,7 +315,7 @@ const checkIsEmptyContent = (field) => {
 export const autopopulateSubfieldSection = (formValues) => {
   const { records } = formValues;
 
-  const recordsWithSubfieds = records.reduce((acc, field) => {
+  const recordsWithSubfields = records.reduce((acc, field) => {
     if (checkIsEmptyContent(field)) {
       return acc;
     }
@@ -324,17 +324,21 @@ export const autopopulateSubfieldSection = (formValues) => {
       return [...acc, field];
     }
 
-    const contentHasSubfield = /^\$[a-z0-9]*/.test(field.content);
+    const fieldContentWithoutLeadingSpaces = field.content.trimStart();
+
+    const contentHasSubfield = /^\$[a-z0-9]*/.test(fieldContentWithoutLeadingSpaces);
 
     return [...acc, {
       ...field,
-      content: contentHasSubfield ? field.content : `$a ${field.content}`,
+      content: contentHasSubfield
+        ? fieldContentWithoutLeadingSpaces
+        : `$a ${fieldContentWithoutLeadingSpaces}`,
     }];
   }, []);
 
   return {
     ...formValues,
-    records: recordsWithSubfieds,
+    records: recordsWithSubfields,
   };
 };
 


### PR DESCRIPTION
## Purpose
Remove leading spaces at the beginning when adding MARC field during editing in quickMARC or deriving new MARC bib record.

## Issues
[UIQM-128](https://issues.folio.org/browse/UIQM-128)