### PR TITLE
UIQM-159: Remove unnecessary cancellation modal on derive record page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [UIQM-169](https://issues.folio.org/browse/UIQM-169) Changing 007 type dropdown value does not enable the Save button.
 * [UIQM-157](https://issues.folio.org/browse/UIQM-157) Fix validation for new row of quickMarc record.
 * [UIQM-172](https://issues.folio.org/browse/UIQM-172) Changing 006 type dropdown value does not enable the Save button
+* [UIQM-159](https://issues.folio.org/browse/UIQM-172) Remove unnecessary cancellation modal on derive record page.
 
 ## [4.0.1](https://github.com/folio-org/ui-quick-marc/tree/v4.0.1) (2021-10-19)
 

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
@@ -1,17 +1,12 @@
 import React, {
-  useState,
   useCallback,
 } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import {
   useShowCallout,
 } from '@folio/stripes-acq-components';
-import {
-  ConfirmationModal,
-} from '@folio/stripes/components';
 
 import QuickMarcEditor from './QuickMarcEditor';
 import {
@@ -49,20 +44,7 @@ const QuickMarcDuplicateWrapper = ({
   location,
   marcType,
 }) => {
-  const [isCancellationModalOpened, setIsCancellationModalOpened] = useState(false);
-
   const showCallout = useShowCallout();
-
-  const closeEditor = () => setIsCancellationModalOpened(true);
-
-  const onConfirmCancellationModal = () => {
-    setIsCancellationModalOpened(false);
-  };
-
-  const onCloseCancellationModal = () => {
-    setIsCancellationModalOpened(false);
-    onClose();
-  };
 
   const getQuickMarcRecordStatus = (qmRecordId) => {
     const maxRequestAttempts = QM_RECORD_STATUS_BAIL_TIME / QM_RECORD_STATUS_TIMEOUT;
@@ -156,27 +138,13 @@ const QuickMarcDuplicateWrapper = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onClose, showCallout]);
 
-  const getCancellationModal = () => (
-    <ConfirmationModal
-      id="quick-marc-cancallation-modal"
-      open={isCancellationModalOpened}
-      onConfirm={onConfirmCancellationModal}
-      onCancel={onCloseCancellationModal}
-      heading={<FormattedMessage id="ui-quick-marc.record.cancellationModal.title" />}
-      message={<FormattedMessage id="ui-quick-marc.record.cancellationModal.message" />}
-      cancelLabel={<FormattedMessage id="ui-quick-marc.record.cancellationModal.cancel" />}
-      confirmLabel={<FormattedMessage id="ui-quick-marc.record.cancellationModal.confirm" />}
-    />
-  );
-
   return (
     <QuickMarcEditor
       instance={instance}
-      onClose={closeEditor}
+      onClose={onClose}
       initialValues={initialValues}
       onSubmit={onSubmit}
       action={action}
-      getCancellationModal={getCancellationModal}
       marcType={marcType}
     />
   );

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.test.js
@@ -226,23 +226,6 @@ describe('Given QuickMarcDuplicateWrapper', () => {
 
       expect('Confirmation modal').toBeDefined();
     });
-
-    describe('when click on close modal button', () => {
-      it('should handle onClose action', () => {
-        const { getByText } = renderQuickMarcDuplicateWrapper({
-          instance,
-          mutator,
-          history,
-          onClose,
-          location,
-        });
-
-        fireEvent.click(getByText('stripes-acq-components.FormFooter.cancel'));
-        fireEvent.click(getByText('Close'));
-
-        expect(onClose).toHaveBeenCalled();
-      });
-    });
   });
 
   describe('when click on save button', () => {

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -5,7 +5,6 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import noop from 'lodash/noop';
 import find from 'lodash/find';
 
 import stripesFinalForm from '@folio/stripes/final-form';
@@ -51,7 +50,6 @@ const QuickMarcEditor = ({
     mutators,
     reset,
   },
-  getCancellationModal,
   marcType,
   locations,
 }) => {
@@ -229,7 +227,6 @@ const QuickMarcEditor = ({
         onConfirm={onConfirmModal}
         onCancel={onCancelModal}
       />
-      {getCancellationModal()}
       <FormSpy
         subscription={spySubscription}
         onChange={changeRecords}
@@ -241,7 +238,6 @@ const QuickMarcEditor = ({
 QuickMarcEditor.propTypes = {
   action: PropTypes.oneOf(Object.values(QUICK_MARC_ACTIONS)).isRequired,
   instance: PropTypes.object,
-  getCancellationModal: PropTypes.func,
   onClose: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   submitting: PropTypes.bool,
@@ -255,10 +251,6 @@ QuickMarcEditor.propTypes = {
   locations: PropTypes.shape({
     records: PropTypes.array.isRequired,
   }),
-};
-
-QuickMarcEditor.defaultProps = {
-  getCancellationModal: noop,
 };
 
 export default stripesFinalForm({

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -162,11 +162,6 @@
   "record.deleteField": "Delete this field",
   "record.collapseRow": "Collapse row",
 
-  "record.cancellationModal.title": "Are you sure?",
-  "record.cancellationModal.message": "There are unsaved changes",
-  "record.cancellationModal.cancel": "Close without saving",
-  "record.cancellationModal.confirm": "Keep editing",
-
   "record.duplicate.notification.success": "This record has successfully saved and is in process. Changes may not appear immediately.",
 
   "record.materialChars.materialType.a": "Language material",


### PR DESCRIPTION
# UIQM-159: Derive a new MARC bib record: Must hit the Are you sure you want to cancel changes modal twice

## Purpose

Navigation modal present in `stripesFinalForm`. Native `CancellationModal` should be deleted.

Issue: [UIQM-159](https://issues.folio.org/browse/UIQM-159)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.

## Screenshot
![jQPvYQuuuP](https://user-images.githubusercontent.com/55701515/139421464-2fd2078e-1e4a-48b9-8c11-d20c8b63491f.gif)

