### PR TITLE
UIQM-231: User able to replace the 001 field value when edit record in quickmarc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [UIQM-230](https://issues.folio.org/browse/UIQM-230) Replace `babel-eslint` with `@babel/eslint-parser`.
 * [UIQM-228](https://issues.folio.org/browse/UIQM-228) "Save & close" button accessibility when edit bib/holdings/authority record via "quickMARC".
 * [UIQM-53](https://issues.folio.org/browse/UIQM-53) Adjust the quickMARC edit UI to indicate that specific fields are protected.
+* [UIQM-231](https://issues.folio.org/browse/UIQM-231) Fix user able to replace the '001' field value when edit record in quickmarc.
 
 ## [5.0.1](https://github.com/folio-org/ui-quick-marc/tree/v5.0.1) (2022-03-29)
 

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.js
@@ -18,6 +18,7 @@ import {
   removeFieldsForDuplicate,
   autopopulateSubfieldSection,
   validateMarcRecord,
+  checkControlFieldLength,
   cleanBytesFields,
   parseHttpError,
 } from './utils';
@@ -49,6 +50,14 @@ const QuickMarcCreateWrapper = ({
   const [httpError, setHttpError] = useState(null);
 
   const onSubmit = useCallback(async (formValues) => {
+    const controlFieldErrorMessage = checkControlFieldLength(formValues);
+
+    if (controlFieldErrorMessage) {
+      showCallout({ message: controlFieldErrorMessage, type: 'error' });
+
+      return null;
+    }
+
     const autopopulatedFormValues = autopopulateSubfieldSection(
       removeFieldsForDuplicate(formValues),
       initialValues,

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
@@ -21,6 +21,7 @@ import {
   autopopulateIndicators,
   autopopulateSubfieldSection,
   validateMarcRecord,
+  checkControlFieldLength,
   cleanBytesFields,
   parseHttpError,
 } from './utils';
@@ -50,6 +51,14 @@ const QuickMarcDuplicateWrapper = ({
   const [httpError, setHttpError] = useState(null);
 
   const onSubmit = useCallback(async (formValues) => {
+    const controlFieldErrorMessage = checkControlFieldLength(formValues);
+
+    if (controlFieldErrorMessage) {
+      showCallout({ message: controlFieldErrorMessage, type: 'error' });
+
+      return null;
+    }
+
     const clearFormValues = removeFieldsForDuplicate(formValues);
     const autopopulatedFormWithIndicators = autopopulateIndicators(clearFormValues);
     const autopopulatedFormWithSubfields = autopopulateSubfieldSection(

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -15,6 +15,7 @@ import { MARC_TYPES } from '../common/constants';
 import {
   hydrateMarcRecord,
   validateMarcRecord,
+  checkControlFieldLength,
   autopopulateIndicators,
   autopopulateSubfieldSection,
   cleanBytesFields,
@@ -49,10 +50,15 @@ const QuickMarcEditWrapper = ({
   const searchParams = new URLSearchParams(location.search);
 
   const onSubmit = useCallback(async (formValues) => {
+    const controlFieldErrorMessage = checkControlFieldLength(formValues);
     const validationErrorMessage = validateMarcRecord(formValues, initialValues, marcType, locations);
+    const errorMessage = controlFieldErrorMessage || validationErrorMessage;
 
-    if (validationErrorMessage) {
-      showCallout({ message: validationErrorMessage, type: 'error' });
+    if (errorMessage) {
+      showCallout({
+        message: errorMessage,
+        type: 'error',
+      });
 
       return null;
     }

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -307,6 +307,7 @@ QuickMarcEditorRows.propTypes = {
     id: PropTypes.string.isRequired,
     tag: PropTypes.string.isRequired,
     indicators: PropTypes.arrayOf(PropTypes.string),
+    isProtected: PropTypes.bool.isRequired,
     content: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   })),
   setDeletedRecords: PropTypes.func.isRequired,

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -304,6 +304,17 @@ export const checkIsInitialRecord = (initialMarcRecord, marcRecordId) => {
   return initialMarcRecordIds.has(marcRecordId);
 };
 
+export const checkControlFieldLength = (formValues) => {
+  const marcRecords = formValues.records || [];
+  const controlFieldRecords = marcRecords.filter(({ tag }) => tag === '001');
+
+  if (controlFieldRecords.length > 1) {
+    return <FormattedMessage id="ui-quick-marc.record.error.controlField.multiple" />;
+  }
+
+  return undefined;
+};
+
 export const validateSubfield = (marcRecords, initialMarcRecords) => {
   const marcRecordsWithSubfields = marcRecords.filter(marcRecord => marcRecord.indicators);
   const isEmptySubfield = marcRecordsWithSubfields.some(marcRecord => {

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -612,6 +612,64 @@ describe('QuickMarcEditor utils', () => {
     });
   });
 
+  describe('checkControlFieldLength', () => {
+    it('should not return error message when only one 001 field is present', () => {
+      const formValues = {
+        records: [{
+          tag: '001',
+          content: 'some content',
+          id: 'id001',
+        }, {
+          tag: '035',
+          content: 'some content',
+          id: 'id035',
+          indicators: ['0', '\\'],
+        }, {
+          content: '',
+          id: 'id999ff',
+          indicators: ['f', 'f'],
+          tag: '999',
+        }],
+        updateInfo: {
+          recordState: 'actual',
+          updateDate: '01/01/1970',
+        },
+      };
+
+      expect(utils.checkControlFieldLength(formValues)).not.toBeDefined();
+    });
+
+    it('should return error message when more than one 001 field is present', () => {
+      const formValues = {
+        records: [{
+          tag: '001',
+          content: 'some content',
+          id: 'id001-1',
+        }, {
+          tag: '001',
+          content: 'some other content',
+          id: 'id001-2',
+        }, {
+          tag: '035',
+          content: 'some content',
+          id: 'id035',
+          indicators: ['0', '\\'],
+        }, {
+          content: '',
+          id: 'id999ff-746e-4058-a35b-8130e4f6d277',
+          indicators: ['f', 'f'],
+          tag: '999',
+        }],
+        updateInfo: {
+          recordState: 'actual',
+          updateDate: '01/01/1970',
+        },
+      };
+
+      expect(utils.checkControlFieldLength(formValues).props.id).toBe('ui-quick-marc.record.error.controlField.multiple');
+    });
+  });
+
   describe('validateSubfield', () => {
     it('should not return error message when indicators are present and content is not empty', () => {
       const initialRecords = [

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -167,6 +167,7 @@
   "record.error.leader.fixedFieldMismatch": "Record cannot be saved. The Leader and 008 do not match.",
   "record.error.leader.invalidPositionValue": "Invalid value entered for the Leader {position}",
   "record.error.bib.leader.invalid005PositionValue": "Record cannot be saved. Invalid value entered for position 5.",
+  "record.error.controlField.multiple": "Record cannot be saved. Can only have one MARC 001.",
   "record.error.instanceHrid.multiple": "Record cannot be saved. Can only have one MARC 004.",
   "record.error.heading.empty": "Record cannot be saved without 1XX field.",
   "record.error.heading.multiple": "Record cannot be saved. Cannot have multiple 1XXs",


### PR DESCRIPTION
## Purpose
Fix user able to replace the '001' field value when edit bib/holdings/authority record in quickmarc by showing an error message. As per ticket requirement the same behavior was also implemented when adding a MARC holdings record and deriving a new MARC bibliographic record.

## Screenshots
https://user-images.githubusercontent.com/84023879/166662425-573b30b1-30e2-41bf-af46-8ebe04b33e39.mp4

## Issues
[UIQM-231](https://issues.folio.org/browse/UIQM-231)