### PR TITLE
UIQM-166: Do not allow user to add 852s for MARC Holdings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,10 @@
 {
   "parser": "babel-eslint",
-  "extends": ["@folio/eslint-config-stripes/acquisitions"]
+  "extends": ["@folio/eslint-config-stripes/acquisitions"],
+  "overrides": [{
+    "files": [ "*.test.js" ],
+    "rules": {
+      "no-unused-expressions": 0
+    }
+  }]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [UIQM-163](https://issues.folio.org/browse/UIQM-163) Edit bib record: Update error messaging when entered an invalid value for Leader/05.
 * [UIQM-132](https://issues.folio.org/browse/UIQM-132) Create a MARC Holdings Record.
 * [UIQM-177](https://issues.folio.org/browse/UIQM-177) Omit `Record` on Status and Last updated labels when Edit/Derive quickMARC.
+* [UIQM-166](https://issues.folio.org/browse/UIQM-166) Do not allow user to add multiple 852s for MARC Holdings.
 
 ## [4.0.3](https://github.com/folio-org/ui-quick-marc/tree/v4.0.3) (2021-11-09)
 

--- a/src/QuickMarcEditor/getQuickMarcRecordStatus.test.js
+++ b/src/QuickMarcEditor/getQuickMarcRecordStatus.test.js
@@ -71,7 +71,7 @@ describe('Given getQuickMarcRecordStatus', () => {
             resolve();
           }, 10);
         });
-      }, 100);
+      }, 1000);
     });
 
     describe('when instanceId is not passed to props', () => {

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -306,6 +306,10 @@ const validateMarcHoldingsRecord = (marcRecords) => {
     return <FormattedMessage id="ui-quick-marc.record.error.location.empty" />;
   }
 
+  if (locationRecords.length > 1) {
+    return <FormattedMessage id="ui-quick-marc.record.error.location.multiple" />;
+  }
+
   return undefined;
 };
 

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -309,6 +309,23 @@ describe('QuickMarcEditor utils', () => {
         expect(utils.validateMarcRecord(record, initialValues, MARC_TYPES.HOLDINGS).props.id).toBe('ui-quick-marc.record.error.location.empty');
       });
     });
+
+    it('should return error message when record has several 852 rows', () => {
+      const initialValues = { records: [] };
+      const record = {
+        leader: '04706cxm a22008651i 4500',
+        records: [
+          {
+            content: '04706cxm a22008651i 4500',
+            tag: 'LDR',
+          },
+          { tag: '852' },
+          { tag: '852' },
+        ],
+      };
+
+      expect(utils.validateMarcRecord(record, initialValues, MARC_TYPES.HOLDINGS).props.id).toBe('ui-quick-marc.record.error.location.multiple');
+    });
   });
 
   describe('validateRecordMismatch', () => {

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -140,6 +140,7 @@
   "record.error.title.multiple": "Record cannot be saved with more than one field 245.",
   "record.error.title.empty": "Record cannot be saved without field 245.",
   "record.error.location.empty": "Record cannot be saved. An 852 is required.",
+  "record.error.location.multiple": "Record cannot be saved. Can only have one MARC 852.",
   "record.error.tag.length": "Record cannot be saved. A MARC tag must contain three characters.",
   "record.error.tag.nonDigits": "Invalid MARC tag. Please try again.",
   "record.error.subfield": "Missing a subfield value for a MARC tag",


### PR DESCRIPTION
# UIQM-166 quickMARC - Holdings | Do not allow user to add multiple 852s

## Purpose
Update validation for MARC Holdings field with 852 tag

Issue: [UIQM-166](https://issues.folio.org/browse/UIQM-166)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
