### PR TITLE
UIQM-133: Edit quikMARC/Derive quickMARC: Show a toast notification upon clicking Save & Close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UIQM-120](https://issues.folio.org/browse/UIQM-120) Fix bug with saving 006 field with type 's'.
 * [UIQM-128](https://issues.folio.org/browse/UIQM-128) Remove leading spaces at the beginning when adding MARC field.
 * [UIQM-119](https://issues.folio.org/browse/UIQM-119) Fix removed deleted record value.
+* [UIQM-133](https://issues.folio.org/browse/UIQM-133) Edit/Derive quickMARC: Show a toast notification upon clicking Save & Close.
 
 ## [3.1.0](https://github.com/folio-org/ui-quick-marc/tree/v3.1.0) (2021-06-17)
 * [UIQM-86](https://issues.folio.org/browse/UIQM-86) Auto-populate a subfield section with leading $a when no leading subfield is present

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
@@ -117,12 +117,12 @@ const QuickMarcDuplicateWrapper = ({
     if (validationErrorMessage) {
       showCallout({ messageId: validationErrorMessage, type: 'error' });
 
-      return;
+      return null;
     }
 
     showCallout({ messageId: 'ui-quick-marc.record.saveNew.onSave' });
 
-    mutator.quickMarcEditMarcRecord.POST(hydrateMarcRecord(formValuesForDuplicate))
+    return mutator.quickMarcEditMarcRecord.POST(hydrateMarcRecord(formValuesForDuplicate))
       .then(({ qmRecordId }) => {
         history.push({
           pathname: '/inventory/view/id',

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -41,10 +41,10 @@ const QuickMarcEditWrapper = ({
     if (validationErrorMessage) {
       showCallout({ messageId: validationErrorMessage, type: 'error' });
 
-      return;
+      return null;
     }
 
-    mutator.quickMarcEditMarcRecord.PUT(hydrateMarcRecord(formValuesForEdit))
+    return mutator.quickMarcEditMarcRecord.PUT(hydrateMarcRecord(formValuesForEdit))
       .then(() => {
         showCallout({ messageId: 'ui-quick-marc.record.save.success.processing' });
         onClose();

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -59,14 +59,14 @@ const QuickMarcEditor = ({
     ? pristine || submitting
     : submitting;
 
-  const confirmSubmit = useCallback((props) => {
+  const confirmSubmit = useCallback((e) => {
     if (deletedRecords.length) {
       setIsDeleteModalOpened(true);
 
       return;
     }
 
-    handleSubmit(props);
+    handleSubmit(e);
   }, [deletedRecords, handleSubmit]);
 
   const paneFooter = useMemo(() => {
@@ -112,9 +112,9 @@ const QuickMarcEditor = ({
     setDeletedRecords([]);
   };
 
-  const onConfirmModal = (props) => {
+  const onConfirmModal = (e) => {
     setIsDeleteModalOpened(false);
-    handleSubmit(props);
+    handleSubmit(e);
   };
 
   const onCancelModal = () => {


### PR DESCRIPTION
## Description
Disable Save&Close button when edit/duplicate quickMARC record request is pending.

## Lessons learned
When `onSubmit` handler is an async function you need to return a Promise to tell final-form if request is still in progress or not. Without this Save&Close button was not being disabled

## Issues
[UIQM-133](https://issues.folio.org/browse/UIQM-133)