### PR TITLE
UIQM-164: quickMARC : When a value is missing in an indicator box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [UIQM-163](https://issues.folio.org/browse/UIQM-163) Edit bib record: Update error messaging when entered an invalid value for Leader/05.
 * [UIQM-132](https://issues.folio.org/browse/UIQM-132) Create a MARC Holdings Record.
 * [UIQM-177](https://issues.folio.org/browse/UIQM-177) Omit `Record` on Status and Last updated labels when Edit/Derive quickMARC.
+* [UIQM-164](https://issues.folio.org/browse/UIQM-164) Autopopulate an empty indicator box with a backslash when a value is missing in a box.
 
 ## [4.0.3](https://github.com/folio-org/ui-quick-marc/tree/v4.0.3) (2021-11-09)
 

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
@@ -17,6 +17,7 @@ import { MARC_TYPES } from '../common/constants';
 import {
   hydrateMarcRecord,
   removeFieldsForDuplicate,
+  autopopulateIndicators,
   autopopulateSubfieldSection,
   validateMarcRecord,
   cleanBytesFields,
@@ -47,8 +48,13 @@ const QuickMarcDuplicateWrapper = ({
 
   const onSubmit = useCallback(async (formValues) => {
     const clearFormValues = removeFieldsForDuplicate(formValues);
-    const autopopulatedFormValues = autopopulateSubfieldSection(clearFormValues, initialValues, marcType);
-    const formValuesForDuplicate = cleanBytesFields(autopopulatedFormValues, initialValues, marcType);
+    const autopopulatedFormWithIndicators = autopopulateIndicators(clearFormValues);
+    const autopopulatedFormWithSubfields = autopopulateSubfieldSection(
+      autopopulatedFormWithIndicators,
+      initialValues,
+      marcType,
+    );
+    const formValuesForDuplicate = cleanBytesFields(autopopulatedFormWithSubfields, initialValues, marcType);
     const validationErrorMessage = validateMarcRecord(formValuesForDuplicate, initialValues);
 
     if (validationErrorMessage) {

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -12,6 +12,7 @@ import { MARC_TYPES } from '../common/constants';
 import {
   hydrateMarcRecord,
   validateMarcRecord,
+  autopopulateIndicators,
   autopopulateSubfieldSection,
   cleanBytesFields,
 } from './utils';
@@ -49,8 +50,13 @@ const QuickMarcEditWrapper = ({
       return null;
     }
 
-    const autopopulateFormValues = autopopulateSubfieldSection(formValues, initialValues, marcType);
-    const formValuesForEdit = cleanBytesFields(autopopulateFormValues, initialValues, marcType);
+    const autopopulatedFormWithIndicators = autopopulateIndicators(formValues);
+    const autopopulatedFormWithSubfields = autopopulateSubfieldSection(
+      autopopulatedFormWithIndicators,
+      initialValues,
+      marcType,
+    );
+    const formValuesForEdit = cleanBytesFields(autopopulatedFormWithSubfields, initialValues, marcType);
 
     const marcRecord = hydrateMarcRecord(formValuesForEdit);
 

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -398,6 +398,28 @@ const checkIsEmptyContent = (field) => {
   return false;
 };
 
+export const autopopulateIndicators = (formValues) => {
+  const { records } = formValues;
+
+  const recordsWithIndicators = records.reduce((acc, field) => {
+    if (!field.indicators || field.indicators?.every(value => !!value)) {
+      return [...acc, field];
+    }
+
+    const autopopulatedIndicators = field.indicators.map(indicator => indicator || '\\');
+
+    return [...acc, {
+      ...field,
+      indicators: autopopulatedIndicators,
+    }];
+  }, []);
+
+  return {
+    ...formValues,
+    records: recordsWithIndicators,
+  };
+};
+
 export const autopopulateSubfieldSection = (formValues, initialValues, marcType = MARC_TYPES.BIB) => {
   const { records } = formValues;
   const { records: initialMarcRecords } = initialValues;

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import faker from 'faker';
 
 import uuid from 'uuid';
@@ -732,6 +733,66 @@ describe('QuickMarcEditor utils', () => {
     };
 
     expect(utils.removeFieldsForDuplicate(formValues)).toEqual(expectedFormValues);
+  });
+
+  describe('autopopulateIndicators', () => {
+    it('should return record with autopopulated indicators', () => {
+      const record = {
+        records: [{
+          tag: '001',
+          content: 'some content',
+          id: 'id001',
+        }, {
+          tag: '035',
+          content: 'some content',
+          id: 'id0351',
+          indicators: ['0', '\\'],
+        }, {
+          tag: '035',
+          content: 'some content',
+          id: 'id0352',
+          indicators: ['\\', undefined],
+        }, {
+          tag: '035',
+          content: '$a',
+          id: 'id0353',
+          indicators: [undefined, undefined],
+        }],
+        updateInfo: {
+          recordState: 'actual',
+          updateDate: '01/01/1970',
+        },
+      };
+
+      const expectedRecord = {
+        records: [{
+          tag: '001',
+          content: 'some content',
+          id: 'id001',
+        }, {
+          tag: '035',
+          content: 'some content',
+          id: 'id0351',
+          indicators: ['0', '\\'],
+        }, {
+          tag: '035',
+          content: 'some content',
+          id: 'id0352',
+          indicators: ['\\', '\\'],
+        }, {
+          tag: '035',
+          content: '$a',
+          id: 'id0353',
+          indicators: ['\\', '\\'],
+        }],
+        updateInfo: {
+          recordState: 'actual',
+          updateDate: '01/01/1970',
+        },
+      };
+
+      expect(utils.autopopulateIndicators(record)).toEqual(expectedRecord);
+    });
   });
 
   describe('autopopulateSubfieldSection', () => {


### PR DESCRIPTION
## Purpose
Autopopulate an empty indicator box with a backslash when a value is missing in a box.

Issue: [UIQM-164](https://issues.folio.org/browse/UIQM-164)