### PR TITLE
UIQM-343: Do not allow users to delete MARC bib 245 and MARC holdindins fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 * [UIQM-330](https://issues.folio.org/browse/UIQM-330) FE - Edit MARC Authority record | MARC field 010 is not repeatable
 * [UIQM-353](https://issues.folio.org/browse/UIQM-353) Fix "Reference" record opens when user clicks on the "View" icon next to the linked "MARC Bib" field
 * [UIQM-345](https://issues.folio.org/browse/UIQM-345) Edit a MARC authority record | Do not allow user to delete 1XX field
+* [UIQM-343](https://issues.folio.org/browse/UIQM-343) Edit/Derive a MARC bib record | Do not allow a user to delete MARC field 245
+* [UIQM-344](https://issues.folio.org/browse/UIQM-344) Create/Edit MARC holdings | Do not allow user to delete MARC field 852
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -59,16 +59,16 @@ export const hasAddException = (recordRow, marcType = MARC_TYPES.BIB) => {
   return ADD_EXCEPTION_ROWS[marcType].has(recordRow.tag);
 };
 
-const DELETE_EXCEPTION_ROWS = new Set([LEADER_TAG, '001', '003', '005', '008']);
-
-const DELETE_EXCEPTION_ROWS_FOR_HOLDINGS = new Set([LEADER_TAG, '001', '003', '004', '005', '008']);
+const DELETE_EXCEPTION_ROWS = {
+  [MARC_TYPES.AUTHORITY]: new Set([LEADER_TAG, '001', '003', '005', '008']),
+  [MARC_TYPES.HOLDINGS]: new Set([LEADER_TAG, '001', '003', '004', '005', '008', '852']),
+  [MARC_TYPES.BIB]: new Set([LEADER_TAG, '001', '003', '005', '008', '245']),
+};
 
 const is1XXField = (tag) => tag[0] === '1';
 
 export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB) => {
-  const rows = marcType === MARC_TYPES.HOLDINGS
-    ? DELETE_EXCEPTION_ROWS_FOR_HOLDINGS
-    : DELETE_EXCEPTION_ROWS;
+  const rows = DELETE_EXCEPTION_ROWS[marcType];
 
   if (marcType === MARC_TYPES.AUTHORITY && is1XXField(recordRow.tag)) return true;
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
@@ -91,8 +91,8 @@ describe('QuickMarcEditorRows utils', () => {
     });
 
     describe('when record type equals BIB', () => {
-      it('should be true for tag 004', () => {
-        expect(utils.hasDeleteException({ tag: '004' }, MARC_TYPES.BIB)).toBeFalsy();
+      it('should be true for tag 245', () => {
+        expect(utils.hasDeleteException({ tag: '245' }, MARC_TYPES.BIB)).toBeTruthy();
       });
     });
 


### PR DESCRIPTION
## Description
Do not allow users po delete MARC bib 245 and MARC holdindins fields

## Issues
[UIQM-343](https://issues.folio.org/browse/UIQM-343)
[UIQM-344](https://issues.folio.org/browse/UIQM-344)

## Screenshots
![image](https://user-images.githubusercontent.com/101110095/212671564-7b5b62f7-59f1-4c83-8105-f681c2b19541.png)
![image](https://user-images.githubusercontent.com/101110095/212671669-3c0acc86-1bb1-41b4-b7cb-09de86cfcbf3.png)