### PR TITLE
UIQM-315 Rename permission to duplicate, now will definitely work as expected

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "visible": true
       },
       {
-        "permissionName": "ui-quick-marc.quick-marc-editor.derive",
+        "permissionName": "ui-quick-marc.quick-marc-editor.duplicate",
         "displayName": "quickMARC: Derive new MARC bibliographic record",
         "subPermissions": [
           "ui-quick-marc.quick-marc-editor.view",
@@ -80,7 +80,6 @@
           "records-editor.records.item.post",
           "instance-authority-links.instances.collection.put"
         ],
-        "replaces": ["ui-quick-marc.quick-marc-editor.duplicate"],
         "visible": true
       },
       {

--- a/src/QuickMarc.js
+++ b/src/QuickMarc.js
@@ -37,7 +37,7 @@ const QuickMarc = ({
     },
     {
       path: `${basePath}/duplicate-bib/:externalId`,
-      permission: 'ui-quick-marc.quick-marc-editor.derive',
+      permission: 'ui-quick-marc.quick-marc-editor.duplicate',
       props: {
         action: QUICK_MARC_ACTIONS.DERIVE,
         wrapper: QuickMarcDeriveWrapper,

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -7,7 +7,7 @@
   "permission.quick-marc-holdings-editor.view": "quickMARC: View MARC holdings record",
   "permission.quick-marc-holdings-editor.all": "quickMARC: View, edit MARC holdings record",
   "permission.quick-marc-holdings-editor.create": "quickMARC: Create a new MARC holdings record",
-  "permission.quick-marc-editor.derive": "quickMARC: Derive new MARC bibliographic record",
+  "permission.quick-marc-editor.duplicate": "quickMARC: Derive new MARC bibliographic record",
   "permission.quick-marc-authorities-editor.all": "quickMARC: View, edit MARC authorities record",
   "permission.quick-marc-authority-records.linkUnlink": "quickMARC: Can Link/unlink authority records to bib records",
 


### PR DESCRIPTION
## Description
Keep Derive permission named as `duplicate` to prevent breaking changes to quick marc and other modules

## Issues
[UIQM-315](https://issues.folio.org/browse/UIQM-315)