### PR TITLE
UIQM-330: Forbid duplicate MARC010 fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [UIQM-331](https://issues.folio.org/browse/UIQM-331) Edit MARC authority: Handling updates 1XX or 010 $a value 
 * [UIQM-339](https://issues.folio.org/browse/UIQM-339) Uncontrolled subfield moved to read only box when linked "MARC Authority" has the same subfield indicator
 * [UIQM-335](https://issues.folio.org/browse/UIQM-335) MARC Bibliographic | Print Source record
+* [UIQM-330](https://issues.folio.org/browse/UIQM-330) FE - Edit MARC Authority record | MARC field 010 is not repeatable
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -374,6 +374,16 @@ export const checkControlFieldLength = (formValues) => {
   return undefined;
 };
 
+export const checkDuplicate010Field = (marcRecords) => {
+  const marc010Records = marcRecords.filter(({ tag }) => tag === '010');
+
+  if (marc010Records.length > 1) {
+    return <FormattedMessage id="ui-quick-marc.record.error.010Field.multiple" />;
+  }
+
+  return undefined;
+};
+
 export const validateSubfield = (marcRecords, initialMarcRecords) => {
   const marcRecordsWithSubfields = marcRecords.filter(marcRecord => marcRecord.indicators);
   const isEmptySubfield = marcRecordsWithSubfields.some(marcRecord => {
@@ -468,6 +478,10 @@ const validateMarcAuthorityRecord = (marcRecords, linksCount, initialRecords) =>
   if (headingRecords.length > 1) {
     return <FormattedMessage id="ui-quick-marc.record.error.heading.multiple" />;
   }
+
+  const duplicate010FieldError = checkDuplicate010Field(marcRecords);
+
+  if (duplicate010FieldError) return duplicate010FieldError;
 
   if (linksCount) {
     return validateMarcAuthority1xxField(initialRecords, marcRecords);

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -777,7 +777,7 @@ describe('QuickMarcEditor utils', () => {
   });
 
   describe('checkControlFieldLength', () => {
-    it('should not return error message when only one 001 field is present', () => {
+    it('should not return error message when only one 001 and 010 fields are present', () => {
       const formValues = {
         records: [{
           tag: '001',
@@ -801,6 +801,7 @@ describe('QuickMarcEditor utils', () => {
       };
 
       expect(utils.checkControlFieldLength(formValues)).not.toBeDefined();
+      expect(utils.checkDuplicate010Field(formValues.records)).not.toBeDefined();
     });
 
     it('should return error message when more than one 001 field is present', () => {
@@ -831,6 +832,36 @@ describe('QuickMarcEditor utils', () => {
       };
 
       expect(utils.checkControlFieldLength(formValues).props.id).toBe('ui-quick-marc.record.error.controlField.multiple');
+    });
+
+    it('should return error message when more than one 010 field is present', () => {
+      const formValues = {
+        records: [{
+          tag: '010',
+          content: 'some content',
+          id: 'id010-1',
+        }, {
+          tag: '010',
+          content: 'some other content',
+          id: 'id010-2',
+        }, {
+          tag: '035',
+          content: 'some content',
+          id: 'id035',
+          indicators: ['0', '\\'],
+        }, {
+          content: '',
+          id: 'id999ff-746e-4058-a35b-8130e4f6d277',
+          indicators: ['f', 'f'],
+          tag: '999',
+        }],
+        updateInfo: {
+          recordState: 'actual',
+          updateDate: '01/01/1970',
+        },
+      };
+
+      expect(utils.checkDuplicate010Field(formValues.records).props.id).toBe('ui-quick-marc.record.error.010Field.multiple');
     });
   });
 

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -171,6 +171,7 @@
   "record.error.bib.leader.invalid005PositionValue": "Record cannot be saved. Invalid value entered for position 5.",
   "record.error.controlField.multiple": "Record cannot be saved. Can only have one MARC 001.",
   "record.error.instanceHrid.multiple": "Record cannot be saved. Can only have one MARC 004.",
+  "record.error.010Field.multiple": "Cannot save multiple 010 fields.",
   "record.error.heading.empty": "Record cannot be saved without 1XX field.",
   "record.error.heading.multiple": "Record cannot be saved. Cannot have multiple 1XXs",
   "record.error.title.multiple": "Record cannot be saved with more than one field 245.",


### PR DESCRIPTION
## Description
Similar to what was done with 001 field, we check to see if there are duplicate 010 fileds and display the corresponding error message.

## Screenshots
https://user-images.githubusercontent.com/101110095/211549081-06a9ff80-81d4-4ecb-83b5-ef16c7af26ea.mp4

## Issues
[UIQM-330](https://issues.folio.org/browse/UIQM-330)