### PR TITLE
UIQM-152: Fix 008 Rept date field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [4.0.1](IN PROGRESS)
 
 * [UIQM-154](https://issues.folio.org/browse/UIQM-154) Add records-editor.records 1.4 interface version
-
+* [UIQM-152](https://issues.folio.org/browse/UIQM-152) Fix 008 `Rept date` field.
 
 ## [4.0.0](https://github.com/folio-org/ui-quick-marc/tree/v4.0.0) (2021-10-06)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/FixedField/HoldingsFixedField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/FixedField/HoldingsFixedField.js
@@ -54,7 +54,7 @@ const config = {
       type: SUBFIELD_TYPES.BYTE,
     },
     {
-      name: 'ReptDate',
+      name: 'Rept date',
       type: SUBFIELD_TYPES.STRING,
     },
   ],

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -69,7 +69,7 @@
   "record.fixedField.Copies": "Copies",
   "record.fixedField.Lend": "Lend",
   "record.fixedField.Repro": "Repro",
-  "record.fixedField.ReptDate": "Rept date",
+  "record.fixedField.Rept date": "Rept date",
   "record.fixedField.Sep/comp": "Sep/comp",
 
   "record.fixedField.Category": "Type",


### PR DESCRIPTION
# UIQM-152 Edit MARC holdings via quickMARC > Cannot save 008's Rept date position

## Purpose
Rename 008 `Rept date` field.
Issue: [UIQM-152](https://issues.folio.org/browse/UIQM-152)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
