### PR TITLE
UIQM-165: Update error message when user attempts to save a record without a 852

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UIQM-157](https://issues.folio.org/browse/UIQM-157) Fix validation for new row of quickMarc record.
 * [UIQM-159](https://issues.folio.org/browse/UIQM-159) Remove unnecessary cancellation modal on derive record page.
 * [UIQM-163](https://issues.folio.org/browse/UIQM-163) Edit bib record: Update error messaging when entered an invalid value for Leader/05.
+* [UIQM-165](https://issues.folio.org/browse/UIQM-165) Update error message when user attempts to save a record without a 852.
 
 ## [4.0.2](https://github.com/folio-org/ui-quick-marc/tree/v4.0.2) (2021-11-02)
 * [UIQM-161](https://issues.folio.org/browse/UIQM-161) Remove add button for MARC holdings tag 004.

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -247,6 +247,16 @@ const validateMarcBibRecord = (marcRecords) => {
   return undefined;
 };
 
+const validateMarcHoldingsRecord = (marcRecords) => {
+  const locationRecords = marcRecords.filter(({ tag }) => tag === '852');
+
+  if (locationRecords.length === 0) {
+    return <FormattedMessage id="ui-quick-marc.record.error.location.empty" />;
+  }
+
+  return undefined;
+};
+
 export const validateMarcRecord = (marcRecord, initialValues, marcType = MARC_TYPES.BIB) => {
   const marcRecords = marcRecord.records || [];
   const initialMarcRecords = initialValues.records;
@@ -262,6 +272,10 @@ export const validateMarcRecord = (marcRecord, initialValues, marcType = MARC_TY
 
   if (marcType === MARC_TYPES.BIB) {
     validationResult = validateMarcBibRecord(marcRecords);
+  }
+
+  if (marcType === MARC_TYPES.HOLDINGS) {
+    validationResult = validateMarcHoldingsRecord(marcRecords);
   }
 
   if (validationResult) {

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -136,6 +136,7 @@
   "record.error.bib.leader.invalid005PositionValue": "Record cannot be saved. Invalid value entered for position 5.",
   "record.error.title.multiple": "Record cannot be saved with more than one field 245.",
   "record.error.title.empty": "Record cannot be saved without field 245.",
+  "record.error.location.empty": "Record cannot be saved. An 852 is required.",
   "record.error.tag.length": "Record cannot be saved. A MARC tag must contain three characters.",
   "record.error.tag.nonDigits": "Invalid MARC tag. Please try again.",
   "record.error.subfield": "Missing a subfield value for a MARC tag",


### PR DESCRIPTION
## Description
Added validation for missing 852 field in Holdings record

## Issues
[UIQM-165](https://issues.folio.org/browse/UIQM-165)