### PR TITLE
UIQM-271: Only display the MARC authority link when the user has the appropriate permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIQM-259](https://issues.folio.org/browse/UIQM-259) Edit MARC authority: User does not get a notification that the record is edited has been deleted by another user.
 * [UIQM-258](https://issues.folio.org/browse/UIQM-258) Add fake link Authority button next to MARC fields.
+* [UIQM-271](https://issues.folio.org/browse/UIQM-271) Only display the MARC authority link when the user has the appropriate permissions.
 
 ## [5.1.1](https://github.com/folio-org/ui-quick-marc/tree/v5.1.1) (2022-08-05)
 

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.js
@@ -32,6 +32,9 @@ const propTypes = {
   locations: PropTypes.object.isRequired,
   marcType: PropTypes.oneOf(Object.values(MARC_TYPES)).isRequired,
   mutator: PropTypes.object.isRequired,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
   onClose: PropTypes.func.isRequired,
 };
 
@@ -45,6 +48,7 @@ const QuickMarcCreateWrapper = ({
   location,
   marcType,
   locations,
+  stripes,
 }) => {
   const showCallout = useShowCallout();
   const [httpError, setHttpError] = useState(null);
@@ -104,6 +108,7 @@ const QuickMarcCreateWrapper = ({
       action={action}
       marcType={marcType}
       httpError={httpError}
+      stripes={stripes}
     />
   );
 };

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.test.js
@@ -119,12 +119,17 @@ const locations = [{
   code: 'KU/CC/DI/A',
 }];
 
+const stripesMock = {
+  hasPerm: jest.fn(),
+};
+
 const renderQuickMarcCreateWrapper = ({
   instance,
   onClose = noop,
   mutator,
   history,
   location,
+  stripes = stripesMock,
 }) => (render(
   <MemoryRouter>
     <QuickMarcCreateWrapper
@@ -137,6 +142,7 @@ const renderQuickMarcCreateWrapper = ({
       location={location}
       marcType={MARC_TYPES.HOLDINGS}
       locations={locations}
+      stripes={stripes}
     />
   </MemoryRouter>,
 ));

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
@@ -34,6 +34,9 @@ const propTypes = {
   location: ReactRouterPropTypes.location.isRequired,
   marcType: PropTypes.oneOf(Object.values(MARC_TYPES)).isRequired,
   mutator: PropTypes.object.isRequired,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
   onClose: PropTypes.func.isRequired,
 };
 
@@ -46,6 +49,7 @@ const QuickMarcDuplicateWrapper = ({
   history,
   location,
   marcType,
+  stripes,
 }) => {
   const showCallout = useShowCallout();
   const [httpError, setHttpError] = useState(null);
@@ -113,6 +117,7 @@ const QuickMarcDuplicateWrapper = ({
       action={action}
       marcType={marcType}
       httpError={httpError}
+      stripes={stripes}
     />
   );
 };

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.test.js
@@ -159,12 +159,17 @@ const record = {
   fields: [],
 };
 
+const stripesMock = {
+  hasPerm: jest.fn(),
+};
+
 const renderQuickMarcDuplicateWrapper = ({
   instance,
   onClose = noop,
   mutator,
   history,
   location,
+  stripes = stripesMock,
 }) => (render(
   <MemoryRouter>
     <QuickMarcDuplicateWrapper
@@ -176,6 +181,7 @@ const renderQuickMarcDuplicateWrapper = ({
       marcType="bib"
       history={history}
       location={location}
+      stripes={stripes}
     />
   </MemoryRouter>,
 ));

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -35,6 +35,9 @@ const propTypes = {
   mutator: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
   locations: PropTypes.arrayOf(PropTypes.object).isRequired,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 const QuickMarcEditWrapper = ({
@@ -46,6 +49,7 @@ const QuickMarcEditWrapper = ({
   marcType,
   locations,
   externalRecordPath,
+  stripes,
 }) => {
   const showCallout = useShowCallout();
   const location = useLocation();
@@ -133,6 +137,7 @@ const QuickMarcEditWrapper = ({
       locations={locations}
       httpError={httpError}
       externalRecordPath={externalRecordPath}
+      stripes={stripes}
     />
   );
 };

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.test.js
@@ -242,6 +242,10 @@ const locations = [{
   code: 'KU/CC/DI/A',
 }];
 
+const stripesMock = {
+  hasPerm: jest.fn(),
+};
+
 const renderQuickMarcEditWrapper = ({
   instance,
   mutator,
@@ -259,6 +263,7 @@ const renderQuickMarcEditWrapper = ({
       location={{}}
       locations={locations}
       externalRecordPath="/some-record"
+      stripes={stripesMock}
       {...props}
     />
   </MemoryRouter>,

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -60,6 +60,7 @@ const QuickMarcEditor = ({
   locations,
   httpError,
   externalRecordPath,
+  stripes,
 }) => {
   const showCallout = useShowCallout();
   const [records, setRecords] = useState([]);
@@ -274,6 +275,7 @@ const QuickMarcEditor = ({
                   subtype={subtype}
                   setDeletedRecords={setDeletedRecords}
                   marcType={marcType}
+                  stripes={stripes}
                 />
               </Col>
             </Row>
@@ -304,6 +306,9 @@ QuickMarcEditor.propTypes = {
   instance: PropTypes.object,
   onClose: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
   submitting: PropTypes.bool,
   pristine: PropTypes.bool,
   initialValues: PropTypes.object.isRequired,

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -82,6 +82,10 @@ const initialValues = {
   }],
 };
 
+const stripesMock = {
+  hasPerm: jest.fn(),
+};
+
 const renderQuickMarcEditor = (props) => (render(
   <MemoryRouter>
     <QuickMarcEditor
@@ -97,6 +101,7 @@ const renderQuickMarcEditor = (props) => (render(
       initialValues={initialValues}
       marcType={MARC_TYPES.BIB}
       locations={locations}
+      stripes={stripesMock}
       {...props}
     />
   </MemoryRouter>,

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -38,6 +38,9 @@ const propTypes = {
   marcType: PropTypes.oneOf(Object.values(MARC_TYPES)).isRequired,
   mutator: PropTypes.object.isRequired,
   match: ReactRouterPropTypes.match.isRequired,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
   wrapper: PropTypes.func.isRequired,
 };
 
@@ -51,6 +54,7 @@ const QuickMarcEditorContainer = ({
   location,
   marcType,
   externalRecordPath,
+  stripes,
 }) => {
   const {
     externalId,
@@ -135,6 +139,7 @@ const QuickMarcEditorContainer = ({
       locations={locations}
       marcType={marcType}
       externalRecordPath={externalRecordUrl}
+      stripes={stripes}
     />
   );
 };

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.test.js
@@ -38,6 +38,9 @@ const record = {
 const locations = [];
 
 const externalRecordPath = '/external/record/path';
+const stripesMock = {
+  hasPerm: jest.fn(),
+};
 
 const renderQuickMarcEditorContainer = ({
   onClose,
@@ -46,6 +49,7 @@ const renderQuickMarcEditorContainer = ({
   wrapper,
   marcType = MARC_TYPES.BIB,
   history = createMemoryHistory(),
+  stripes = stripesMock,
 }) => (render(
   <Router history={history}>
     <QuickMarcEditorContainer
@@ -56,6 +60,7 @@ const renderQuickMarcEditorContainer = ({
       action={action}
       marcType={marcType}
       externalRecordPath={externalRecordPath}
+      stripes={stripes}
     />
   </Router>,
 ));

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -57,7 +57,10 @@ const QuickMarcEditorRows = ({
     moveRecord,
   },
   marcType,
+  stripes,
 }) => {
+  const showLinkToMarcAuthority = stripes.hasPerm('ui-marc-authorities.authority-record.view') &&
+    stripes.hasPerm('ui-quick-marc.quick-marc-authorities-editor.all');
   const intl = useIntl();
   const { initialValues } = useFormState();
 
@@ -296,11 +299,13 @@ const QuickMarcEditorRows = ({
                       />
                     )
                   }
-                  <Pluggable
-                    type="find-authority"
-                  >
-                    <FormattedMessage id="ui-quick-marc.noPlugin" />
-                  </Pluggable>
+                  {showLinkToMarcAuthority &&
+                    <Pluggable
+                      type="find-authority"
+                    >
+                      <FormattedMessage id="ui-quick-marc.noPlugin" />
+                    </Pluggable>
+                  }
                 </div>
               </div>
             );
@@ -314,6 +319,9 @@ const QuickMarcEditorRows = ({
 QuickMarcEditorRows.propTypes = {
   action: PropTypes.oneOf(Object.values(QUICK_MARC_ACTIONS)).isRequired,
   type: PropTypes.string.isRequired,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
   subtype: PropTypes.string.isRequired,
   fields: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -15,6 +15,11 @@ import * as utils from './utils';
 import { QUICK_MARC_ACTIONS } from '../constants';
 import { MARC_TYPES } from '../../common/constants';
 
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  Pluggable: jest.fn(({ type }) => <div data-testid={type}>Pluggable</div>),
+}));
+
 const values = [
   {
     id: '1',
@@ -61,6 +66,9 @@ const addRecordMock = jest.fn();
 const deleteRecordMock = jest.fn();
 const moveRecordMock = jest.fn();
 const setDeletedRecordsMock = jest.fn();
+const stripesMock = {
+  hasPerm: () => true,
+};
 
 const renderQuickMarcEditorRows = (props = {}) => (render(
   <MemoryRouter>
@@ -84,6 +92,7 @@ const renderQuickMarcEditorRows = (props = {}) => (render(
           }}
           subtype="test"
           setDeletedRecords={setDeletedRecordsMock}
+          stripes={stripesMock}
           {...props}
         />
       )}
@@ -223,6 +232,18 @@ describe('Given QuickMarcEditorRows', () => {
 
         expect(queryByTestId('quick-marc-protected-field-popover')).toBeNull();
       });
+    });
+  });
+
+  describe('when there are no required permissions', () => {
+    it('should not display the `find-authority` plugin', () => {
+      const { queryByTestId } = renderQuickMarcEditorRows({
+        stripes: {
+          hasPerm: () => false,
+        },
+      });
+
+      expect(queryByTestId('find-authority')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Users who have the following permissions assigned will be able to access modal:
- MARC Authority: View MARC authority record
- quickMARC: View, edit MARC authorities record

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIPFAUTH-3](https://issues.folio.org/browse/UIPFAUTH-3)
[UIQM-271](https://issues.folio.org/browse/UIQM-271)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
