### PR TITLE
UIQM-198: Saving a MARC holdings record upon creation/update displays Instance record then Holdings record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [UIQM-142](https://issues.folio.org/browse/UIQM-142) Edit MARC authority record via quickMARC.
 * Lock `faker` version.
 * [UIQM-195](https://issues.folio.org/browse/UIQM-195) Changes for MARC Authorities App: Closing third pane does not resize the second pane.
+* [UIQM-198](https://issues.folio.org/browse/UIQM-198) Saving a MARC holdings record upon creation/update displays Instance record then Holdings record.
 
 ## [4.0.3](https://github.com/folio-org/ui-quick-marc/tree/v4.0.3) (2021-11-09)
 

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.js
@@ -70,7 +70,6 @@ const QuickMarcCreateWrapper = ({
         });
 
         showCallout({ messageId: 'ui-quick-marc.record.save.success.processing' });
-        onClose();
       })
       .catch(async (errorResponse) => {
         let messageId;


### PR DESCRIPTION
## Purpose
Prevent Instance record from showing when saving new MARC Holdings created via quickmark.

## Screenshots
![HHFOw2GomE](https://user-images.githubusercontent.com/84023879/149631581-63c9306f-2beb-4aa9-83ca-af49c9365fe2.gif)

## Issues
[UIQM-198](https://issues.folio.org/browse/UIQM-198)
