### PR TITLE
UIQM-243

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [UIQM-242](https://issues.folio.org/browse/UIQM-242) Apply to MARC Authority:  Optimistic locking: display error message to inform user about OL
 * [UIQM-239](https://issues.folio.org/browse/UIQM-239) FE: Derive/Edit MARC bibliographic record: Error message for when a user attempts to edit a read-only leader value  is not updated
 * [UIQM-241](https://issues.folio.org/browse/UIQM-241) update NodeJS to v16 in GitHub Actions
+* [UIQM-243](https://issues.folio.org/browse/UIQM-243) Optimistic Locking: Do not send update request when user attempts to update older version of MARC bib/holdings/authority
 
 ## [5.0.1](https://github.com/folio-org/ui-quick-marc/tree/v5.0.1) (2022-03-29)
 

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -11,7 +11,10 @@ import {
 
 import QuickMarcEditor from './QuickMarcEditor';
 import { QUICK_MARC_ACTIONS } from './constants';
-import { MARC_TYPES } from '../common/constants';
+import {
+  EXTERNAL_INSTANCE_APIS,
+  MARC_TYPES,
+} from '../common/constants';
 import {
   hydrateMarcRecord,
   validateMarcRecord,
@@ -72,6 +75,22 @@ const QuickMarcEditWrapper = ({
     const formValuesForEdit = cleanBytesFields(autopopulatedFormWithSubfields, initialValues, marcType);
 
     const marcRecord = hydrateMarcRecord(formValuesForEdit);
+
+    const path = EXTERNAL_INSTANCE_APIS[marcType];
+    const instancePromise = await mutator.quickMarcEditInstance.GET({ path: `${path}/${marcRecord.externalId}` });
+
+    const prevVersion = instance._version;
+    const lastVersion = instancePromise._version;
+
+    if (prevVersion !== lastVersion) {
+      setHttpError({
+        code: 'VERSINO_ERROR',
+        errorType: 'optimisticLocking',
+        message: 'Depricated instance version cannot be updated.',
+      });
+
+      return null;
+    }
 
     marcRecord.relatedRecordVersion = marcType === MARC_TYPES.AUTHORITY
       ? instance._version

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -14,6 +14,7 @@ import { QUICK_MARC_ACTIONS } from './constants';
 import {
   EXTERNAL_INSTANCE_APIS,
   MARC_TYPES,
+  ERROR_TYPES,
 } from '../common/constants';
 import {
   hydrateMarcRecord,
@@ -84,7 +85,7 @@ const QuickMarcEditWrapper = ({
 
     if (prevVersion && lastVersion && prevVersion !== lastVersion) {
       setHttpError({
-        errorType: 'optimisticLocking',
+        errorType: ERROR_TYPES.OPTIMISTIC_LOCKING,
         message: 'Instance cannot be updated. Depricated instance version.',
       });
 

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -82,11 +82,10 @@ const QuickMarcEditWrapper = ({
     const prevVersion = instance._version;
     const lastVersion = instancePromise._version;
 
-    if (prevVersion !== lastVersion) {
+    if (prevVersion && lastVersion && prevVersion !== lastVersion) {
       setHttpError({
-        code: 'VERSINO_ERROR',
         errorType: 'optimisticLocking',
-        message: 'Depricated instance version cannot be updated.',
+        message: 'Instance cannot be updated. Depricated instance version.',
       });
 
       return null;

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.test.js
@@ -5,6 +5,7 @@ import {
   cleanup,
   act,
   fireEvent,
+  waitFor,
 } from '@testing-library/react';
 import faker from 'faker';
 import noop from 'lodash/noop';
@@ -275,7 +276,7 @@ describe('Given QuickMarcEditWrapper', () => {
         update: jest.fn(),
       },
       quickMarcEditInstance: {
-        GET: () => Promise.resolve(instance),
+        GET: jest.fn(() => Promise.resolve(instance)),
       },
       quickMarcEditMarcRecord: {
         GET: jest.fn(() => Promise.resolve(record)),
@@ -308,8 +309,10 @@ describe('Given QuickMarcEditWrapper', () => {
 
         await fireEvent.click(getByText('stripes-acq-components.FormFooter.save'));
 
+        expect(mutator.quickMarcEditInstance.GET).toHaveBeenCalled();
         expect(mutator.quickMarcEditMarcRecord.PUT).toHaveBeenCalled();
-        expect(mockShowCallout).toHaveBeenCalledWith({ messageId: 'ui-quick-marc.record.save.success.processing' });
+
+        waitFor(() => expect(mockShowCallout).toHaveBeenCalledWith({ messageId: 'ui-quick-marc.record.save.success.processing' }));
 
         await new Promise(resolve => {
           setTimeout(() => {
@@ -408,7 +411,10 @@ describe('Given QuickMarcEditWrapper', () => {
 
         await fireEvent.click(getByText('stripes-acq-components.FormFooter.save'));
 
-        expect(mockShowCallout).toHaveBeenCalledWith({ messageId: 'ui-quick-marc.record.save.updated' });
+        expect(mutator.quickMarcEditInstance.GET).toHaveBeenCalled();
+        expect(mutator.quickMarcEditMarcRecord.PUT).toHaveBeenCalled();
+
+        waitFor(() => expect(mockShowCallout).toHaveBeenCalledWith({ messageId: 'ui-quick-marc.record.save.updated' }));
 
         await new Promise(resolve => {
           setTimeout(() => {


### PR DESCRIPTION
## Purpose
Optimistic Locking: Do not send update request when user attempts to update older version of MARC bib/holdings/authority

## Approach
Request to fetch the latest _instancePromise_ is made. Then we compare fetched _instancePromise_'s version with current _instancePromise_'s version. If it is different, the conflict detection banner is showed up with error message.

