### PR TITLE
UIQM-345: Do not allow users to delete 1XX fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [UIQM-335](https://issues.folio.org/browse/UIQM-335) MARC Bibliographic | Print Source record
 * [UIQM-330](https://issues.folio.org/browse/UIQM-330) FE - Edit MARC Authority record | MARC field 010 is not repeatable
 * [UIQM-353](https://issues.folio.org/browse/UIQM-353) Fix "Reference" record opens when user clicks on the "View" icon next to the linked "MARC Bib" field
+* [UIQM-345](https://issues.folio.org/browse/UIQM-345) Edit a MARC authority record | Do not allow user to delete 1XX field
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -43,7 +43,6 @@ import {
   isPhysDescriptionRecord,
   isFixedFieldRow,
 } from './utils';
-import { getContentSubfieldValue } from '../utils';
 import { useAuthorityLinking } from '../../hooks';
 import { QUICK_MARC_ACTIONS } from '../constants';
 import {

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -63,10 +63,14 @@ const DELETE_EXCEPTION_ROWS = new Set([LEADER_TAG, '001', '003', '005', '008']);
 
 const DELETE_EXCEPTION_ROWS_FOR_HOLDINGS = new Set([LEADER_TAG, '001', '003', '004', '005', '008']);
 
+const is1XXField = (tag) => tag[0] === '1';
+
 export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB) => {
   const rows = marcType === MARC_TYPES.HOLDINGS
     ? DELETE_EXCEPTION_ROWS_FOR_HOLDINGS
     : DELETE_EXCEPTION_ROWS;
+
+  if (marcType === MARC_TYPES.AUTHORITY && is1XXField(recordRow.tag)) return true;
 
   return rows.has(recordRow.tag) || isLastRecord(recordRow);
 };

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
@@ -101,6 +101,12 @@ describe('QuickMarcEditorRows utils', () => {
         expect(utils.hasDeleteException({ tag: '004' }, MARC_TYPES.HOLDINGS)).toBeTruthy();
       });
     });
+
+    describe('when record type equals AUTHORITY', () => {
+      it('should be true for 1XX tags', () => {
+        expect(utils.hasDeleteException({ tag: '150' }, MARC_TYPES.HOLDINGS)).toBeTruthy();
+      });
+    });
   });
 
   describe('hasMoveException', () => {

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
@@ -104,7 +104,7 @@ describe('QuickMarcEditorRows utils', () => {
 
     describe('when record type equals AUTHORITY', () => {
       it('should be true for 1XX tags', () => {
-        expect(utils.hasDeleteException({ tag: '150' }, MARC_TYPES.HOLDINGS)).toBeTruthy();
+        expect(utils.hasDeleteException({ tag: '150' }, MARC_TYPES.AUTHORITY)).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION

## Description
Disallowed users to delete 1XX field when editing MARC Authority records

## Screenshots
![image](https://user-images.githubusercontent.com/101110095/212318387-6af591a1-41ab-4a6e-b6d6-2c5e650f6951.png)

## Issues
[UIQM-345](https://issues.folio.org/browse/UIQM-345)