### PR TITLE
UIQM-204: Edit MARC holdings via quickMARC > Cannot save 008's Gen re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [UIQM-189](https://issues.folio.org/browse/UIQM-189) Add/Edit MARC holdings record: Improve error messaging when user enters an invalid Location (852 $b) value
 * [UIQM-187](https://issues.folio.org/browse/UIQM-187) Add a new MARC holdings/Edit MARC Holdings - 852 field display a Location Lookup link and modal.
 * [UIQM-197](https://issues.folio.org/browse/UIQM-197) Edit MARC authority record | Remove last 1XX crashes MARC Authority app.
+* [UIQM-204](https://issues.folio.org/browse/UIQM-204) Edit MARC holdings via quickMARC > Cannot save 008's Gen ret position.
 
 ## [4.0.3](https://github.com/folio-org/ui-quick-marc/tree/v4.0.3) (2021-11-09)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/FixedField/HoldingsFixedField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/FixedField/HoldingsFixedField.js
@@ -21,7 +21,7 @@ const config = {
       type: SUBFIELD_TYPES.STRING,
     },
     {
-      name: 'GenRet',
+      name: 'Gen ret',
       type: SUBFIELD_TYPES.BYTE,
     },
     {

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -76,7 +76,7 @@
   "record.fixedField.AcqStatus": "AcqStatus",
   "record.fixedField.AcqMethod": "AcqMethod",
   "record.fixedField.AcqEndDate": "AcqEndDate",
-  "record.fixedField.GenRet": "Gen ret",
+  "record.fixedField.Gen ret": "Gen ret",
   "record.fixedField.Spec ret": "Spec ret",
   "record.fixedField.Compl": "Compl",
   "record.fixedField.Copies": "Copies",


### PR DESCRIPTION
## Description
Changed 008's Gen ret position for correct name

## Issues
[UIQM-204](https://issues.folio.org/browse/UIQM-204)

## Screenshots
https://user-images.githubusercontent.com/96055497/152572317-08fd59a1-7ccf-4cbd-a103-74cc02e9d55e.mp4

