### PR TITLE
UIQM-226 MARC holdings: Can add multiple 852s tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIQM-213](https://issues.folio.org/browse/UIQM-213) New Permission: View MARC holdings record.
 * [UIQM-212](https://issues.folio.org/browse/UIQM-212) New permission: View source (instance).
+* [UIQM-226](https://issues.folio.org/browse/UIQM-226) MARC holdings: Can add multiple 852s tags.
 
 ## [5.0.1](https://github.com/folio-org/ui-quick-marc/tree/v5.0.1) (2022-03-29)
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,8 @@ module.exports = {
     ...commonCofig.collectCoverageFrom,
     './src/*.{js,jsx}',
   ],
+  moduleNameMapper: {
+    '^.+\\.(css)$': 'identity-obj-proxy',
+    '^.+\\.(svg)$': 'identity-obj-proxy',
+  },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,8 +7,4 @@ module.exports = {
     ...commonCofig.collectCoverageFrom,
     './src/*.{js,jsx}',
   ],
-  moduleNameMapper: {
-    '^.+\\.(css)$': 'identity-obj-proxy',
-    '^.+\\.(svg)$': 'identity-obj-proxy',
-  },
 };

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -6,6 +6,7 @@ import React, {
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import find from 'lodash/find';
+import { FormSpy } from 'react-final-form';
 
 import stripesFinalForm from '@folio/stripes/final-form';
 import {
@@ -19,8 +20,6 @@ import {
   HasCommand,
   checkScope,
 } from '@folio/stripes/components';
-
-import { FormSpy } from 'react-final-form';
 
 import { QuickMarcRecordInfo } from './QuickMarcRecordInfo';
 import { QuickMarcEditorRows } from './QuickMarcEditorRows';
@@ -56,7 +55,6 @@ const QuickMarcEditor = ({
   const [records, setRecords] = useState([]);
   const [isDeleteModalOpened, setIsDeleteModalOpened] = useState(false);
   const [deletedRecords, setDeletedRecords] = useState([]);
-  const [permanentLocation, setPermanentLocation] = useState('');
   const [isLocationLookupUsed, setIsLocationLookupUsed] = useState(false);
 
   const isLocationLookupNeeded = marcType === MARC_TYPES.HOLDINGS
@@ -189,14 +187,6 @@ const QuickMarcEditor = ({
   const changeRecords = useCallback(({ values }) => {
     if (values?.records) {
       setRecords(values.records);
-
-      if (isLocationLookupNeeded) {
-        const locationField = values.records.find(field => field.tag === '852');
-
-        const matchedLocation = getLocationValue(locationField?.content);
-
-        setPermanentLocation(matchedLocation);
-      }
     }
   }, []);
 
@@ -249,8 +239,6 @@ const QuickMarcEditor = ({
                   subtype={initialValues?.leader[7]}
                   setDeletedRecords={setDeletedRecords}
                   isLocationLookupNeeded={isLocationLookupNeeded}
-                  permanentLocation={permanentLocation}
-                  setPermanentLocation={setPermanentLocation}
                   isLocationLookupUsed={isLocationLookupUsed}
                   setIsLocationLookupUsed={setIsLocationLookupUsed}
                   marcType={marcType}

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -40,7 +40,6 @@ import {
   restoreRecordAtIndex,
   getCorrespondingMarcTag,
   getContentSubfieldValue,
-  getLocationValue,
 } from './utils';
 
 const spySubscription = { values: true };

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -6,6 +6,7 @@ import { Field } from 'react-final-form';
 import {
   useIntl,
 } from 'react-intl';
+import { omit } from 'lodash';
 
 import {
   TextField,
@@ -44,8 +45,6 @@ const QuickMarcEditorRows = ({
   subtype,
   setDeletedRecords,
   isLocationLookupNeeded,
-  permanentLocation,
-  setPermanentLocation,
   isLocationLookupUsed,
   setIsLocationLookupUsed,
   mutators: {
@@ -103,7 +102,7 @@ const QuickMarcEditorRows = ({
 
           return (
             <div
-              key={idx}
+              key={recordRow.id}
               className={styles.quickMarcEditorRow}
               data-testid="quick-marc-editorid"
             >
@@ -225,13 +224,12 @@ const QuickMarcEditorRows = ({
                         {(props) => {
                           return isLocationField ? (
                             <LocationField
+                              id={recordRow.id}
                               action={action}
                               fields={fields}
                               isLocationLookupUsed={isLocationLookupUsed}
                               setIsLocationLookupUsed={setIsLocationLookupUsed}
-                              permanentLocation={permanentLocation}
-                              setPermanentLocation={setPermanentLocation}
-                              {...props}
+                              {...omit(props, ['id'])}
                             />
                           ) : (
                             <ContentField {...props} />

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -246,7 +246,6 @@ export const validateLeader = (prevLeader = '', leader = '', marcType = MARC_TYP
 
 export const getLocationValue = (value) => {
   const matches = value?.match(/\$b\s([^$\s]+\/?)+/) || [];
-
   return matches[0] || '';
 };
 


### PR DESCRIPTION
## Description
Fix issue with incorrect error displayed when saving a record with multiple 852 fields

## Approach
There were two issues: with `<LocationField>` and `<QuickMarcEditorRows>`
1. `<LocationField>` accepted `permanentLocation` as a prop. This was stored higher in the component tree, so all location rows shared the same location. The fix is to store `permanentLocation` in state of `<LocationField>`
2. `<QuickMarcEditorRows>` used index as a key for rows. When deleting a row it caused some weird mixing of row contents.

## Screenshots

https://user-images.githubusercontent.com/19309423/161759249-4be2d5b2-9935-471d-a0cb-08b3a878c048.mp4

## Issues
[UIQM-226](https://issues.folio.org/browse/UIQM-226)