### PR TITLE
UIQM-247 Folio crashes in quickmarc editor when cypress clears LDR field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [UIQM-242](https://issues.folio.org/browse/UIQM-242) Apply to MARC Authority:  Optimistic locking: display error message to inform user about OL
 * [UIQM-239](https://issues.folio.org/browse/UIQM-239) FE: Derive/Edit MARC bibliographic record: Error message for when a user attempts to edit a read-only leader value  is not updated
 * [UIQM-241](https://issues.folio.org/browse/UIQM-241) update NodeJS to v16 in GitHub Actions
+* [UIQM-247](https://issues.folio.org/browse/UIQM-247) Folio crashes in quickmarc editor when cypress clears LDR field
 
 ## [5.0.1](https://github.com/folio-org/ui-quick-marc/tree/v5.0.1) (2022-03-29)
 

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -67,8 +67,8 @@ const QuickMarcEditor = ({
   const [deletedRecords, setDeletedRecords] = useState([]);
 
   const leader = records[0];
-  const type = leader?.content[6];
-  const subtype = leader?.content[7];
+  const type = leader?.content?.[6];
+  const subtype = leader?.content?.[7];
 
   const saveFormDisabled = action === QUICK_MARC_ACTIONS.EDIT
     ? pristine || submitting

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -124,6 +124,18 @@ describe('Given QuickMarcEditor', () => {
     expect(getByTestId('quick-marc-editor-rows')).toBeDefined();
   });
 
+  describe('when clearing LDR field', () => {
+    it('should not crash the app', () => {
+      const { getByTestId } = renderQuickMarcEditor();
+
+      const contentField = getByTestId('content-field-0');
+
+      fireEvent.change(contentField, { target: { value: '' } });
+
+      expect(getByTestId('quick-marc-editor-rows')).toBeDefined();
+    });
+  });
+
   describe('when deleted a row', () => {
     it('should not display ConfirmationModal', () => {
       const {


### PR DESCRIPTION
## Description
Fix Folio crashes in quickmarc editor when cypress clears LDR field

## Screenshots

https://user-images.githubusercontent.com/19309423/171904831-22831c43-b20f-45af-89c0-4c24d4e5d42d.mp4


## Issues
[UIQM-247](https://issues.folio.org/browse/UIQM-247)