### PR TITLE
UIQM-135: Fix validation for empty subfield

### DIFF
--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -155,10 +155,7 @@ export const validateRecordTag = marcRecords => {
 
 export const validateSubfield = marcRecords => {
   const marcRecordsWithSubfields = marcRecords.filter(marcRecord => marcRecord.indicators);
-
-  const isEmptySubfield = marcRecordsWithSubfields.some(marcRecord => {
-    return marcRecord.indicators.some(value => value === undefined);
-  });
+  const isEmptySubfield = marcRecordsWithSubfields.some(marcRecord => !marcRecord.content);
 
   if (isEmptySubfield) {
     return 'ui-quick-marc.record.error.subfield';

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -340,20 +340,22 @@ describe('QuickMarcEditor utils', () => {
   });
 
   describe('validateSubfield', () => {
-    it('should not return error message when indicators are present', () => {
+    it('should not return error message when indicators are present and content is not empty', () => {
       const records = [
         {
           indicators: ['\\', '\\'],
+          content: 'test',
         },
         {
           indicators: ['\\', '7'],
+          content: 'test',
         },
       ];
 
       expect(utils.validateSubfield(records)).not.toBeDefined();
     });
 
-    it('should return error message when indicators are undefined (invalid length)', () => {
+    it('should return error message when content is empty', () => {
       const records = [
         {
           indicators: ['\\', '\\'],
@@ -364,19 +366,6 @@ describe('QuickMarcEditor utils', () => {
       ];
 
       expect(utils.validateSubfield(records)).toBe('ui-quick-marc.record.error.subfield');
-    });
-
-    it('should return error message when tag is not valid (non-digit characters)', () => {
-      const records = [
-        {
-          tag: '01a',
-        },
-        {
-          tag: '245',
-        },
-      ];
-
-      expect(utils.validateRecordTag(records)).toBe('ui-quick-marc.record.error.tag.nonDigits');
     });
   });
 


### PR DESCRIPTION
# UIQM-135: Fix validation for empty subfield 

## Purpose
Fix [PR](https://github.com/folio-org/ui-quick-marc/pull/195)
 
Issue: [UIQM-135](https://issues.folio.org/browse/UIQM-135)


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
