### PR TITLE
UIQM-144: Edit a holdings record via quickMARC - Make 004 field read only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.0.1](IN PROGRESS)
 
 * [UIQM-154](https://issues.folio.org/browse/UIQM-154) Add records-editor.records 1.4 interface version
+* [UIQM-144](https://issues.folio.org/browse/UIQM-144) Make 004 field read only when edit a holdings record via quickMARC.
 
 
 ## [4.0.0](https://github.com/folio-org/ui-quick-marc/tree/v4.0.0) (2021-10-06)

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -79,10 +79,10 @@ const QuickMarcEditorRows = ({
     <>
       {
         fields.map((recordRow, idx) => {
-          const isDisabled = isReadOnly(recordRow, action);
+          const isDisabled = isReadOnly(recordRow, action, marcType);
           const withIndicators = !hasIndicatorException(recordRow);
           const withAddRowAction = hasAddException(recordRow);
-          const withDeleteRowAction = hasDeleteException(recordRow);
+          const withDeleteRowAction = hasDeleteException(recordRow, marcType);
           const withMoveUpRowAction = hasMoveException(recordRow, fields[idx - 1]);
           const withMoveDownRowAction = hasMoveException(recordRow, fields[idx + 1]);
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -2,6 +2,7 @@ import {
   LEADER_TAG,
   QUICK_MARC_ACTIONS,
 } from '../constants';
+import { MARC_TYPES } from '../../common/constants';
 
 export const isLastRecord = recordRow => {
   return (
@@ -16,7 +17,15 @@ const READ_ONLY_ROWS = new Set(['001', '005']);
 
 const READ_ONLY_ROWS_FOR_DUPLICATE = new Set([LEADER_TAG, '001', '005']);
 
-export const isReadOnly = (recordRow, action = QUICK_MARC_ACTIONS.EDIT) => {
+export const isReadOnly = (
+  recordRow,
+  action = QUICK_MARC_ACTIONS.EDIT,
+  marcType = MARC_TYPES.BIB,
+) => {
+  if (marcType === MARC_TYPES.HOLDINGS) {
+    READ_ONLY_ROWS.add('004');
+  }
+
   const rows = action === QUICK_MARC_ACTIONS.DUPLICATE
     ? READ_ONLY_ROWS_FOR_DUPLICATE
     : READ_ONLY_ROWS;
@@ -34,9 +43,13 @@ export const hasAddException = recordRow => ADD_EXCEPTION_ROWS.has(recordRow.tag
 
 const DELETE_EXCEPTION_ROWS = new Set([LEADER_TAG, '001', '003', '005', '008']);
 
-export const hasDeleteException = recordRow => (
-  DELETE_EXCEPTION_ROWS.has(recordRow.tag) || isLastRecord(recordRow)
-);
+export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB) => {
+  if (marcType === MARC_TYPES.HOLDINGS) {
+    DELETE_EXCEPTION_ROWS.add('004');
+  }
+
+  return DELETE_EXCEPTION_ROWS.has(recordRow.tag) || isLastRecord(recordRow);
+};
 
 const MOVE_EXCEPTION_ROWS = new Set([LEADER_TAG, '001', '005', '008']);
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
@@ -2,6 +2,7 @@ import {
   LEADER_TAG,
   QUICK_MARC_ACTIONS,
 } from '../constants';
+import { MARC_TYPES } from '../../common/constants';
 
 import * as utils from './utils';
 
@@ -9,6 +10,22 @@ describe('QuickMarcEditorRows utils', () => {
   describe('isReadOnly', () => {
     it('should be true for record start', () => {
       expect(utils.isReadOnly({ tag: '001' })).toBeTruthy();
+    });
+
+    describe('when record type equals BIB', () => {
+      it('should be true for tag 004', () => {
+        expect(utils.isReadOnly({ tag: '004' })).toBeFalsy();
+      });
+    });
+
+    describe('when record type equals HOLDINGS', () => {
+      it('should be true for tag 004', () => {
+        expect(utils.isReadOnly(
+          { tag: '004' },
+          QUICK_MARC_ACTIONS.EDIT,
+          MARC_TYPES.HOLDINGS,
+        )).toBeTruthy();
+      });
     });
 
     it('should be true for tag 005 (Date and Time of Latest Transaction)', () => {
@@ -68,6 +85,18 @@ describe('QuickMarcEditorRows utils', () => {
     it('should be false for exeptional row', () => {
       expect(utils.hasDeleteException({ tag: '010' })).toBeFalsy();
     });
+
+    describe('when record type equals BIB', () => {
+      it('should be true for tag 004', () => {
+        expect(utils.hasDeleteException({ tag: '004' }, MARC_TYPES.BIB)).toBeFalsy();
+      });
+    });
+
+    describe('when record type equals HOLDINGS', () => {
+      it('should be true for tag 004', () => {
+        expect(utils.hasDeleteException({ tag: '004' }, MARC_TYPES.HOLDINGS)).toBeTruthy();
+      });
+    });
   });
 
   describe('hasMoveException', () => {
@@ -82,6 +111,26 @@ describe('QuickMarcEditorRows utils', () => {
 
     it('should be false for common rows', () => {
       expect(utils.hasMoveException({ tag: '010' }, { tag: '011' })).toBeFalsy();
+    });
+  });
+
+  describe('isMaterialCharsRecord', () => {
+    it('should be true for exeptional row', () => {
+      expect(utils.isMaterialCharsRecord({ tag: '006' })).toBeTruthy();
+    });
+
+    it('should be false for common rows', () => {
+      expect(utils.isMaterialCharsRecord({ tag: '010' })).toBeFalsy();
+    });
+  });
+
+  describe('isPhysDescriptionRecord', () => {
+    it('should be true for exeptional row', () => {
+      expect(utils.isPhysDescriptionRecord({ tag: '007' })).toBeTruthy();
+    });
+
+    it('should be false for common rows', () => {
+      expect(utils.isPhysDescriptionRecord({ tag: '010' })).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
## Purpose
Make 004 field read only and unable to delete when edit a holdings record via quickMARC.

## Screenshots
![image](https://user-images.githubusercontent.com/84023879/136361705-cc020692-edf4-4093-ad2e-c66922c0748d.png)

## Issues
[UIQM-144](https://issues.folio.org/browse/UIQM-144)
