### PR TITLE
UIQM-348: Do not allow user to delete 010 field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [UIQM-341](https://issues.folio.org/browse/UIQM-341) Error handling | Edit/Derive a new MARC bib record | User adds an invalid $9
 * [UIQM-368](https://issues.folio.org/browse/UIQM-368) Bump stripes to 8.0.0 for Orchid/2023-R1
 * [UIQM-359](https://issues.folio.org/browse/UIQM-359) Change to Linked MARC authority record has been updated confirmation messaging
+* [UIQM-348](https://issues.folio.org/browse/UIQM-348) Change to Linked MARC authority record has been updated confirmation messaging
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -402,6 +402,7 @@ const QuickMarcEditor = ({
                     type={type}
                     subtype={subtype}
                     marcType={marcType}
+                    linksCount={linksCount}
                   />
                 </Col>
               </Row>

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -68,6 +68,7 @@ const QuickMarcEditorRows = ({
     restoreRecord,
   },
   marcType,
+  linksCount,
 }) => {
   const stripes = useStripes();
   const intl = useIntl();
@@ -210,7 +211,7 @@ const QuickMarcEditorRows = ({
             const isDisabled = isReadOnly(recordRow, action, marcType);
             const withIndicators = !hasIndicatorException(recordRow);
             const withAddRowAction = hasAddException(recordRow, marcType);
-            const withDeleteRowAction = hasDeleteException(recordRow, marcType);
+            const withDeleteRowAction = hasDeleteException(recordRow, marcType, linksCount);
             const withMoveUpRowAction = hasMoveException(recordRow, fields[idx - 1]);
             const withMoveDownRowAction = hasMoveException(recordRow, fields[idx + 1]);
 
@@ -501,6 +502,7 @@ QuickMarcEditorRows.propTypes = {
     restoreRecord: PropTypes.func.isRequired,
   }),
   marcType: PropTypes.oneOf(Object.values(MARC_TYPES)).isRequired,
+  linksCount: PropTypes.number,
 };
 
 export default QuickMarcEditorRows;

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -67,10 +67,14 @@ const DELETE_EXCEPTION_ROWS = {
 
 const is1XXField = (tag) => tag[0] === '1';
 
-export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB) => {
+export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB, linksCount = 0) => {
   const rows = DELETE_EXCEPTION_ROWS[marcType];
 
-  if (marcType === MARC_TYPES.AUTHORITY && is1XXField(recordRow.tag)) return true;
+  if (marcType === MARC_TYPES.AUTHORITY) {
+    if (is1XXField(recordRow.tag) || (recordRow.tag === '010' && linksCount > 0)) {
+      return true;
+    }
+  }
 
   return rows.has(recordRow.tag) || isLastRecord(recordRow);
 };

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
@@ -106,6 +106,9 @@ describe('QuickMarcEditorRows utils', () => {
       it('should be true for 1XX tags', () => {
         expect(utils.hasDeleteException({ tag: '150' }, MARC_TYPES.AUTHORITY)).toBeTruthy();
       });
+      it('should be true for tag 010 that populates bib field(s)', () => {
+        expect(utils.hasDeleteException({ tag: '010' }, MARC_TYPES.AUTHORITY, 1)).toBeTruthy();
+      });
     });
   });
 

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -919,24 +919,18 @@ export const splitFields = marcRecord => {
   };
 };
 
-export const are010Or1xxUpdated = (initial, updated) => {
-  let is010Updated = false;
-  let is1XXUpdated = false;
+export const is010Updated = (initial, updated) => {
+  const initial010 = initial.find(rec => rec.tag === '010');
+  const updated010 = updated.find(rec => rec.tag === '010');
 
-  const authRec010Tag = '010';
-  const initial010 = initial.find(rec => rec.tag === authRec010Tag);
-  const updated010 = updated.find(rec => rec.tag === authRec010Tag);
-
-  if (initial010 &&
+  return initial010 &&
     updated010 &&
-    getContentSubfieldValue(initial010.content).$a !== getContentSubfieldValue(updated010.content).$a
-  ) {
-    is010Updated = true;
-  }
+    getContentSubfieldValue(initial010.content).$a !== getContentSubfieldValue(updated010.content).$a;
+};
 
-  const authRec1XXTagStartsWith = '1';
-  const initial1xxRecords = initial.filter(rec => rec.tag[0] === authRec1XXTagStartsWith);
-  const updated1xxRecords = updated.filter(rec => rec.tag[0] === authRec1XXTagStartsWith);
+export const is1XXUpdated = (initial, updated) => {
+  const initial1xxRecords = initial.filter(rec => rec.tag[0] === '1');
+  const updated1xxRecords = updated.filter(rec => rec.tag[0] === '1');
 
   const updated1xxArr = [];
 
@@ -948,9 +942,9 @@ export const are010Or1xxUpdated = (initial, updated) => {
     }
   });
 
-  if (updated1xxArr.length) {
-    is1XXUpdated = true;
-  }
+  return !!updated1xxArr.length;
+};
 
-  return is010Updated || is1XXUpdated;
+export const are010Or1xxUpdated = (initial, updated) => {
+  return is010Updated(initial, updated) || is1XXUpdated(initial, updated);
 };


### PR DESCRIPTION
## Description
Do not allow user to delete 010 field when it populates any bib record field

## Screenshot
![image](https://user-images.githubusercontent.com/101110095/213183990-3fbb9906-2a6e-4fae-bba9-ae3e4265eda8.png)

## Issues
[UIQM-348](https://issues.folio.org/browse/UIQM-348)
