### PR TITLE
UIQM-288 Hide link authority permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       {
         "permissionName": "ui-quick-marc.quick-marc-authority-records.linkUnlink",
         "displayName": "quickMARC: Can Link/unlink authority records to bib records",
-        "visible": true
+        "visible": false
       }
     ]
   },


### PR DESCRIPTION
## Description
Hide "Can Link/unlink authority records to bib records" permission

## Issues
[UIQM-288](https://issues.folio.org/browse/UIQM-288)