### PR TITLE
UIQM-126: Permission: quickMARC:  Create a new MARC holdings record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [UIQM-140](https://issues.folio.org/browse/UIQM-140) Auto-populate indicator box with a backslash when Edit or Derive quickMARC record.
 * [UIQM-130](https://issues.folio.org/browse/UIQM-130) increment stripes to v7 and react to v17
 * [UIQM-124](https://issues.folio.org/browse/UIQM-124) Edit MARC Holdings via quickMARC.
+* [UIQM-126](https://issues.folio.org/browse/UIQM-126) Permission: quickMARC:  Create a new MARC holdings record.
 
 ## [3.1.0](https://github.com/folio-org/ui-quick-marc/tree/v3.1.0) (2021-06-17)
 * [UIQM-86](https://issues.folio.org/browse/UIQM-86) Auto-populate a subfield section with leading $a when no leading subfield is present

--- a/package.json
+++ b/package.json
@@ -43,6 +43,17 @@
         "visible": true
       },
       {
+        "permissionName": "ui-quick-marc.quick-marc-holdings-editor.create",
+        "displayName": "quickMARC: Create a new MARC holdings record",
+        "subPermissions": [
+          "records-editor.records.status.item.get",
+          "records-editor.records.item.get",
+          "records-editor.records.item.post",
+          "inventory.instances.item.get"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-quick-marc.quick-marc-editor.duplicate",
         "displayName": "quickMARC: Derive new MARC bibliographic record",
         "subPermissions": [

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -3,6 +3,8 @@
   "meta.source.system": "System",
 
   "permission.quick-marc-editor.all": "quickMARC: View, edit MARC bibliographic record",
+  "permission.quick-marc-holdings-editor.all": "quickMARC: View, edit MARC holdings record",
+  "permission.quick-marc-holdings-editor.create": "quickMARC: Create a new MARC holdings record",
   "permission.quick-marc-editor.duplicate": "quickMARC: Derive new MARC bibliographic record",
 
   "bib-record.edit.title": "Edit MARC record - {title}",


### PR DESCRIPTION
## Description
Permission: quickMARC:  Create a new MARC holdings record 

## Issues
[UIQM-126](https://issues.folio.org/browse/UIQM-126)