### PR TITLE
UIQM-292: Change field level actions for Move field a row buttons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [UIQM-274](https://issues.folio.org/browse/UIQM-274) Derive/Edit a bib record | Display link icon for eligible name bib fields to link to authority records and show Select a MARC authority plug-in
 * [UIQM-276](https://issues.folio.org/browse/UIQM-276) Derive/Edit MARC bib | Link bib field to authority record | Validate and Generate $0 value
 * [UIQM-293](https://issues.folio.org/browse/UIQM-293) Edit/Derive - MARC bib - Remove 008 Desc box
+* [UIQM-292](https://issues.folio.org/browse/UIQM-292) Change field level actions for "Move field a row" buttons.
 
 ## [5.1.2](https://github.com/folio-org/ui-quick-marc/tree/v5.1.2) (2022-08-23)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -125,23 +125,17 @@ const QuickMarcEditorRows = ({
 
     const row = containerRef.current.querySelector(`[data-row="record-row[${index}]"]`);
 
-    let nextFocusableElement;
-
     if (index > indexToSwitch && !row.previousElementSibling.querySelector('[data-icon="move-up"]')) {
-      nextFocusableElement = row.querySelector('[data-icon="move-down"]');
+      row.querySelector('[data-icon="move-down"]')?.focus();
     }
 
     if (index < indexToSwitch && !row.nextElementSibling.querySelector('[data-icon="move-down"]')) {
-      nextFocusableElement = row.querySelector('[data-icon="move-up"]');
+      row.querySelector('[data-icon="move-up"]')?.focus();
     }
 
     moveRecord({
       index,
       indexToSwitch,
-    });
-
-    defer(() => {
-      nextFocusableElement?.focus();
     });
   }, [moveRecord]);
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -120,9 +120,28 @@ const QuickMarcEditorRows = ({
   }, [fields, deleteRecord, markRecordDeleted, isNewRow, containerRef]);
 
   const moveRow = useCallback(({ target }) => {
+    const index = parseInt(target.dataset.index, 10);
+    const indexToSwitch = parseInt(target.dataset.indexToSwitch, 10);
+
+    const row = containerRef.current.querySelector(`[data-row="record-row[${index}]"]`);
+
+    let nextFocusableElement;
+
+    if (index > indexToSwitch && !row.previousElementSibling.querySelector('[data-icon="move-up"]')) {
+      nextFocusableElement = row.querySelector('[data-icon="move-down"]');
+    }
+
+    if (index < indexToSwitch && !row.nextElementSibling.querySelector('[data-icon="move-down"]')) {
+      nextFocusableElement = row.querySelector('[data-icon="move-up"]');
+    }
+
     moveRecord({
-      index: +target.dataset.index,
-      indexToSwitch: parseInt(target.dataset.indexToSwitch, 10),
+      index,
+      indexToSwitch,
+    });
+
+    defer(() => {
+      nextFocusableElement?.focus();
     });
   }, [moveRecord]);
 
@@ -234,6 +253,7 @@ const QuickMarcEditorRows = ({
                           <IconButton
                             ref={ref}
                             name="icon-arrow-down"
+                            data-icon="move-down"
                             aria-labelledby={ariaIds.text}
                             data-test-move-down-row
                             data-index={idx}


### PR DESCRIPTION
## Purpose
In the scenario that you cannot move up any further: If you hit the Enter key on the last up arrow then shift to that row's down arrow.

In the scenario that you cannot move down any further: If you hit the Enter key on the last down arrow then shift to that row's up arrow.

## Issues
[UIQM-292](https://issues.folio.org/browse/UIQM-292)