### PR TITLE
UIQM-248: Not expected validator message in quickmarc editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [UIQM-241](https://issues.folio.org/browse/UIQM-241) update NodeJS to v16 in GitHub Actions
 * [UIQM-247](https://issues.folio.org/browse/UIQM-247) Folio crashes in quickmarc editor when cypress clears LDR field
 * [UIQM-243](https://issues.folio.org/browse/UIQM-243) Optimistic Locking: Do not send update request when user attempts to update older version of MARC bib/holdings/authority
+* [UIQM-248](https://issues.folio.org/browse/UIQM-248) Not expected validator message in quickmarc editor
 
 ## [5.0.1](https://github.com/folio-org/ui-quick-marc/tree/v5.0.1) (2022-03-29)
 

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -246,8 +246,12 @@ const validateLeaderPositions = (prevLeader, leader, marcType) => {
   const prevLeaderJoinedPositions = joinFailedPositions(prevLeaderFailedPositions);
   const failedPositions = getInvalidLeaderPositions(leader, marcType);
   const joinedPositions = joinFailedPositions(failedPositions);
+  const isEighthFieldBlank = !FixedFieldFactory.getFixedFieldByType(marcType, leader[6], leader[7]);
 
-  if (prevLeaderFailedPositions.length && prevLeader === leader) {
+  if (
+    (prevLeaderFailedPositions.length && prevLeader === leader)
+    || isEighthFieldBlank
+  ) {
     // invalid leader positions came from backend
     return (
       <FormattedMessage


### PR DESCRIPTION
## Purpose
Fix the not expected validator message in quickmarc editor

## Approach
The _validateLeaderPositions_' condition is extended to check if the _008_ field is blank. Then show up a valid error message according to condition result.