### PR TITLE
UIQM-273: Add a new field : Default focus/cursor to after $a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UIQM-259](https://issues.folio.org/browse/UIQM-259) Edit MARC authority: User does not get a notification that the record is edited has been deleted by another user.
 * [UIQM-258](https://issues.folio.org/browse/UIQM-258) Add fake link Authority button next to MARC fields.
 * [UIQM-261](https://issues.folio.org/browse/UIQM-261) Shift focus to MARC tag box once you click Add or Delete field.
+* [UIQM-273](https://issues.folio.org/browse/UIQM-273) Add a new field : Default focus/cursor to after $a.
 
 ## [5.1.2](https://github.com/folio-org/ui-quick-marc/tree/v5.1.2) (2022-08-23)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/ContentField/ContentField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/ContentField/ContentField.js
@@ -1,6 +1,7 @@
 import React, {
   useRef,
   useLayoutEffect,
+  useEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 
@@ -13,6 +14,7 @@ import { getResizeStyles } from './utils';
 export const ContentField = ({
   input,
   id,
+  onProcessSubfieldRef,
   ...props
 }) => {
   const ref = useRef();
@@ -29,6 +31,12 @@ export const ContentField = ({
     }
   }, [ref, input.value]);
 
+  useEffect(() => {
+    if (ref.current && onProcessSubfieldRef) {
+      onProcessSubfieldRef(ref.current);
+    }
+  }, [ref]);
+
   return (
     <TextArea
       {...props}
@@ -44,4 +52,5 @@ ContentField.propTypes = {
   input: PropTypes.shape({
     value: PropTypes.string,
   }),
+  onProcessSubfieldRef: PropTypes.func,
 };

--- a/src/QuickMarcEditor/QuickMarcEditorRows/ContentField/ContentField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/ContentField/ContentField.js
@@ -2,6 +2,7 @@ import React, {
   useRef,
   useLayoutEffect,
   useEffect,
+  useCallback,
 } from 'react';
 import PropTypes from 'prop-types';
 
@@ -18,6 +19,12 @@ export const ContentField = ({
   ...props
 }) => {
   const ref = useRef();
+
+  const processSubfieldFocus = useCallback(({ target }) => {
+    const end = target.value.length;
+
+    target.setSelectionRange(end, end);
+  }, []);
 
   useLayoutEffect(() => {
     if (ref.current) {
@@ -43,6 +50,7 @@ export const ContentField = ({
       input={input}
       inputRef={ref}
       data-testid={id}
+      onFocus={processSubfieldFocus}
     />
   );
 };

--- a/src/QuickMarcEditor/QuickMarcEditorRows/ContentField/ContentField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/ContentField/ContentField.js
@@ -35,7 +35,7 @@ export const ContentField = ({
     if (ref.current && onProcessSubfieldRef) {
       onProcessSubfieldRef(ref.current);
     }
-  }, [ref]);
+  }, [ref, onProcessSubfieldRef]);
 
   return (
     <TextArea

--- a/src/QuickMarcEditor/QuickMarcEditorRows/ContentField/ContentField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/ContentField/ContentField.js
@@ -1,7 +1,6 @@
 import React, {
   useRef,
   useLayoutEffect,
-  useEffect,
   useCallback,
 } from 'react';
 import PropTypes from 'prop-types';
@@ -15,7 +14,6 @@ import { getResizeStyles } from './utils';
 export const ContentField = ({
   input,
   id,
-  onProcessSubfieldRef,
   ...props
 }) => {
   const ref = useRef();
@@ -38,12 +36,6 @@ export const ContentField = ({
     }
   }, [ref, input.value]);
 
-  useEffect(() => {
-    if (ref.current && onProcessSubfieldRef) {
-      onProcessSubfieldRef(ref.current);
-    }
-  }, [ref, onProcessSubfieldRef]);
-
   return (
     <TextArea
       {...props}
@@ -60,5 +52,4 @@ ContentField.propTypes = {
   input: PropTypes.shape({
     value: PropTypes.string,
   }),
-  onProcessSubfieldRef: PropTypes.func,
 };

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -103,7 +103,7 @@ const QuickMarcEditorRows = ({
     });
   }, [moveRecord]);
 
-  const processSubfieldRef = useCallback(ref => {
+  const processTagRef = useCallback(ref => {
     if (!ref) return;
     const index = parseInt(ref.dataset.index, 10);
 
@@ -203,6 +203,8 @@ const QuickMarcEditorRows = ({
 
                 <div className={styles.quickMarcEditorRowTag}>
                   <Field
+                    inputRef={processTagRef}
+                    data-index={idx}
                     dirty={false}
                     ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.field' })}
                     name={`${name}.tag`}
@@ -292,8 +294,6 @@ const QuickMarcEditorRows = ({
                         marginBottom0
                         disabled={isDisabled}
                         id={`content-field-${idx}`}
-                        data-index={idx}
-                        onProcessSubfieldRef={processSubfieldRef}
                         component={ContentField}
                       />
                     )

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -112,12 +112,6 @@ const QuickMarcEditorRows = ({
     }
   }, [indexOfNewRow, newRowRef]);
 
-  const processSubfieldFocus = useCallback(({ target }) => {
-    const end = target.value.length;
-
-    target.setSelectionRange(end, end);
-  }, []);
-
   return (
     <div
       id="quick-marc-editor-rows"
@@ -300,7 +294,6 @@ const QuickMarcEditorRows = ({
                         id={`content-field-${idx}`}
                         data-index={idx}
                         onProcessSubfieldRef={processSubfieldRef}
-                        onFocus={processSubfieldFocus}
                         component={ContentField}
                       />
                     )

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -114,6 +114,7 @@ const QuickMarcEditorRows = ({
 
   const processSubfieldFocus = useCallback(({ target }) => {
     const end = target.value.length;
+
     target.setSelectionRange(end, end);
   }, []);
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -103,7 +103,7 @@ const QuickMarcEditorRows = ({
     });
   }, [moveRecord]);
 
-  const processTagRef = useCallback(ref => {
+  const processSubfieldRef = useCallback(ref => {
     if (!ref) return;
     const index = parseInt(ref.dataset.index, 10);
 
@@ -111,6 +111,11 @@ const QuickMarcEditorRows = ({
       newRowRef.current = ref;
     }
   }, [indexOfNewRow, newRowRef]);
+
+  const processSubfieldFocus = useCallback(({ target }) => {
+    const end = target.value.length;
+    target.setSelectionRange(end, end);
+  }, []);
 
   return (
     <div
@@ -203,8 +208,6 @@ const QuickMarcEditorRows = ({
 
                 <div className={styles.quickMarcEditorRowTag}>
                   <Field
-                    inputRef={processTagRef}
-                    data-index={idx}
                     dirty={false}
                     ariaLabel={intl.formatMessage({ id: 'ui-quick-marc.record.field' })}
                     name={`${name}.tag`}
@@ -294,6 +297,9 @@ const QuickMarcEditorRows = ({
                         marginBottom0
                         disabled={isDisabled}
                         id={`content-field-${idx}`}
+                        data-index={idx}
+                        onProcessSubfieldRef={processSubfieldRef}
+                        onFocus={processSubfieldFocus}
                         component={ContentField}
                       />
                     )

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -173,8 +173,8 @@ describe('Given QuickMarcEditorRows', () => {
 
         fireEvent.focus(subfield);
         expect(spySetSelectionRange).toHaveBeenCalledWith(valueLength, valueLength);
-      })
-    })
+      });
+    });
 
     describe('and deleting a new row and saving', () => {
       it('should not mark the row as deleted', () => {

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -164,6 +164,18 @@ describe('Given QuickMarcEditorRows', () => {
       expect(defer).toHaveBeenCalled();
     });
 
+    describe('when the subfield is focused', () => {
+      it('should have a cursor at the end of the field value', () => {
+        const { getByTestId } = renderQuickMarcEditorRows();
+        const subfield = getByTestId('content-field-0');
+        const valueLength = subfield.value.length;
+        const spySetSelectionRange = jest.spyOn(subfield, 'setSelectionRange');
+
+        fireEvent.focus(subfield);
+        expect(spySetSelectionRange).toHaveBeenCalledWith(valueLength, valueLength);
+      })
+    })
+
     describe('and deleting a new row and saving', () => {
       it('should not mark the row as deleted', () => {
         const {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
After adding a new row, the subfield should be focused and the cursor needs to be at the end of the field value.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-273](https://issues.folio.org/browse/UIQM-273)

## Screencast







https://user-images.githubusercontent.com/77053927/186637265-9a418201-815c-42ed-b054-b78c523ab08e.mp4




## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
