### PR TITLE
UIQM-317: Linking of empty field with "MARC Authority" record doesn't happen 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [UIQM-307](https://issues.folio.org/browse/UIQM-307) Link then Unlink bib field before saving record behavior
 * [UIQM-312](https://issues.folio.org/browse/UIQM-312) Create a test Harness for quick marc tests
 * [UIQM-314](https://issues.folio.org/browse/UIQM-314) Enable authority linking for the following MARC bib fields
+* [UIQM-317](https://issues.folio.org/browse/UIQM-317) Linking of empty field with "MARC Authority" record doesn't happen
 
 ## [5.1.2](https://github.com/folio-org/ui-quick-marc/tree/v5.1.2) (2022-08-23)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/BytesField/BytesField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/BytesField/BytesField.js
@@ -77,7 +77,7 @@ const renderSubField = (name, config) => {
           {([ariaLabel]) => (
             <Field
               dirty={false}
-              ariaLabel={ariaLabel}
+              aria-label={ariaLabel}
               name={fieldName}
               label={label}
               component={Select}

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -405,6 +405,7 @@ const QuickMarcEditorRows = ({
                             dirty={false}
                             aria-label={intl.formatMessage({ id: 'ui-quick-marc.record.subfield' })}
                             name={`${name}.content`}
+                            parse={v => v}
                             marginBottom0
                             disabled={isDisabled}
                             id={`content-field-${idx}`}

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -125,6 +125,7 @@ const getComponent = (props) => (
             moveRecord: moveRecordMock,
             markRecordLinked: jest.fn(),
             markRecordUnlinked: jest.fn(),
+            restoreRecord: jest.fn(),
           }}
           subtype="test"
           {...props}

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -76,7 +76,7 @@ const useAuthorityLinking = () => {
     delete field.authorityNaturalId;
     delete field.authorityId;
 
-    field.content = field.prevContent || joinSubfields(bibSubfields);
+    field.content = field.prevContent ?? joinSubfields(bibSubfields);
     delete field.prevContent;
 
     return {

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -111,14 +111,14 @@ describe('Given useAuthorityLinking', () => {
   });
 
   describe('when calling linkAuthority without saving changes, and then unlinkAuthority', () => {
+    const authority = {
+      id: 'authority-id',
+      sourceFileId: '1',
+      naturalId: 'n0001',
+    };
+
     it('should return previous field content', () => {
       const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const authority = {
-        id: 'authority-id',
-        sourceFileId: '1',
-        naturalId: 'n0001',
-      };
       const field = {
         tag: '100',
         content: '$a Crumb, George. test',
@@ -128,6 +128,19 @@ describe('Given useAuthorityLinking', () => {
       const unlinkedField = result.current.unlinkAuthority(linkedField);
 
       expect(unlinkedField.content).toBe('$a Crumb, George. test');
+    });
+
+    it('should return previous field content even if it is empty', () => {
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+      const field = {
+        tag: '100',
+        content: '',
+      };
+
+      const linkedField = result.current.linkAuthority(authority, authoritySource, field);
+      const unlinkedField = result.current.unlinkAuthority(linkedField);
+
+      expect(unlinkedField.content).toBe('');
     });
   });
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Be able to link the bib field when the content of the field is empty.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-317](https://issues.folio.org/browse/UIQM-317)

## Screencast








https://user-images.githubusercontent.com/77053927/199765027-408dced4-ae35-4580-8bc2-968846835728.mp4






## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
