### PR TITLE
UIQM-353 Don't pass headingRef to href to linked authority record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [UIQM-331](https://issues.folio.org/browse/UIQM-331) Edit MARC authority: Handling updates 1XX or 010 $a value 
 * [UIQM-339](https://issues.folio.org/browse/UIQM-339) Uncontrolled subfield moved to read only box when linked "MARC Authority" has the same subfield indicator
 * [UIQM-335](https://issues.folio.org/browse/UIQM-335) MARC Bibliographic | Print Source record
+* [UIQM-353](https://issues.folio.org/browse/UIQM-353) Fix "Reference" record opens when user clicks on the "View" icon next to the linked "MARC Bib" field
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -454,24 +454,20 @@ const QuickMarcEditorRows = ({
                       id={`view-marc-authority-record-tooltip-${idx}`}
                       text={intl.formatMessage({ id: 'ui-quick-marc.record.viewMarcAuthorityRecord' })}
                     >
-                      {({ ref, ariaIds }) => {
-                        const headingRef = getContentSubfieldValue(recordRow.content).$a;
-
-                        return (
-                          <Link
-                            to={`/marc-authorities/authorities/${recordRow.authorityId}?authRefType=Authorized&headingRef=${headingRef}&segment=search`}
-                            target="_blank"
-                            data-testid="view-authority-record-link"
-                            tabIndex="-1"
-                          >
-                            <IconButton
-                              icon="eye-open"
-                              ref={ref}
-                              aria-labelledby={ariaIds.text}
-                            />
-                          </Link>
-                        );
-                      }}
+                      {({ ref, ariaIds }) => (
+                        <Link
+                          to={`/marc-authorities/authorities/${recordRow.authorityId}?authRefType=Authorized&segment=search`}
+                          target="_blank"
+                          data-testid="view-authority-record-link"
+                          tabIndex="-1"
+                        >
+                          <IconButton
+                            icon="eye-open"
+                            ref={ref}
+                            aria-labelledby={ariaIds.text}
+                          />
+                        </Link>
+                      )}
                     </Tooltip>
                   )}
                 </div>

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -334,7 +334,7 @@ describe('Given QuickMarcEditorRows', () => {
       expect(getByTestId('view-authority-record-link')).toBeVisible();
       expect(getByTestId('view-authority-record-link')).toHaveAttribute(
         'href',
-        '/marc-authorities/authorities/authority-id?authRefType=Authorized&headingRef=Kirby, Jack,&segment=search',
+        '/marc-authorities/authorities/authority-id?authRefType=Authorized&segment=search',
       );
     });
   });


### PR DESCRIPTION
## Description
Fix Reference record displaying when opening linked record

We're opening unique Authorized record, so we can ignore `headingRef` param that can be inconsistently formatted

## Screenshots

https://user-images.githubusercontent.com/19309423/211845762-ca1da83e-b56b-43a7-b3b2-6f33a1de39ec.mp4

## Issues
[UIQM-353](https://issues.folio.org/browse/UIQM-353)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/52