### PR TITLE
UIQM-266 Edit quickMARC: Undoing a delete field is not restored in the same position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIQM-259](https://issues.folio.org/browse/UIQM-259) Edit MARC authority: User does not get a notification that the record is edited has been deleted by another user.
 * [UIQM-258](https://issues.folio.org/browse/UIQM-258) Add fake link Authority button next to MARC fields.
+* [UIQM-266](https://issues.folio.org/browse/UIQM-266) Edit quickMARC: Undoing a delete field is not restored in the same position.
 
 ## [5.1.1](https://github.com/folio-org/ui-quick-marc/tree/v5.1.1) (2022-08-05)
 

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -24,6 +24,7 @@ import {
   autopopulateSubfieldSection,
   cleanBytesFields,
   parseHttpError,
+  removeDeletedRecords,
 } from './utils';
 
 const propTypes = {
@@ -54,8 +55,9 @@ const QuickMarcEditWrapper = ({
   const searchParams = new URLSearchParams(location.search);
 
   const onSubmit = useCallback(async (formValues) => {
-    const controlFieldErrorMessage = checkControlFieldLength(formValues);
-    const validationErrorMessage = validateMarcRecord(formValues, initialValues, marcType, locations);
+    const formValuesToSave = removeDeletedRecords(formValues);
+    const controlFieldErrorMessage = checkControlFieldLength(formValuesToSave);
+    const validationErrorMessage = validateMarcRecord(formValuesToSave, initialValues, marcType, locations);
     const errorMessage = controlFieldErrorMessage || validationErrorMessage;
 
     if (errorMessage) {
@@ -67,7 +69,7 @@ const QuickMarcEditWrapper = ({
       return null;
     }
 
-    const autopopulatedFormWithIndicators = autopopulateIndicators(formValues);
+    const autopopulatedFormWithIndicators = autopopulateIndicators(formValuesToSave);
     const autopopulatedFormWithSubfields = autopopulateSubfieldSection(
       autopopulatedFormWithIndicators,
       initialValues,

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -357,8 +357,4 @@ export default stripesFinalForm({
       tools.changeValue(state, 'records', () => records);
     },
   },
-  subscription: {
-    dirty: true,
-    dirtyFields: true,
-  },
 })(QuickMarcEditor);

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -26,6 +26,7 @@ import {
   dehydrateMarcRecordResponse,
   getCreateMarcRecordResponse,
   formatMarcRecordByQuickMarcAction,
+  addInternalFieldProperties,
 } from './utils';
 import { QUICK_MARC_ACTIONS } from './constants';
 
@@ -100,9 +101,10 @@ const QuickMarcEditorContainer = ({
           : dehydrateMarcRecordResponse(marcRecordResponse);
 
         const formattedMarcRecord = formatMarcRecordByQuickMarcAction(dehydratedMarcRecord, action);
+        const marcRecordWithInternalProps = addInternalFieldProperties(formattedMarcRecord);
 
         setInstance(instanceResponse);
-        setMarcRecord(formattedMarcRecord);
+        setMarcRecord(marcRecordWithInternalProps);
         setLocations(locationsResponse);
         setIsLoading(false);
       })

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -103,22 +103,6 @@ const QuickMarcEditorRows = ({
     });
   }, [moveRecord]);
 
-  const areRecordsEqual = useCallback((aArray, bArray) => {
-    // this function will deep compare MARC fields to determine if form is dirty or not
-    // if we face issues when form is dirty or clean when it's not supposed to be - look here
-    if (!Array.isArray(aArray) || !Array.isArray(bArray)) {
-      return false;
-    }
-
-    if (aArray.length !== bArray.length) {
-      return false;
-    }
-
-    return aArray.every((a, index) => {
-      return isEqual(a, bArray[index]);
-    });
-  }, []);
-
   const processTagRef = useCallback(ref => {
     if (!ref) return;
     const index = parseInt(ref.dataset.index, 10);
@@ -136,7 +120,7 @@ const QuickMarcEditorRows = ({
     >
       <FieldArray
         name="records"
-        isEqual={areRecordsEqual}
+        isEqual={isEqual}
       >
         {({ fields: records }) => (
           records.map((name, idx) => {

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -15,7 +15,7 @@ import * as utils from './utils';
 import { QUICK_MARC_ACTIONS } from '../constants';
 import { MARC_TYPES } from '../../common/constants';
 
-const values = [
+const initValues = [
   {
     id: '1',
     tag: '001',
@@ -57,10 +57,16 @@ const values = [
   },
 ];
 
-const addRecordMock = jest.fn();
+let values = [...initValues];
+const addRecordMock = jest.fn().mockImplementation(({ index }) => {
+  values.splice(index, 0, {
+    id: 'new-1',
+    content: '',
+  });
+});
 const deleteRecordMock = jest.fn();
 const moveRecordMock = jest.fn();
-const setDeletedRecordsMock = jest.fn();
+const markRecordDeletedMock = jest.fn();
 
 const renderQuickMarcEditorRows = (props = {}) => (render(
   <MemoryRouter>
@@ -68,7 +74,7 @@ const renderQuickMarcEditorRows = (props = {}) => (render(
       onSubmit={jest.fn()}
       mutators={arrayMutators}
       initialValues={{
-        records: values,
+        records: initValues,
       }}
       render={() => (
         <QuickMarcEditorRows
@@ -80,10 +86,10 @@ const renderQuickMarcEditorRows = (props = {}) => (render(
           mutators={{
             addRecord: addRecordMock,
             deleteRecord: deleteRecordMock,
+            markRecordDeleted: markRecordDeletedMock,
             moveRecord: moveRecordMock,
           }}
           subtype="test"
-          setDeletedRecords={setDeletedRecordsMock}
           {...props}
         />
       )}
@@ -92,6 +98,10 @@ const renderQuickMarcEditorRows = (props = {}) => (render(
 ));
 
 describe('Given QuickMarcEditorRows', () => {
+  beforeEach(() => {
+    values = [...initValues];
+  });
+
   afterEach(cleanup);
 
   it('should display row for each record value', () => {
@@ -143,7 +153,7 @@ describe('Given QuickMarcEditorRows', () => {
     });
 
     describe('and deleting a new row and saving', () => {
-      it('should mark the row as deleted', () => {
+      it('should not mark the row as deleted', () => {
         const {
           getAllByRole,
           getByTestId,
@@ -156,17 +166,18 @@ describe('Given QuickMarcEditorRows', () => {
 
         fireEvent.click(addButton);
         // delete button next to added row
-        const deleteButton = getAllByRole('button', { name: 'ui-quick-marc.record.addField' })[1];
+        const deleteButton = getAllByRole('button', { name: 'ui-quick-marc.record.deleteField' })[0];
 
         fireEvent.click(deleteButton);
 
-        expect(setDeletedRecordsMock).not.toHaveBeenCalled();
+        expect(markRecordDeletedMock).not.toHaveBeenCalled();
+        expect(deleteRecordMock).toHaveBeenCalled();
       });
     });
   });
 
   describe('when deleting rows', () => {
-    it('should call setDeletedRecords 2 times', () => {
+    it('should call markRecordDeleted 2 times', () => {
       const { getAllByTestId } = renderQuickMarcEditorRows();
 
       const testIdx1 = 1;
@@ -177,7 +188,7 @@ describe('Given QuickMarcEditorRows', () => {
       fireEvent.click(deleteIcon1[1]);
       fireEvent.click(deleteIcon2[1]);
 
-      expect(setDeletedRecordsMock).toHaveBeenCalledTimes(2);
+      expect(markRecordDeletedMock).toHaveBeenCalledTimes(2);
     });
 
     it('should handle deleteRecord', () => {

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -193,6 +193,16 @@ export const formatMarcRecordByQuickMarcAction = (marcRecord, action) => {
   return marcRecord;
 };
 
+export const addInternalFieldProperties = (marcRecord) => {
+  return {
+    ...marcRecord,
+    records: marcRecord.records.map(record => ({
+      ...record,
+      _isDeleted: false,
+    })),
+  };
+};
+
 export const hydrateMarcRecord = marcRecord => ({
   ...marcRecord,
   leader: marcRecord.records[0].content,
@@ -471,6 +481,17 @@ export const deleteRecordByIndex = (index, state) => {
   return records;
 };
 
+export const markDeletedRecordByIndex = (index, state) => {
+  const records = [...state.formState.values.records];
+
+  records[index] = {
+    ...records[index],
+    _isDeleted: true,
+  };
+
+  return records;
+};
+
 export const reorderRecords = (index, indexToSwitch, state) => {
   const records = [...state.formState.values.records];
 
@@ -479,12 +500,24 @@ export const reorderRecords = (index, indexToSwitch, state) => {
   return records;
 };
 
-export const restoreRecordAtIndex = (index, record, state) => {
+export const restoreRecordAtIndex = (index, state) => {
   const records = [...state.formState.values.records];
 
-  records.splice(index, 0, record);
+  records[index] = {
+    ...records[index],
+    _isDeleted: false,
+  };
 
   return records;
+};
+
+export const removeDeletedRecords = (formValues) => {
+  const { records } = formValues;
+
+  return {
+    ...formValues,
+    records: records.filter(record => !record._isDeleted),
+  };
 };
 
 export const removeFieldsForDuplicate = (formValues) => {

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -117,6 +117,7 @@ describe('QuickMarcEditor utils', () => {
               {
                 tag: '011',
                 content: '$a fss $b asd',
+                _isDeleted: true,
               },
               {
                 tag: '012',
@@ -128,13 +129,9 @@ describe('QuickMarcEditor utils', () => {
       };
 
       const insertIndex = 1;
-      const insertedRecord = {
-        tag: '013',
-        content: '$a fss $b asd',
-      };
-      const newRecords = utils.restoreRecordAtIndex(insertIndex, insertedRecord, state);
+      const newRecords = utils.restoreRecordAtIndex(insertIndex, state);
 
-      expect(newRecords[1]).toBe(insertedRecord);
+      expect(newRecords[1]._isDeleted).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Description
Restore deleted fields in the same position as it was.
Instead of removing deleted field from form state - it's now marked as `_isDeleted`, which allows to keep it's original index in fields array.

## Screenshots

https://user-images.githubusercontent.com/19309423/184117990-c5cbe7d8-ef0c-43cb-99de-12ad8a3b4c14.mp4



## Issues
[UIQM-266](https://issues.folio.org/browse/UIQM-266)