### PR TITLE
UIQM-261: Shift focus to MARC tag box once you click Add or Delete field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIQM-259](https://issues.folio.org/browse/UIQM-259) Edit MARC authority: User does not get a notification that the record is edited has been deleted by another user.
 * [UIQM-258](https://issues.folio.org/browse/UIQM-258) Add fake link Authority button next to MARC fields.
+* [UIQM-261](https://issues.folio.org/browse/UIQM-261) Shift focus to MARC tag box once you click Add or Delete field.
 
 ## [5.1.1](https://github.com/folio-org/ui-quick-marc/tree/v5.1.1) (2022-08-05)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -7,6 +7,9 @@ import {
 } from '@testing-library/react';
 import { Form } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
+import {
+  defer,
+} from 'lodash';
 
 import '@folio/stripes-acq-components/test/jest/__mock__';
 
@@ -14,6 +17,11 @@ import QuickMarcEditorRows from './QuickMarcEditorRows';
 import * as utils from './utils';
 import { QUICK_MARC_ACTIONS } from '../constants';
 import { MARC_TYPES } from '../../common/constants';
+
+jest.mock('lodash', () => ({
+  ...jest.requireActual('lodash'),
+  defer: jest.fn(),
+}));
 
 const values = [
   {
@@ -92,6 +100,9 @@ const renderQuickMarcEditorRows = (props = {}) => (render(
 ));
 
 describe('Given QuickMarcEditorRows', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   afterEach(cleanup);
 
   it('should display row for each record value', () => {
@@ -142,6 +153,14 @@ describe('Given QuickMarcEditorRows', () => {
       expect(addRecordMock).toHaveBeenCalled();
     });
 
+    it('should focus the new `tag` field with a delay', async () => {
+      const { getAllByRole } = renderQuickMarcEditorRows();
+      const [addButton] = getAllByRole('button', { name: 'ui-quick-marc.record.addField' });
+
+      fireEvent.click(addButton);
+      expect(defer).toHaveBeenCalled();
+    });
+
     describe('and deleting a new row and saving', () => {
       it('should mark the row as deleted', () => {
         const {
@@ -188,6 +207,14 @@ describe('Given QuickMarcEditorRows', () => {
       fireEvent.click(deleteButton);
 
       expect(deleteRecordMock).toHaveBeenCalled();
+    });
+
+    it('should focus the `tag` field that is located after the deleted field with a delay', async () => {
+      const { getAllByRole } = renderQuickMarcEditorRows();
+      const [deleteButton] = getAllByRole('button', { name: 'ui-quick-marc.record.deleteField' });
+
+      fireEvent.click(deleteButton);
+      expect(defer).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
- By clicking on Add a field the focus should shift to the newly added row's MARC tag text box
- By clicking on Remove a field the focus should move the next down row's MARC tag text box 
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-261](https://issues.folio.org/browse/UIQM-261)

## Screencast




https://user-images.githubusercontent.com/77053927/183629289-e201ee65-841c-4d7f-ad04-7b57b919481d.mp4





## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
