### PR TITLE
UIQM-319: Not actual "relatedRecordVersion" value sends when user saves "MARC Bib" record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [UIQM-313](https://issues.folio.org/browse/UIQM-313) Reference "MARC Authority" record is opened when user clicks on the "View MARC authority record" icon
 * [UIQM-315](https://issues.folio.org/browse/UIQM-315) Rename "Duplicate BIB" feature to "Derive BIB" feature
 * [UIQM-320](https://issues.folio.org/browse/UIQM-320) The permission "quickMARC: Can Link/unlink authority records to bib records" is hidden on UI.
+* [UIQM-319](https://issues.folio.org/browse/UIQM-319) Not actual "relatedRecordVersion" value sends when user saves "MARC Bib" record
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -100,6 +100,14 @@ const QuickMarcEditorContainer = ({
 
     await Promise.all([instancePromise, marcRecordPromise, locationsPromise])
       .then(([instanceResponse, marcRecordResponse, locationsResponse]) => {
+        if (action !== QUICK_MARC_ACTIONS.CREATE) {
+          searchParams.set('relatedRecordVersion', instanceResponse._version);
+
+          history.replace({
+            search: searchParams.toString(),
+          });
+        }
+
         const dehydratedMarcRecord = action === QUICK_MARC_ACTIONS.CREATE
           ? getCreateMarcRecordResponse(instanceResponse)
           : dehydrateMarcRecordResponse(marcRecordResponse);
@@ -118,7 +126,7 @@ const QuickMarcEditorContainer = ({
         closeEditor();
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [externalId, relatedRecordVersion]);
+  }, [externalId, relatedRecordVersion, history]);
 
   useEffect(() => {
     loadData();

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.test.js
@@ -27,6 +27,7 @@ jest.mock('../queries', () => ({
 const getInstance = () => ({
   id: faker.random.uuid(),
   title: 'ui-quick-marc.bib-record.edit.title',
+  _version: '1',
 });
 
 const match = {
@@ -144,6 +145,46 @@ describe('Given Quick Marc Editor Container', () => {
     });
 
     expect(getByText(instance.title)).toBeDefined();
+  });
+
+  describe('when the action is not CREATE', () => {
+    it('should append the relatedRecordVersion parameter to URL', async () => {
+      const history = createMemoryHistory();
+
+      history.replace = jest.fn();
+
+      await act(async () => {
+        await renderQuickMarcEditorContainer({
+          mutator,
+          onClose: jest.fn(),
+          action: QUICK_MARC_ACTIONS.EDIT,
+          wrapper: QuickMarcEditWrapper,
+          history,
+        });
+      });
+
+      expect(history.replace).toHaveBeenCalledWith({ search: 'relatedRecordVersion=1' });
+    });
+  });
+
+  describe('when the action is CREATE', () => {
+    it('should not append the relatedRecordVersion parameter to URL', async () => {
+      const history = createMemoryHistory();
+
+      history.replace = jest.fn();
+
+      await act(async () => {
+        await renderQuickMarcEditorContainer({
+          mutator,
+          onClose: jest.fn(),
+          action: QUICK_MARC_ACTIONS.CREATE,
+          wrapper: QuickMarcEditWrapper,
+          history,
+        });
+      });
+
+      expect(history.replace).not.toBeCalled();
+    });
   });
 
   describe('When close button is pressed', () => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Always display the actual record version in the URL (`relatedRecordVersion`).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Related PRs
[UIIN-2244 pool request](https://github.com/folio-org/ui-inventory/pull/1846)

## Issues
[UIQM-319](https://issues.folio.org/browse/UIQM-319)
[UIIN-2244](https://issues.folio.org/browse/UIIN-2244)

## Screencast





https://user-images.githubusercontent.com/77053927/201738117-231526c2-6734-46a9-b5f6-2e5797b78d61.mp4








## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
