### PR TITLE
UIQM-167: quickMARC - Holdings | Do not allow user to add multiple 004s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [UIQM-163](https://issues.folio.org/browse/UIQM-163) Edit bib record: Update error messaging when entered an invalid value for Leader/05.
 * [UIQM-165](https://issues.folio.org/browse/UIQM-165) Update error message when user attempts to save a record without a 852.
 * [UIQM-132](https://issues.folio.org/browse/UIQM-132) Create a MARC Holdings Record.
+* [UIQM-167](https://issues.folio.org/browse/UIQM-167) Do not allow user to add multiple 004s for MARC Holdings.
 
 ## [4.0.2](https://github.com/folio-org/ui-quick-marc/tree/v4.0.2) (2021-11-02)
 * [UIQM-161](https://issues.folio.org/browse/UIQM-161) Remove add button for MARC holdings tag 004.

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -302,7 +302,7 @@ const validateMarcBibRecord = (marcRecords) => {
 const validateMarcHoldingsRecord = (marcRecords) => {
   const instanceHridRecords = marcRecords.filter(({ tag }) => tag === '004');
 
-  if (instanceHridRecords.length > 0) {
+  if (instanceHridRecords.length > 1) {
     return <FormattedMessage id="ui-quick-marc.record.error.instanceHrid.multiple" />;
   }
 

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -300,6 +300,12 @@ const validateMarcBibRecord = (marcRecords) => {
 };
 
 const validateMarcHoldingsRecord = (marcRecords) => {
+  const instanceHridRecords = marcRecords.filter(({ tag }) => tag === '004');
+
+  if (instanceHridRecords.length > 0) {
+    return <FormattedMessage id="ui-quick-marc.record.error.instanceHrid.multiple" />;
+  }
+
   const locationRecords = marcRecords.filter(({ tag }) => tag === '852');
 
   if (!locationRecords.length) {

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -308,6 +308,23 @@ describe('QuickMarcEditor utils', () => {
 
         expect(utils.validateMarcRecord(record, initialValues, MARC_TYPES.HOLDINGS).props.id).toBe('ui-quick-marc.record.error.location.empty');
       });
+
+      it('should return error message when record has several 004 rows', () => {
+        const initialValues = { records: [] };
+        const record = {
+          leader: '04706cxm a22008651i 4500',
+          records: [
+            {
+              content: '04706cxm a22008651i 4500',
+              tag: 'LDR',
+            },
+            { tag: '004' },
+            { tag: '004' },
+          ],
+        };
+
+        expect(utils.validateMarcRecord(record, initialValues, MARC_TYPES.HOLDINGS).props.id).toBe('ui-quick-marc.record.error.instanceHrid.multiple');
+      });
     });
   });
 

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -135,6 +135,7 @@
   "record.error.leader.fixedFieldMismatch": "Record cannot be saved. The Leader and 008 do not match.",
   "record.error.leader.invalidPositionValue": "Invalid value entered for the Leader {position}",
   "record.error.bib.leader.invalid005PositionValue": "Record cannot be saved. Invalid value entered for position 5.",
+  "record.error.instanceHrid.multiple": "Record cannot be saved. Can only have one MARC 004.",
   "record.error.title.multiple": "Record cannot be saved with more than one field 245.",
   "record.error.title.empty": "Record cannot be saved without field 245.",
   "record.error.location.empty": "Record cannot be saved. An 852 is required.",


### PR DESCRIPTION
## Purpose
Do not allow user to add multiple 004s for MARC Holdings.

Issue: [UIQM-167](https://issues.folio.org/browse/UIQM-167)