### PR TITLE
Lock faker version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [UIQM-183](https://issues.folio.org/browse/UIQM-183) Add QuickMarcView component.
 * [UIQM-191](https://issues.folio.org/browse/UIQM-191) Use supported `uuid`.
 * [UIQM-142](https://issues.folio.org/browse/UIQM-142) Edit MARC authority record via quickMARC.
+* Lock `faker` version.
 
 ## [4.0.3](https://github.com/folio-org/ui-quick-marc/tree/v4.0.3) (2021-11-09)
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "eslint": "^6.2.1",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-jest": "^23.0.4",
-    "faker": "^4.1.0",
+    "faker": "4.1.0",
     "history": "^5.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.4.2",


### PR DESCRIPTION
The popular mock-data generation package 'faker' has been emptied by the maintainer... the latest, broken version is 6.6.6
Locking the version in case they empty older major versions