### PR TITLE
UIQM-162: Optimistic locking: display error message to inform user about OL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIQM-213](https://issues.folio.org/browse/UIQM-213) New Permission: View MARC holdings record.
 * [UIQM-212](https://issues.folio.org/browse/UIQM-212) New permission: View source (instance).
+* [UIQM-162](https://issues.folio.org/browse/UIQM-162) Optimistic locking: display error message to inform user about OL.
 
 ## [5.0.0](https://github.com/folio-org/ui-quick-marc/tree/v5.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-quick-marc/compare/v4.0.3...v5.0.0)

--- a/src/QuickMarc.js
+++ b/src/QuickMarc.js
@@ -16,6 +16,7 @@ import { MARC_TYPES } from './common/constants';
 
 const QuickMarc = ({
   basePath,
+  externalRecordPath,
   onClose,
 }) => {
   const editorRoutesConfig = [
@@ -83,6 +84,7 @@ const QuickMarc = ({
                   <IfPermission perm={permission}>
                     <QuickMarcEditorContainer
                       onClose={onClose}
+                      externalRecordPath={externalRecordPath}
                       {...routeProps}
                     />
                   </IfPermission>
@@ -90,6 +92,7 @@ const QuickMarc = ({
                 : (
                   <QuickMarcEditorContainer
                     onClose={onClose}
+                    externalRecordPath={externalRecordPath}
                     {...routeProps}
                   />
                 )
@@ -104,6 +107,7 @@ const QuickMarc = ({
 
 QuickMarc.propTypes = {
   basePath: PropTypes.string.isRequired,
+  externalRecordPath: PropTypes.string,
   onClose: PropTypes.func.isRequired,
 };
 

--- a/src/QuickMarcEditor/OptimisticLockingBanner/OptimisticLockingBanner.js
+++ b/src/QuickMarcEditor/OptimisticLockingBanner/OptimisticLockingBanner.js
@@ -1,0 +1,30 @@
+import {
+  useRef,
+  useCallback,
+} from 'react';
+import PropTypes from 'prop-types';
+
+import { ConflictDetectionBanner } from '@folio/stripes/components';
+
+import { ERROR_TYPES } from '../../common/constants';
+
+const OptimisticLockingBanner = ({ latestVersionLink, httpError }) => {
+  const conflictDetectionBannerRef = useRef(null);
+  const focusConflictDetectionBanner = useCallback(() => conflictDetectionBannerRef.current.focus(), []);
+
+  return (
+    httpError?.errorType === ERROR_TYPES.OPTIMISTIC_LOCKING &&
+    <ConflictDetectionBanner
+      latestVersionLink={latestVersionLink}
+      conflictDetectionBannerRef={conflictDetectionBannerRef}
+      focusConflictDetectionBanner={focusConflictDetectionBanner}
+    />
+  );
+};
+
+OptimisticLockingBanner.propTypes = {
+  latestVersionLink: PropTypes.string,
+  httpError: PropTypes.object,
+};
+
+export default OptimisticLockingBanner;

--- a/src/QuickMarcEditor/OptimisticLockingBanner/OptimisticLockingBanner.test.js
+++ b/src/QuickMarcEditor/OptimisticLockingBanner/OptimisticLockingBanner.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import {
+  render,
+  cleanup,
+} from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import '@folio/stripes-acq-components/test/jest/__mock__';
+
+import OptimisticLockingBanner from './OptimisticLockingBanner';
+import { ERROR_TYPES } from '../../common/constants';
+
+const renderOptimisticLockingBanner = (props) => (render(
+  <MemoryRouter>
+    <OptimisticLockingBanner
+      latestVersionLink="/some-url"
+      {...props}
+    />
+  </MemoryRouter>,
+));
+
+describe('Given OptimisticLockingBanner', () => {
+  afterEach(cleanup);
+
+  describe('when error is not caused by optimistic locking', () => {
+    it('should not render banner', () => {
+      const { queryByText } = renderOptimisticLockingBanner();
+
+      expect(queryByText('stripes-components.optimisticLocking.saveError')).toBeNull();
+    });
+  });
+
+  describe('when error is caused by optimistic locking', () => {
+    it('should render banner', () => {
+      const { getByText } = renderOptimisticLockingBanner({
+        httpError: {
+          errorType: ERROR_TYPES.OPTIMISTIC_LOCKING,
+        },
+      });
+
+      expect(getByText('stripes-components.optimisticLocking.saveError')).toBeDefined();
+    });
+  });
+});

--- a/src/QuickMarcEditor/OptimisticLockingBanner/index.js
+++ b/src/QuickMarcEditor/OptimisticLockingBanner/index.js
@@ -1,0 +1,1 @@
+export { default as OptimisticLockingBanner } from './OptimisticLockingBanner';

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.js
@@ -1,4 +1,7 @@
-import React, { useCallback } from 'react';
+import React, {
+  useCallback,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
@@ -16,6 +19,7 @@ import {
   autopopulateSubfieldSection,
   validateMarcRecord,
   cleanBytesFields,
+  parseHttpError,
 } from './utils';
 
 const propTypes = {
@@ -42,6 +46,7 @@ const QuickMarcCreateWrapper = ({
   locations,
 }) => {
   const showCallout = useShowCallout();
+  const [httpError, setHttpError] = useState(null);
 
   const onSubmit = useCallback(async (formValues) => {
     const autopopulatedFormValues = autopopulateSubfieldSection(
@@ -74,22 +79,9 @@ const QuickMarcCreateWrapper = ({
         showCallout({ messageId: 'ui-quick-marc.record.save.success.processing' });
       })
       .catch(async (errorResponse) => {
-        let messageId;
-        let error;
+        const parsedError = await parseHttpError(errorResponse);
 
-        try {
-          error = await errorResponse.json();
-        } catch (e) {
-          error = {};
-        }
-
-        if (error.code === 'ILLEGAL_FIXED_LENGTH_CONTROL_FIELD') {
-          messageId = 'ui-quick-marc.record.save.error.illegalFixedLength';
-        } else {
-          messageId = 'ui-quick-marc.record.save.error.generic';
-        }
-
-        showCallout({ messageId, type: 'error' });
+        setHttpError(parsedError);
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onClose, showCallout]);
@@ -102,6 +94,7 @@ const QuickMarcCreateWrapper = ({
       onSubmit={onSubmit}
       action={action}
       marcType={marcType}
+      httpError={httpError}
     />
   );
 };

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.test.js
@@ -220,7 +220,10 @@ describe('Given QuickMarcCreateWrapper', () => {
           }).getByText;
         });
 
-        mutator.quickMarcEditMarcRecord.POST = jest.fn(() => Promise.reject());
+        // eslint-disable-next-line prefer-promise-reject-errors
+        mutator.quickMarcEditMarcRecord.POST = jest.fn(() => Promise.reject({
+          json: () => Promise.resolve({}),
+        }));
 
         await fireEvent.click(getByText('stripes-acq-components.FormFooter.save'));
 

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  useState,
 } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
@@ -21,6 +22,7 @@ import {
   autopopulateSubfieldSection,
   validateMarcRecord,
   cleanBytesFields,
+  parseHttpError,
 } from './utils';
 
 const propTypes = {
@@ -45,6 +47,7 @@ const QuickMarcDuplicateWrapper = ({
   marcType,
 }) => {
   const showCallout = useShowCallout();
+  const [httpError, setHttpError] = useState(null);
 
   const onSubmit = useCallback(async (formValues) => {
     const clearFormValues = removeFieldsForDuplicate(formValues);
@@ -85,22 +88,9 @@ const QuickMarcDuplicateWrapper = ({
         });
       })
       .catch(async (errorResponse) => {
-        let messageId;
-        let error;
+        const parsedError = await parseHttpError(errorResponse);
 
-        try {
-          error = await errorResponse.json();
-        } catch (e) {
-          error = {};
-        }
-
-        if (error.code === 'ILLEGAL_FIXED_LENGTH_CONTROL_FIELD') {
-          messageId = 'ui-quick-marc.record.save.error.illegalFixedLength';
-        } else {
-          messageId = 'ui-quick-marc.record.save.error.generic';
-        }
-
-        showCallout({ messageId, type: 'error' });
+        setHttpError(parsedError);
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onClose, showCallout]);
@@ -113,6 +103,7 @@ const QuickMarcDuplicateWrapper = ({
       onSubmit={onSubmit}
       action={action}
       marcType={marcType}
+      httpError={httpError}
     />
   );
 };

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.test.js
@@ -270,7 +270,10 @@ describe('Given QuickMarcDuplicateWrapper', () => {
           }).getByText;
         });
 
-        mutator.quickMarcEditMarcRecord.POST = jest.fn(() => Promise.reject());
+        // eslint-disable-next-line prefer-promise-reject-errors
+        mutator.quickMarcEditMarcRecord.POST = jest.fn(() => Promise.reject({
+          json: () => Promise.resolve({}),
+        }));
 
         await fireEvent.click(getByText('stripes-acq-components.FormFooter.save'));
 

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -2,6 +2,7 @@ import React, {
   useEffect,
   useState,
   useCallback,
+  useMemo,
 } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
@@ -48,6 +49,7 @@ const QuickMarcEditorContainer = ({
   history,
   location,
   marcType,
+  externalRecordPath,
 }) => {
   const {
     externalId,
@@ -59,6 +61,14 @@ const QuickMarcEditorContainer = ({
   const [isLoading, setIsLoading] = useState(true);
 
   const showCallout = useShowCallout();
+
+  const externalRecordUrl = useMemo(() => {
+    if (marcType === MARC_TYPES.BIB || action === QUICK_MARC_ACTIONS.CREATE) {
+      return `${externalRecordPath}/${externalId}`;
+    } else {
+      return `${externalRecordPath}/${instanceId}/${externalId}`;
+    }
+  }, [externalRecordPath, marcType, externalId, instanceId, action]);
 
   useEffect(() => {
     const path = action === QUICK_MARC_ACTIONS.CREATE
@@ -132,6 +142,7 @@ const QuickMarcEditorContainer = ({
       location={location}
       locations={locations}
       marcType={marcType}
+      externalRecordPath={externalRecordUrl}
     />
   );
 };

--- a/src/common/constants/errorTypes.js
+++ b/src/common/constants/errorTypes.js
@@ -1,0 +1,4 @@
+export const ERROR_TYPES = {
+  OPTIMISTIC_LOCKING: 'optimisticLocking',
+  OTHER: 'other',
+};

--- a/src/common/constants/index.js
+++ b/src/common/constants/index.js
@@ -1,3 +1,4 @@
 export * from './api';
 export * from './restrictions';
 export * from './marcTypes';
+export * from './errorTypes';


### PR DESCRIPTION
## Description
Showing optimistic locking banner when a user tries to update an old version of a record

## Issues
[UIQM-162](https://issues.folio.org/browse/UIQM-162)

## Related PRs
https://github.com/folio-org/ui-inventory/pull/1645