### PR TITLE
UIQM-214: Update 'records-editor.records' interface version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [UIQM-202](https://issues.folio.org/browse/UIQM-202) Fix tests that fail due to timeouts on Jenkins.
 * [UIQM-209](https://issues.folio.org/browse/UIQM-209) Highlight clicked on Heading/Reference in Authorities Detail record
 * [UIQM-207](https://issues.folio.org/browse/UIQM-207) ui-quick-marc: Configure GitHub actions
+* [UIQM-214](https://issues.folio.org/browse/UIQM-214) Update 'records-editor.records' interface version to v3.1.
 
 ## [4.0.3](https://github.com/folio-org/ui-quick-marc/tree/v4.0.3) (2021-11-09)
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "displayName": "ui-quick-marc.meta.title",
     "okapiInterfaces": {
       "inventory": "10.0 11.0",
-      "records-editor.records": "3.0"
+      "records-editor.records": "3.1"
     },
     "stripesDeps": [
       "@folio/stripes-acq-components"


### PR DESCRIPTION
## Purpose
Update `records-editor.records` interface version to v3.1.

## Issues
[UIQM-214](https://issues.folio.org/browse/UIQM-214)
