### PR TITLE
UIQM-213 New Permission: View MARC holdings record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change history for ui-quick-marc
 
-## IN PROGRESS
+## [5.1.0] (IN PROGRESS)
+
+* [UIQM-213](https://issues.folio.org/browse/UIQM-213) New Permission: View MARC holdings record.
 
 ## [5.0.0](https://github.com/folio-org/ui-quick-marc/tree/v5.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-quick-marc/compare/v4.0.3...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -33,12 +33,20 @@
         "visible": true
       },
       {
+        "permissionName": "ui-quick-marc.quick-marc-holdings-editor.view",
+        "displayName": "quickMARC: View MARC holdings record",
+        "subPermissions": [
+          "records-editor.records.item.get",
+          "inventory.instances.item.get"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-quick-marc.quick-marc-holdings-editor.all",
         "displayName": "quickMARC: View, edit MARC holdings record",
         "subPermissions": [
-          "records-editor.records.item.get",
-          "records-editor.records.item.put",
-          "inventory.instances.item.get"
+          "ui-quick-marc.quick-marc-holdings-editor.view",
+          "records-editor.records.item.put"
         ],
         "visible": true
       },
@@ -46,10 +54,9 @@
         "permissionName": "ui-quick-marc.quick-marc-holdings-editor.create",
         "displayName": "quickMARC: Create a new MARC holdings record",
         "subPermissions": [
+          "ui-quick-marc.quick-marc-holdings-editor.view",
           "records-editor.records.status.item.get",
-          "records-editor.records.item.get",
-          "records-editor.records.item.post",
-          "inventory.instances.item.get"
+          "records-editor.records.item.post"
         ],
         "visible": true
       },

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -3,6 +3,7 @@
   "meta.source.system": "System",
 
   "permission.quick-marc-editor.all": "quickMARC: View, edit MARC bibliographic record",
+  "permission.quick-marc-holdings-editor.view": "quickMARC: View MARC holdings record",
   "permission.quick-marc-holdings-editor.all": "quickMARC: View, edit MARC holdings record",
   "permission.quick-marc-holdings-editor.create": "quickMARC: Create a new MARC holdings record",
   "permission.quick-marc-editor.duplicate": "quickMARC: Derive new MARC bibliographic record",


### PR DESCRIPTION
## Description
Added new permission: "View MARC holdings record"

## Issues
[UIQM-213](https://issues.folio.org/browse/UIQM-213)

## Related PRs
https://github.com/folio-org/ui-inventory/pull/1632