### PR TITLE
UIQM-177: Edit/Derive quickMARC > Omit Record on Status and Last updated labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [UIQM-163](https://issues.folio.org/browse/UIQM-163) Edit bib record: Update error messaging when entered an invalid value for Leader/05.
 * [UIQM-165](https://issues.folio.org/browse/UIQM-165) Update error message when user attempts to save a record without a 852.
 * [UIQM-132](https://issues.folio.org/browse/UIQM-132) Create a MARC Holdings Record.
+* [UIQM-177](https://issues.folio.org/browse/UIQM-177) Omit `Record` on Status and Last updated labels when Edit/Derive quickMARC.
 
 ## [4.0.2](https://github.com/folio-org/ui-quick-marc/tree/v4.0.2) (2021-11-02)
 * [UIQM-161](https://issues.folio.org/browse/UIQM-161) Remove add button for MARC holdings tag 004.

--- a/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.js
+++ b/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.js
@@ -52,7 +52,7 @@ export const QuickMarcRecordInfo = ({
           <>
             <span>&nbsp;&bull;&nbsp;</span>
             <FormattedMessage
-              id="stripes-components.metaSection.recordLastUpdated"
+              id="ui-quick-marc.record.lastUpdated"
               values={{
                 date: <FormattedDate value={updateDate} />,
                 time: <FormattedTime value={updateDate} />,

--- a/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.test.js
+++ b/src/QuickMarcEditor/QuickMarcRecordInfo/QuickMarcRecordInfo.test.js
@@ -41,7 +41,7 @@ describe('Given Quick Marc Record Info', () => {
   it('should display record updated date', () => {
     const { getByText } = renderQuickMarcRecordInfo();
 
-    expect(getByText('stripes-components.metaSection.recordLastUpdated', { exact: false })).toBeDefined();
+    expect(getByText('ui-quick-marc.record.lastUpdated', { exact: false })).toBeDefined();
   });
 
   it('should display person who last edited', () => {

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -12,11 +12,13 @@
   "holdings-record.create.title": "Create a new MARC Holdings record",
   "holdings-record.edit.title": "Edit MARC holdings - Location: {location} - [{callNumber}]",
 
-  "record.status": "Record status:",
+  "record.status": "Status:",
   "record.status.new": "New",
   "record.status.current": "Current",
   "record.status.progress": "In progress",
   "record.status.error": "Error",
+
+  "record.lastUpdated": "Last updated: {date} {time}",
 
   "record.fixedField.Type": "Type",
   "record.fixedField.ELvl": "ELvl",


### PR DESCRIPTION
## Purpose
Omit word 'Record' on Status and Last updated labels when Edit/Derive quickMARC.

Issue: [UIQM-177](https://issues.folio.org/browse/UIQM-177)