### PR TITLE
UIQM-315: Rename derive bib record permission back to duplicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "visible": true
       },
       {
-        "permissionName": "ui-quick-marc.quick-marc-editor.derive",
+        "permissionName": "ui-quick-marc.quick-marc-editor.duplicate",
         "displayName": "quickMARC: Derive new MARC bibliographic record",
         "subPermissions": [
           "ui-quick-marc.quick-marc-editor.view",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "visible": true
       },
       {
-        "permissionName": "ui-quick-marc.quick-marc-editor.duplicate",
+        "permissionName": "ui-quick-marc.quick-marc-editor.derive",
         "displayName": "quickMARC: Derive new MARC bibliographic record",
         "subPermissions": [
           "ui-quick-marc.quick-marc-editor.view",
@@ -80,6 +80,7 @@
           "records-editor.records.item.post",
           "instance-authority-links.instances.collection.put"
         ],
+        "replaces": ["ui-quick-marc.quick-marc-editor.duplicate"],
         "visible": true
       },
       {


### PR DESCRIPTION
## Description
This permission is referenced in at least two other modules (ui-inventory and stripes-testing) so the permission name should be changed back

## Issues
[UIQM-315](https://issues.folio.org/browse/UIQM-315)