### PR TITLE
UIQM-321: Deleted fields not processing when deriving a new MARC bibliographic record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-quick-marc
 
+## [5.1.3](IN PROGRESS)
+
+* [UIQM-321](https://issues.folio.org/browse/UIQM-321) Deleted fields not processing when deriving a new MARC bibliographic record
+
 ## [5.1.2](https://github.com/folio-org/ui-quick-marc/tree/v5.1.2) (2022-08-23)
 
 * [UIQM-266](https://issues.folio.org/browse/UIQM-266) Edit quickMARC: Undoing a delete field is not restored in the same position.

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.js
@@ -21,6 +21,7 @@ import {
   checkControlFieldLength,
   cleanBytesFields,
   parseHttpError,
+  removeDeletedRecords,
 } from './utils';
 
 const propTypes = {
@@ -50,7 +51,8 @@ const QuickMarcCreateWrapper = ({
   const [httpError, setHttpError] = useState(null);
 
   const onSubmit = useCallback(async (formValues) => {
-    const controlFieldErrorMessage = checkControlFieldLength(formValues);
+    const formValuesToSave = removeDeletedRecords(formValues);
+    const controlFieldErrorMessage = checkControlFieldLength(formValuesToSave);
 
     if (controlFieldErrorMessage) {
       showCallout({ message: controlFieldErrorMessage, type: 'error' });
@@ -59,7 +61,7 @@ const QuickMarcCreateWrapper = ({
     }
 
     const autopopulatedFormValues = autopopulateSubfieldSection(
-      removeFieldsForDuplicate(formValues),
+      removeFieldsForDuplicate(formValuesToSave),
       initialValues,
       marcType,
     );
@@ -74,7 +76,7 @@ const QuickMarcCreateWrapper = ({
 
     return mutator.quickMarcEditMarcRecord.POST(hydrateMarcRecord(formValuesForCreate))
       .then(({ qmRecordId }) => {
-        const instanceId = formValues.externalId;
+        const instanceId = formValuesToSave.externalId;
 
         getQuickMarcRecordStatus({
           quickMarcRecordStatusGETRequest: mutator.quickMarcRecordStatus.GET,

--- a/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDuplicateWrapper.js
@@ -24,6 +24,7 @@ import {
   checkControlFieldLength,
   cleanBytesFields,
   parseHttpError,
+  removeDeletedRecords,
 } from './utils';
 
 const propTypes = {
@@ -51,7 +52,8 @@ const QuickMarcDuplicateWrapper = ({
   const [httpError, setHttpError] = useState(null);
 
   const onSubmit = useCallback(async (formValues) => {
-    const controlFieldErrorMessage = checkControlFieldLength(formValues);
+    const formValuesToSave = removeDeletedRecords(formValues);
+    const controlFieldErrorMessage = checkControlFieldLength(formValuesToSave);
 
     if (controlFieldErrorMessage) {
       showCallout({ message: controlFieldErrorMessage, type: 'error' });
@@ -59,7 +61,7 @@ const QuickMarcDuplicateWrapper = ({
       return null;
     }
 
-    const clearFormValues = removeFieldsForDuplicate(formValues);
+    const clearFormValues = removeFieldsForDuplicate(formValuesToSave);
     const autopopulatedFormWithIndicators = autopopulateIndicators(clearFormValues);
     const autopopulatedFormWithSubfields = autopopulateSubfieldSection(
       autopopulatedFormWithIndicators,


### PR DESCRIPTION
## Description
Instead of deleting fields we mark them as `_isDeleted` to be able to restore them in correct position

## Approach
Remove fields marked as deleted from form values before saving

## Screenshots

https://user-images.githubusercontent.com/19309423/200852428-b6e3fc19-ab37-40ef-9645-79d9f15e1652.mp4



## Issues
[UIQM-321](https://issues.folio.org/browse/UIQM-321)