### PR TITLE
Revert "UIQM-349 Align the module with API breaking change"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 * [UIQM-330](https://issues.folio.org/browse/UIQM-330) FE - Edit MARC Authority record | MARC field 010 is not repeatable
 * [UIQM-353](https://issues.folio.org/browse/UIQM-353) Fix "Reference" record opens when user clicks on the "View" icon next to the linked "MARC Bib" field
 * [UIQM-345](https://issues.folio.org/browse/UIQM-345) Edit a MARC authority record | Do not allow user to delete 1XX field
-* [UIQM-349](https://issues.folio.org/browse/UIQM-349) Align the module with mod-search API breaking change
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pluginType": "quick-marc",
     "displayName": "ui-quick-marc.meta.title",
     "okapiInterfaces": {
-      "inventory": "13.0",
+      "inventory": "10.0 11.0 12.0",
       "records-editor.records": "3.1",
       "instance-authority-links": "1.0"
     },


### PR DESCRIPTION
Reverts folio-org/ui-quick-marc#429 until back-end interface has been updated