### PR TITLE
UIQM-339 Uncontrolled subfield moved to read only box when linked "MARC Authority" has the same subfield indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [UIQM-332](https://issues.folio.org/browse/UIQM-332) Default search/browse option and Authority source file selections based on MARC bib field to be linked
 * [UIQM-322](https://issues.folio.org/browse/UIQM-322) Edit MARC authority app | User edits the 1XX value and has linked bib fields
 * [UIQM-331](https://issues.folio.org/browse/UIQM-331) Edit MARC authority: Handling updates 1XX or 010 $a value 
+* [UIQM-339](https://issues.folio.org/browse/UIQM-339) Uncontrolled subfield moved to read only box when linked "MARC Authority" has the same subfield indicator
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -77,6 +77,7 @@ describe('Given useAuthorityLinking', () => {
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
         content: '$a authority value $b some other value $t field for modification $0 http://some.url/n0001 $9 authority-id',
+        authorityControlledSubfields: ['a', 'b', 't'],
       });
     });
   });
@@ -97,6 +98,7 @@ describe('Given useAuthorityLinking', () => {
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
         content: '$a authority value $b some other value $0 http://some.url/n0001 $9 authority-id $t field for modification',
+        authorityControlledSubfields: ['a', 'b', 't'],
       });
     });
   });
@@ -117,6 +119,7 @@ describe('Given useAuthorityLinking', () => {
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
         content: '$a authority value $b some other value $e author $e illustrator $t field for modification $0 http://some.url/n0001 $9 authority-id',
+        authorityControlledSubfields: ['a', 'b', 't'],
       });
     });
   });
@@ -154,6 +157,7 @@ describe('Given useAuthorityLinking', () => {
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
         content: '$a authority value $b some other value $e author $e illustrator $c field for modification $0 http://some.url/n0001 $9 authority-id',
+        authorityControlledSubfields: ['a', 'b', 'c'],
       });
     });
   });


### PR DESCRIPTION
## Description
Use authority linking rules to provide correct list of controlled subfields

## Screenshots

https://user-images.githubusercontent.com/19309423/208895928-afe15c56-8723-4c41-9887-4bed9e0e8cc4.mp4



## Issues
[UIQM-339](https://issues.folio.org/browse/UIQM-339)