### PR TITLE
UIQM-256: Change field level actions display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [UIQM-267](https://issues.folio.org/browse/UIQM-267) MARC Holdings - Leader position 18 accept a space and \ as a valid value
 * [UIQM-262](https://issues.folio.org/browse/UIQM-262) FE: Derive/Edit MARC bibliographic record: Improve Leader position 08 error message
 * [UIQM-265](https://issues.folio.org/browse/UIQM-265) Add/Edit MARC Holdings - Adding a new field above MARC 852 results in 852$b value populating the newly added field
+* [UIQM-256](https://issues.folio.org/browse/UIQM-256) Change field level actions display
 
 ## [5.1.0](https://github.com/folio-org/ui-quick-marc/tree/v5.1.0) (2022-07-08)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.css
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.css
@@ -11,7 +11,7 @@
 
 .quickMarcEditorRowInfoPopover {
   width: 23px;
-  margin-right: 15px;
+  margin-inline: 10px;
 }
 
 .quickMarcEditorRowTag {
@@ -29,8 +29,8 @@
 }
 
 .quickMarcEditorActions {
-  width: 76px;
-  margin-left: 10px;
+  width: 50px;
+  margin-right: 10px;
 }
 
 .quickMarcEditorMovingRow {

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.css
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.css
@@ -29,7 +29,6 @@
 }
 
 .quickMarcEditorActions {
-  width: 76px;
   margin-left: 10px;
 }
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.css
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.css
@@ -29,6 +29,7 @@
 }
 
 .quickMarcEditorActions {
+  width: 76px;
   margin-left: 10px;
 }
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -87,8 +87,8 @@ const QuickMarcEditorRows = ({
     const prevElementRow = currElementRow.previousElementSibling;
     const nextElementRow = currElementRow.nextElementSibling;
 
-    const prevDeleteIcon = prevElementRow.querySelector('[name="icon-delete"]');
-    const nextDeleteIcon = nextElementRow.querySelector('[name="icon-delete"]');
+    const prevDeleteIcon = prevElementRow?.querySelector('[name="icon-delete"]');
+    const nextDeleteIcon = nextElementRow?.querySelector('[name="icon-delete"]');
 
     if (isNewRow(fields[index])) {
       deleteRecord({ index });

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -81,9 +81,7 @@ const QuickMarcEditorRows = ({
 
   const deleteRow = useCallback(({ target }) => {
     const index = parseInt(target.dataset.index, 10);
-    const recordsLength = parseInt(target.dataset.recordsLength, 10);
-    const isLastRowDeleted = index === recordsLength - 1;
-    const indexOfFocusableField = isLastRowDeleted ? index - 1 : index;
+    const nextRowIndex = index + 1;
 
     if (isNewRow(fields[index])) {
       deleteRecord({ index });
@@ -92,7 +90,7 @@ const QuickMarcEditorRows = ({
     }
 
     defer(() => {
-      containerRef.current.querySelector(`[name="records[${indexOfFocusableField}].tag"]`).focus();
+      containerRef.current.querySelector(`[name="${nextRowIndex}.delete"]`)?.focus();
     });
   }, [fields, deleteRecord, markRecordDeleted, isNewRow]);
 
@@ -203,6 +201,7 @@ const QuickMarcEditorRows = ({
                       <IconButton
                         title={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
                         ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
+                        name={`${idx}.delete`}
                         data-testid={`data-test-remove-row-${idx}`}
                         data-index={idx}
                         data-records-length={records.length}

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -18,6 +18,7 @@ import defer from 'lodash/defer';
 import { Pluggable } from '@folio/stripes/core';
 import {
   TextField,
+  Tooltip,
   IconButton,
   InfoPopover,
 } from '@folio/stripes/components';
@@ -156,28 +157,42 @@ const QuickMarcEditorRows = ({
                 <div className={styles.quickMarcEditorMovingRow}>
                   {
                     !withMoveUpRowAction && (
-                      <IconButton
-                        title={intl.formatMessage({ id: 'ui-quick-marc.record.moveUpRow' })}
-                        ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.moveUpRow' })}
-                        data-test-move-up-row
-                        data-index={idx}
-                        data-index-to-switch={idx - 1}
-                        icon="arrow-up"
-                        onClick={moveRow}
-                      />
+                      <Tooltip
+                        id="moving-row-move-up"
+                        text={intl.formatMessage({ id: 'ui-quick-marc.record.moveUpRow' })}
+                      >
+                        {({ ref, ariaIds }) => (
+                          <IconButton
+                            ref={ref}
+                            aria-labelledby={ariaIds.text}
+                            data-test-move-up-row
+                            data-index={idx}
+                            data-index-to-switch={idx - 1}
+                            icon="arrow-up"
+                            onClick={moveRow}
+                          />
+                        )}
+                      </Tooltip>
                     )
                   }
                   {
                     !withMoveDownRowAction && (
-                      <IconButton
-                        title={intl.formatMessage({ id: 'ui-quick-marc.record.moveDownRow' })}
-                        ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.moveDownRow' })}
-                        data-test-move-down-row
-                        data-index={idx}
-                        data-index-to-switch={idx + 1}
-                        icon="arrow-down"
-                        onClick={moveRow}
-                      />
+                      <Tooltip
+                        id="moving-row-move-down"
+                        text={intl.formatMessage({ id: 'ui-quick-marc.record.moveDownRow' })}
+                      >
+                        {({ ref, ariaIds }) => (
+                          <IconButton
+                            ref={ref}
+                            aria-labelledby={ariaIds.text}
+                            data-test-move-down-row
+                            data-index={idx}
+                            data-index-to-switch={idx + 1}
+                            icon="arrow-down"
+                            onClick={moveRow}
+                          />
+                        )}
+                      </Tooltip>
                     )
                   }
                 </div>
@@ -185,29 +200,43 @@ const QuickMarcEditorRows = ({
                 <div className={styles.quickMarcEditorActions}>
                   {
                     !withAddRowAction && (
-                      <IconButton
-                        className="quickMarcEditorAddField"
-                        title={intl.formatMessage({ id: 'ui-quick-marc.record.addField' })}
-                        ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.addField' })}
-                        data-test-add-row
-                        data-index={idx}
-                        icon="plus-sign"
-                        onClick={addNewRow}
-                      />
+                      <Tooltip
+                        id="actions-add-field"
+                        text={intl.formatMessage({ id: 'ui-quick-marc.record.addField' })}
+                      >
+                        {({ ref, ariaIds }) => (
+                          <IconButton
+                            ref={ref}
+                            aria-labelledby={ariaIds.text}
+                            className="quickMarcEditorAddField"
+                            data-test-add-row
+                            data-index={idx}
+                            icon="plus-sign"
+                            onClick={addNewRow}
+                          />
+                        )}
+                      </Tooltip>
                     )
                   }
                   {
                     !withDeleteRowAction && (
-                      <IconButton
-                        title={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
-                        ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
-                        name={`${idx}.delete`}
-                        data-testid={`data-test-remove-row-${idx}`}
-                        data-index={idx}
-                        data-records-length={records.length}
-                        icon="trash"
-                        onClick={deleteRow}
-                      />
+                      <Tooltip
+                        id="actions-delete-field"
+                        text={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
+                      >
+                        {({ ref, ariaIds }) => (
+                          <IconButton
+                            ref={ref}
+                            aria-labelledby={ariaIds.text}
+                            name={`${idx}.delete`}
+                            data-testid={`data-test-remove-row-${idx}`}
+                            data-index={idx}
+                            data-records-length={records.length}
+                            icon="trash"
+                            onClick={deleteRow}
+                          />
+                        )}
+                      </Tooltip>
                     )
                   }
                 </div>

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -212,23 +212,6 @@ const QuickMarcEditorRows = ({
                   }
                 </div>
 
-                {
-                  isMARCFieldProtections && (
-                    <div className={styles.quickMarcEditorRowInfoPopover}>
-                      {
-                        isProtectedField && (
-                          <div data-testid="quick-marc-protected-field-popover">
-                            <InfoPopover
-                              iconSize="medium"
-                              content={intl.formatMessage({ id: 'ui-quick-marc.record.protectedField' })}
-                            />
-                          </div>
-                        )
-                      }
-                    </div>
-                  )
-                }
-
                 <div className={styles.quickMarcEditorRowTag}>
                   <Field
                     inputRef={processTagRef}
@@ -327,6 +310,23 @@ const QuickMarcEditorRows = ({
                     )
                   }
                 </div>
+
+                {
+                  isMARCFieldProtections && (
+                    <div className={styles.quickMarcEditorRowInfoPopover}>
+                      {
+                        isProtectedField && (
+                          <div data-testid="quick-marc-protected-field-popover">
+                            <InfoPopover
+                              iconSize="medium"
+                              content={intl.formatMessage({ id: 'ui-quick-marc.record.protectedField' })}
+                            />
+                          </div>
+                        )
+                      }
+                    </div>
+                  )
+                }
 
                 <div className={styles.quickMarcEditorActions}>
                   <Pluggable

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -357,13 +357,11 @@ const QuickMarcEditorRows = ({
                   )
                 }
 
-                <div className={styles.quickMarcEditorActions}>
-                  <Pluggable
-                    type="find-authority"
-                  >
-                    <FormattedMessage id="ui-quick-marc.noPlugin" />
-                  </Pluggable>
-                </div>
+                <Pluggable
+                  type="find-authority"
+                >
+                  <FormattedMessage id="ui-quick-marc.noPlugin" />
+                </Pluggable>
               </div>
             );
           })

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -211,11 +211,6 @@ const QuickMarcEditorRows = ({
                       />
                     )
                   }
-                  <Pluggable
-                    type="find-authority"
-                  >
-                    <FormattedMessage id="ui-quick-marc.noPlugin" />
-                  </Pluggable>
                 </div>
 
                 {
@@ -332,6 +327,14 @@ const QuickMarcEditorRows = ({
                       />
                     )
                   }
+                </div>
+
+                <div className={styles.quickMarcEditorActions}>
+                  <Pluggable
+                    type="find-authority"
+                  >
+                    <FormattedMessage id="ui-quick-marc.noPlugin" />
+                  </Pluggable>
                 </div>
               </div>
             );

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -184,6 +184,40 @@ const QuickMarcEditorRows = ({
                   }
                 </div>
 
+                <div className={styles.quickMarcEditorActions}>
+                  {
+                    !withAddRowAction && (
+                      <IconButton
+                        className="quickMarcEditorAddField"
+                        title={intl.formatMessage({ id: 'ui-quick-marc.record.addField' })}
+                        ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.addField' })}
+                        data-test-add-row
+                        data-index={idx}
+                        icon="plus-sign"
+                        onClick={addNewRow}
+                      />
+                    )
+                  }
+                  {
+                    !withDeleteRowAction && (
+                      <IconButton
+                        title={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
+                        ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
+                        data-testid={`data-test-remove-row-${idx}`}
+                        data-index={idx}
+                        data-records-length={records.length}
+                        icon="trash"
+                        onClick={deleteRow}
+                      />
+                    )
+                  }
+                  <Pluggable
+                    type="find-authority"
+                  >
+                    <FormattedMessage id="ui-quick-marc.noPlugin" />
+                  </Pluggable>
+                </div>
+
                 {
                   isMARCFieldProtections && (
                     <div className={styles.quickMarcEditorRowInfoPopover}>
@@ -298,40 +332,6 @@ const QuickMarcEditorRows = ({
                       />
                     )
                   }
-                </div>
-
-                <div className={styles.quickMarcEditorActions}>
-                  {
-                    !withAddRowAction && (
-                      <IconButton
-                        className="quickMarcEditorAddField"
-                        title={intl.formatMessage({ id: 'ui-quick-marc.record.addField' })}
-                        ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.addField' })}
-                        data-test-add-row
-                        data-index={idx}
-                        icon="plus-sign"
-                        onClick={addNewRow}
-                      />
-                    )
-                  }
-                  {
-                    !withDeleteRowAction && (
-                      <IconButton
-                        title={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
-                        ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.deleteField' })}
-                        data-testid={`data-test-remove-row-${idx}`}
-                        data-index={idx}
-                        data-records-length={records.length}
-                        icon="trash"
-                        onClick={deleteRow}
-                      />
-                    )
-                  }
-                  <Pluggable
-                    type="find-authority"
-                  >
-                    <FormattedMessage id="ui-quick-marc.noPlugin" />
-                  </Pluggable>
                 </div>
               </div>
             );

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -82,7 +82,13 @@ const QuickMarcEditorRows = ({
 
   const deleteRow = useCallback(({ target }) => {
     const index = parseInt(target.dataset.index, 10);
-    const nextRowIndex = index + 1;
+
+    const currElementRow = containerRef.current.querySelector(`[name="record-row[${index}]"]`);
+    const prevElementRow = currElementRow.previousElementSibling;
+    const nextElementRow = currElementRow.nextElementSibling;
+
+    const prevDeleteIcon = prevElementRow.querySelector('[name="icon-delete"]');
+    const nextDeleteIcon = nextElementRow.querySelector('[name="icon-delete"]');
 
     if (isNewRow(fields[index])) {
       deleteRecord({ index });
@@ -91,7 +97,13 @@ const QuickMarcEditorRows = ({
     }
 
     defer(() => {
-      containerRef.current.querySelector(`[name="${nextRowIndex}.delete"]`)?.focus();
+      if (nextDeleteIcon) {
+        nextDeleteIcon.focus();
+
+        return;
+      }
+
+      prevDeleteIcon?.focus();
     });
   }, [fields, deleteRecord, markRecordDeleted, isNewRow]);
 
@@ -153,6 +165,7 @@ const QuickMarcEditorRows = ({
                 key={recordRow.id}
                 className={styles.quickMarcEditorRow}
                 data-testid="quick-marc-editorid"
+                name={`record-row[${idx}]`}
               >
                 <div className={styles.quickMarcEditorMovingRow}>
                   {
@@ -228,7 +241,7 @@ const QuickMarcEditorRows = ({
                           <IconButton
                             ref={ref}
                             aria-labelledby={ariaIds.text}
-                            name={`${idx}.delete`}
+                            name="icon-delete"
                             data-testid={`data-test-remove-row-${idx}`}
                             data-index={idx}
                             data-records-length={records.length}


### PR DESCRIPTION
## Purpose
Change field level actions display

## Approach
Changed items order of `QuickMarcEditorRows`. Removed a fixed width from `quickMarcEditorActions` styles which was causing an extra space between `quickMarcEditorActions` items and `quickMarcEditorRowContent` item.

## Screenshots
![actions-display](https://user-images.githubusercontent.com/111242500/185919005-aafd93d2-efbf-4e7e-9662-c73b078d349e.jpg)

## Issues
[UIQM-256](https://issues.folio.org/browse/UIQM-256)
