### PR TITLE
UIQM-267 MARC Holdings - Leader position 18 accept a space and \ as a valid value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UIQM-259](https://issues.folio.org/browse/UIQM-259) Edit MARC authority: User does not get a notification that the record is edited has been deleted by another user.
 * [UIQM-258](https://issues.folio.org/browse/UIQM-258) Add fake link Authority button next to MARC fields.
 * [UIQM-260](https://issues.folio.org/browse/UIQM-260) Fix Add MARC holdings:  852 field > cannot enter text 
+* [UIQM-267](https://issues.folio.org/browse/UIQM-267) MARC Holdings - Leader position 18 accept a space and \ as a valid value
 
 ## [5.1.0](https://github.com/folio-org/ui-quick-marc/tree/v5.1.0) (2022-07-08)
 

--- a/src/QuickMarcEditor/constants.js
+++ b/src/QuickMarcEditor/constants.js
@@ -18,7 +18,7 @@ export const LEADER_VALUES_FOR_POSITION = {
     5: ['c', 'd', 'n'],
     6: ['u', 'v', 'x', 'y'],
     17: ['1', '2', '3', '4', '5', 'm', 'u', 'z'],
-    18: ['i', 'n'],
+    18: ['\\', ' ', '\u00A0', 'i', 'n'],
   },
   [MARC_TYPES.AUTHORITY]: [],
 };


### PR DESCRIPTION
## Description
Add support for `\`, space and a non-breaking space in MARC Holdings Leader 18

## Issues
[UIQM-267](https://issues.folio.org/browse/UIQM-267)