### PR TITLE
UIQM-150: Add interface version for inventory optimistic locking

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pluginType": "quick-marc",
     "displayName": "ui-quick-marc.meta.title",
     "okapiInterfaces": {
-      "inventory": "10.0",
+      "inventory": "10.0 11.0",
       "records-editor.records": "2.0"
     },
     "stripesDeps": [


### PR DESCRIPTION
Depend on the new inventory interface version for optimistic locking -
in addition to the old interface version.

This modules uses GET only, it doesn't PUT to inventory.
Therefore no code change is needed to support the
_version property in these records that are needed for
optimistic locking.