### PR TITLE
UIQM-195: Changes for MARC Authorities App: Closing third pane does not resize the second pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [UIQM-183](https://issues.folio.org/browse/UIQM-183) Add QuickMarcView component.
 * [UIQM-191](https://issues.folio.org/browse/UIQM-191) Use supported `uuid`.
 * [UIQM-142](https://issues.folio.org/browse/UIQM-142) Edit MARC authority record via quickMARC.
+* [UIQM-195](https://issues.folio.org/browse/UIQM-195) Changes for MARC Authorities App: Closing third pane does not resize the second pane.
 
 ## [4.0.3](https://github.com/folio-org/ui-quick-marc/tree/v4.0.3) (2021-11-09)
 

--- a/src/QuickMarcView/QuickMarcView.js
+++ b/src/QuickMarcView/QuickMarcView.js
@@ -13,6 +13,7 @@ import { isControlField } from './utils';
 import styles from './QuickMarcView.css';
 
 const propTypes = {
+  isPaneset: PropTypes.bool,
   lastMenu: PropTypes.node,
   marc: PropTypes.object.isRequired,
   marcTitle: PropTypes.node.isRequired,
@@ -36,6 +37,7 @@ const QuickMarcView = ({
   onClose,
   paneWidth,
   lastMenu,
+  isPaneset,
 }) => {
   const parsedContent = marc.parsedRecord.content;
   const parsedMarc = {
@@ -52,52 +54,64 @@ const QuickMarcView = ({
     optionalProps.lastMenu = lastMenu;
   }
 
-  return (
-    <Paneset isRoot>
-      <Pane
-        paneTitle={paneTitle}
-        paneSub={paneSub}
-        defaultWidth={paneWidth}
-        id="marc-view-pane"
-        dismissible
-        onClose={onClose}
-        data-test-instance-marc
-        {...optionalProps}
-      >
-        <section className={styles.marcWrapper}>
-          <Headline
-            size="large"
-            margin="small"
-            tag="h3"
-          >
-            {marcTitle}
-          </Headline>
+  const renderContent = () => (
+    <Pane
+      paneTitle={paneTitle}
+      paneSub={paneSub}
+      defaultWidth={paneWidth}
+      id="marc-view-pane"
+      dismissible
+      onClose={onClose}
+      data-test-instance-marc
+      {...optionalProps}
+    >
+      <section className={styles.marcWrapper}>
+        <Headline
+          size="large"
+          margin="small"
+          tag="h3"
+        >
+          {marcTitle}
+        </Headline>
 
-          <table className={styles.marc}>
-            <tbody>
-              <tr data-test-instance-marc-field>
-                <td colSpan="4">
-                  {`LEADER ${parsedMarc.leader}`}
-                </td>
-              </tr>
+        <table className={styles.marc}>
+          <tbody>
+            <tr data-test-instance-marc-field>
+              <td colSpan="4">
+                {`LEADER ${parsedMarc.leader}`}
+              </td>
+            </tr>
 
-              {
-                parsedMarc.fields
-                  .map((field, idx) => (
-                    <MarcField
-                      field={field}
-                      key={idx}
-                    />
-                  ))
-              }
-            </tbody>
-          </table>
-        </section>
-      </Pane>
-    </Paneset>
+            {
+              parsedMarc.fields
+                .map((field, idx) => (
+                  <MarcField
+                    field={field}
+                    key={idx}
+                  />
+                ))
+            }
+          </tbody>
+        </table>
+      </section>
+    </Pane>
   );
+
+  return isPaneset
+    ? (
+      <Paneset
+        isRoot
+        data-testid="qm-view-paneset"
+      >
+        {renderContent()}
+      </Paneset>
+    )
+    : renderContent();
 };
 
 QuickMarcView.propTypes = propTypes;
+QuickMarcView.defaultProps = {
+  isPaneset: true,
+};
 
 export default QuickMarcView;

--- a/src/QuickMarcView/QuickMarcView.test.js
+++ b/src/QuickMarcView/QuickMarcView.test.js
@@ -81,6 +81,22 @@ describe('Given QuickMarcView', () => {
     expect(getByText(`LEADER ${marc.parsedRecord.content.leader}`)).toBeDefined();
   });
 
+  it('should render paneset wrapper', () => {
+    const { getByTestId } = renderQuickMarcView();
+
+    expect(getByTestId('qm-view-paneset')).toBeDefined();
+  });
+
+  describe('when "isPaneset" prop is false', () => {
+    it('should not render paneset wrapper', () => {
+      const { queryByTestId } = renderQuickMarcView({
+        isPaneset: false,
+      });
+
+      expect(queryByTestId('qm-view-paneset')).toBeNull();
+    });
+  });
+
   describe('when present "lastMenu" prop', () => {
     it('should render "lastMenu" prop', () => {
       const { getByText } = renderQuickMarcView({


### PR DESCRIPTION
## Purpose
Changes needed for MARC Authorities App: Closing third pane does not resize the second pane.

## Approach
The wrapping Paneset around `QuickMarcView` component was preventing the result list pane from resizing properly when the detail view pane was closed in the MARC Authorities App. So the new prop `isPaneset` was introduced to indicate when that Paneset is not needed.

## Issues
[UIQM-195](https://issues.folio.org/browse/UIQM-195)
Relates to: [UIMARCAUTH-37](https://issues.folio.org/browse/UIMARCAUTH-37)