### PR TITLE
Increment version to next latest release (5.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/quick-marc",
-  "version": "4.0.3",
+  "version": "5.0.0",
   "description": "Quick MARC editor",
   "main": "index.js",
   "repository": "",


### PR DESCRIPTION
## Description
There are three builds in npm-folioci with version `5.0.1...` that prevent users from getting the latest builds of quickMARC because `5.0.0` > `4.0.3`. We need to increment the version to fix this

## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/73
https://github.com/folio-org/ui-inventory/pull/1607