### PR TITLE
UIQM-156: Infinite loading after Deriving a new MARC bib record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UIQM-144](https://issues.folio.org/browse/UIQM-144) Make 004 field read only when edit a holdings record via quickMARC.
 * [UIQM-152](https://issues.folio.org/browse/UIQM-152) Fix 008 `Rept date` field.
 * [UIQM-148](https://issues.folio.org/browse/UIQM-148) Change error message when MARC tag does not contain 3 digits.
+* [UIQM-156](https://issues.folio.org/browse/UIQM-156) Infinite loading after Deriving a new MARC bib record
 
 ## [4.0.0](https://github.com/folio-org/ui-quick-marc/tree/v4.0.0) (2021-10-06)
 

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
@@ -71,7 +71,7 @@ const QuickMarcDuplicateWrapper = ({
 
     function makeRequest() {
       mutator.quickMarcRecordStatus.GET({ params: { qmRecordId } })
-        .then(({ externalId, status }) => {
+        .then(({ instanceId, status }) => {
           if (status === 'ERROR') {
             clearInterval(intervalId);
             showCallout({
@@ -89,12 +89,12 @@ const QuickMarcDuplicateWrapper = ({
             }
           }
 
-          if (externalId !== null && status === 'CREATED') {
+          if (instanceId !== null && status === 'CREATED') {
             clearInterval(intervalId);
             showCallout({ messageId: 'ui-quick-marc.record.saveNew.success' });
 
             history.push({
-              pathname: `/inventory/view/${externalId}`,
+              pathname: `/inventory/view/${instanceId}`,
               search: location.search,
             });
           }

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.test.js
@@ -21,7 +21,7 @@ jest.mock('react-final-form', () => ({
 
 const mockFormValues = jest.fn(() => ({
   fields: undefined,
-  externalId: '17064f9d-0362-468d-8317-5984b7efd1b5',
+  instanceId: '17064f9d-0362-468d-8317-5984b7efd1b5',
   leader: '02949cama2200517Kii50000',
   parsedRecordDtoId: '1bf159d9-4da8-4c3f-9aac-c83e68356bbf',
   parsedRecordId: '1bf159d9-4da8-4c3f-9aac-c83e68356bbf',
@@ -277,10 +277,10 @@ describe('Given QuickMarcDuplicateWrapper', () => {
     describe('when form is valid and status is created', () => {
       it('should show success toast notification', async () => {
         let getByText;
-        const externalId = faker.random.uuid();
+        const instanceId = faker.random.uuid();
 
         mutator.quickMarcRecordStatus.GET = jest.fn(() => Promise.resolve({
-          externalId,
+          instanceId,
           jobExecutionId: faker.random.uuid(),
           status: 'CREATED',
         }));
@@ -301,7 +301,7 @@ describe('Given QuickMarcDuplicateWrapper', () => {
             expect(mutator.quickMarcRecordStatus.GET).toHaveBeenCalled();
             expect(mockShowCallout).toHaveBeenCalledWith({ messageId: 'ui-quick-marc.record.saveNew.success' });
             expect(history.push).toHaveBeenCalledWith({
-              pathname: `/inventory/view/${externalId}`,
+              pathname: `/inventory/view/${instanceId}`,
               search: location.search,
             });
 
@@ -316,7 +316,7 @@ describe('Given QuickMarcDuplicateWrapper', () => {
         let getByText;
 
         mutator.quickMarcRecordStatus.GET = jest.fn(() => Promise.resolve({
-          externalId: null,
+          instanceId: null,
           jobExecutionId: faker.random.uuid(),
           status: 'ERROR',
         }));
@@ -382,7 +382,7 @@ describe('Given QuickMarcDuplicateWrapper', () => {
         let getByText;
 
         mutator.quickMarcRecordStatus.GET = jest.fn(() => Promise.resolve({
-          externalId: null,
+          instanceId: null,
           jobExecutionId: faker.random.uuid(),
           status: 'IN_PROGRESS',
         }));

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -515,7 +515,7 @@ describe('QuickMarcEditor utils', () => {
   describe('removeFieldsForDuplicate', () => {
     const formValues = {
       fields: undefined,
-      externalId: 'c58ed340-5123-4c2c-8a99-add5db68c71f',
+      instanceId: 'c58ed340-5123-4c2c-8a99-add5db68c71f',
       leader: '01897cas\\a2200493\\a\\4500',
       parsedRecordDtoId: '73f23ed5-4981-4cb2-8cdf-1ec644bd8f34',
       parsedRecordId: '3f75732f-53b9-44ed-b097-0cd14e5867b2',
@@ -560,7 +560,7 @@ describe('QuickMarcEditor utils', () => {
 
     const expectedFormValues = {
       fields: undefined,
-      externalId: 'c58ed340-5123-4c2c-8a99-add5db68c71f',
+      instanceId: 'c58ed340-5123-4c2c-8a99-add5db68c71f',
       leader: '01897cas\\a2200493\\a\\4500',
       parsedRecordDtoId: '73f23ed5-4981-4cb2-8cdf-1ec644bd8f34',
       parsedRecordId: '3f75732f-53b9-44ed-b097-0cd14e5867b2',


### PR DESCRIPTION
## Description
Fix infinite loading after Deriving a new MARC bib record. `externalId` parameter in `/records-editor/records/status` is not available in interface `records-editor.records` before `3.0`

## Issues
[UIQM-156](https://issues.folio.org/browse/UIQM-156)