### PR TITLE
UIQM-148: Fix validation error when tag is empty

### DIFF
--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -173,7 +173,7 @@ export const validateLeader = (prevLeader = '', leader = '', marcType = MARC_TYP
 };
 
 export const validateRecordTag = marcRecords => {
-  if (marcRecords.some(({ tag }) => tag.length !== 3)) {
+  if (marcRecords.some(({ tag }) => !tag || tag.length !== 3)) {
     return <FormattedMessage id="ui-quick-marc.record.error.tag.length" />;
   }
 


### PR DESCRIPTION
## Description
Fix error when trying to access `tag.length` during validation and `tag` is undefined

## Issues
[UIQM-148](https://issues.folio.org/browse/UIQM-148)