### PR TITLE
UIQM-295 Fix validation for subfield existence

### DIFF
--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -73,7 +73,9 @@ const useAuthorityLinking = () => {
       const ruleSubfield = Object.keys(rule)[0];
       const subfieldShouldExist = rule[ruleSubfield];
 
-      const isValid = authoritySubfields[formatSubfieldCode(ruleSubfield)] && subfieldShouldExist;
+      // should be valid when subfield exists and rule requires it
+      // and not valid when subfield doesn't exist and rule requires it to be empty
+      const isValid = Boolean(authoritySubfields[formatSubfieldCode(ruleSubfield)]) === subfieldShouldExist;
 
       return isValid;
     });


### PR DESCRIPTION
## Description
Fix validation for subfield existence
Using `&&` returns incorrect results when there's a rule `{ t: false }`. In all cases it will make linking invalid
Instead need to use `==` - that way we will check that existence of subfield and validation rule match

## Screenshots

https://user-images.githubusercontent.com/19309423/206145465-6afdceea-b235-42ea-8a03-674515a16996.mp4



## Issues
[UIQM-295](https://issues.folio.org/browse/UIQM-295)