### PR TITLE
UIQM-275: Handle repeated subfields

### DIFF
--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -11,7 +11,13 @@ import { LINKED_BIB_TO_AUTHORITY_FIELDS } from '../../common/constants';
 const useAuthorityLinking = () => {
   const { sourceFiles } = useAuthoritySourceFiles();
 
-  const joinSubfields = (subfields) => Object.keys(subfields).reduce((content, key) => [content, `${key} ${subfields[key]}`].join(' '), '').trim();
+  const joinSubfields = (subfields) => Object.keys(subfields).reduce((content, key) => {
+    const subfield = Array.isArray(subfields[key])
+      ? subfields[key].join(` ${key} `) // if the subfield is repeatable - join the items with subfield key
+      : subfields[key];
+
+    return [content, `${key} ${subfield}`].join(' ');
+  }, '').trim();
 
   const copySubfieldsFromAuthority = (bibSubfields, authField) => {
     const authSubfields = getContentSubfieldValue(authField.content);

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -89,4 +89,42 @@ describe('Given useAuthorityLinking', () => {
       });
     });
   });
+
+  describe('when calling linkAuthority with repeated subfields', () => {
+    it('should return field with correctly formatted subfields', () => {
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const authority = {
+        id: 'authority-id',
+        sourceFileId: '1',
+        naturalId: 'n0001',
+      };
+      const field = {
+        tag: '100',
+        content: '$a some value $b some other value $e author $e illustrator',
+      };
+
+      expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
+        content: '$a authority value $b some other value $e author $e illustrator $0 http://some.url/n0001 $9 authority-id',
+      });
+    });
+  });
+
+  describe('when calling unlinkAuthority', () => {
+    it('should return field with correct data', () => {
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const field = {
+        tag: '100',
+        content: '$a authority value $b some other value $e author $e illustrator $0 http://some.url/n0001 $9 authority-id',
+        authorityNaturalId: 'n0001',
+        authorityId: 'authority-id',
+      };
+
+      expect(result.current.unlinkAuthority(field)).toMatchObject({
+        tag: '100',
+        content: '$a authority value $b some other value $e author $e illustrator $0 http://some.url/n0001',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description
Fix issue with repeated subfields being joined with `,`

## Screenshots

https://user-images.githubusercontent.com/19309423/195117625-753d3fdc-26ce-4adf-b7cd-a5a0503ea4c0.mp4

## Issues
[UIQM-275](https://issues.folio.org/browse/UIQM-275)