### PR TITLE
UIQM-370: check for undefined parameter in  is1XXXField utility function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [UIQM-343](https://issues.folio.org/browse/UIQM-343) Edit/Derive a MARC bib record | Do not allow a user to delete MARC field 245
 * [UIQM-344](https://issues.folio.org/browse/UIQM-344) Create/Edit MARC holdings | Do not allow user to delete MARC field 852
 * [UIQM-341](https://issues.folio.org/browse/UIQM-341) Error handling | Edit/Derive a new MARC bib record | User adds an invalid $9
+* [UIQM-370](https://issues.folio.org/browse/UIQM-370) Error when clearing "1XX" field tag for "MARC authority" record
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -65,7 +65,7 @@ const DELETE_EXCEPTION_ROWS = {
   [MARC_TYPES.BIB]: new Set([LEADER_TAG, '001', '003', '005', '008', '245']),
 };
 
-const is1XXField = (tag) => tag[0] === '1';
+const is1XXField = (tag) => tag && tag[0] === '1';
 
 export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB) => {
   const rows = DELETE_EXCEPTION_ROWS[marcType];


### PR DESCRIPTION
## Description
is1XXField function in utils.js needs to check if the parameter is undefined instead of string before accessing its first character

## Screecast
https://user-images.githubusercontent.com/101110095/212901249-55f0333e-c0d9-44d7-8d13-61de8971d1d1.mp4

## Issue
[UIQM-370](https://issues.folio.org/browse/UIQM-370)
