### PR TITLE
UIQM-191 use supported uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [UIQM-182](https://issues.folio.org/browse/UIQM-182) Update onSubmit action for `<QuickMarcCreateWrapper>`
 * [UIQM-181](https://issues.folio.org/browse/UIQM-181) Add as a default `008` and `852` fields to create MARC Holdings record page.
 * [UIQM-183](https://issues.folio.org/browse/UIQM-183) Add QuickMarcView component.
+* [UIQM-191](https://issues.folio.org/browse/UIQM-191) Use supported `uuid`.
 
 ## [4.0.3](https://github.com/folio-org/ui-quick-marc/tree/v4.0.3) (2021-11-09)
 

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "react-final-form-listeners": "^1.0.2",
     "react-hot-loader": "^4.3.12",
     "react-router-prop-types": "^1.0.4",
-    "uuid": "^3.0.1"
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "@folio/stripes": "^7.0.0",

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 import omit from 'lodash/omit';
 import compact from 'lodash/compact';
 import isString from 'lodash/isString';
@@ -39,7 +39,7 @@ export const dehydrateMarcRecordResponse = marcRecordResponse => ({
     },
     ...marcRecordResponse.fields.map(record => ({
       ...record,
-      id: uuid(),
+      id: uuidv4(),
     })),
   ],
 });
@@ -48,7 +48,7 @@ const getCreateMarcRecordDefaultFields = (instanceRecord) => {
   return CREATE_MARC_RECORD_DEFAULT_FIELD_TAGS.map(tag => {
     const field = {
       tag,
-      id: uuid(),
+      id: uuidv4(),
     };
 
     if (tag === '004') {
@@ -175,7 +175,7 @@ export const addNewRecord = (index, state) => {
   const records = [...state.formState.values.records];
   const newIndex = index + 1;
   const emptyRow = {
-    id: uuid(),
+    id: uuidv4(),
     tag: '',
     content: '$a ',
     indicators: ['\\', '\\'],

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import faker from 'faker';
 
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import {
   LEADER_TAG,
   QUICK_MARC_ACTIONS,
@@ -13,7 +13,9 @@ import { RECORD_STATUS_NEW } from './QuickMarcRecordInfo/constants';
 import * as utils from './utils';
 
 jest.mock('uuid', () => {
-  return () => 'uuid';
+  return {
+    v4: () => 'uuid',
+  };
 });
 
 describe('QuickMarcEditor utils', () => {


### PR DESCRIPTION
Use a supported version of `uuid` that doesn't throw build warnings.

Attn: @dmitriyfolio , @Vladyslav-Velytskyi 

Refs [UIQM-191](https://issues.folio.org/browse/UIQM-191)

