### PR TITLE
UIQM-347 quickMARC | Show errors messages then show confirmation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [UIQM-353](https://issues.folio.org/browse/UIQM-353) Fix "Reference" record opens when user clicks on the "View" icon next to the linked "MARC Bib" field
 * [UIQM-345](https://issues.folio.org/browse/UIQM-345) Edit a MARC authority record | Do not allow user to delete 1XX field
 * [UIQM-349](https://issues.folio.org/browse/UIQM-349) Align the module with mod-search API breaking change
+* [UIQM-347](https://issues.folio.org/browse/UIQM-347) quickMARC | Show errors messages then show confirmation messages
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.js
@@ -119,7 +119,7 @@ const QuickMarcCreateWrapper = ({
         setHttpError(parsedError);
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onClose, showCallout]);
+  }, [onClose, showCallout, prepareForSubmit]);
 
   return (
     <QuickMarcEditor

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.js
@@ -48,7 +48,7 @@ const QuickMarcCreateWrapper = ({
   const showCallout = useShowCallout();
   const [httpError, setHttpError] = useState(null);
 
-  const prepareForSubmit = (formValues) => {
+  const prepareForSubmit = useCallback((formValues) => {
     const formValuesToSave = removeDeletedRecords(formValues);
     const autopopulatedFormValues = autopopulateSubfieldSection(
       removeFieldsForDerive(formValuesToSave),
@@ -58,9 +58,9 @@ const QuickMarcCreateWrapper = ({
     const formValuesForCreate = cleanBytesFields(autopopulatedFormValues, initialValues, marcType);
 
     return formValuesForCreate;
-  };
+  }, [initialValues, marcType]);
 
-  const validate = (formValues) => {
+  const validate = useCallback((formValues) => {
     const formValuesForValidation = prepareForSubmit(formValues);
     const controlFieldErrorMessage = checkControlFieldLength(formValuesForValidation);
 
@@ -80,7 +80,7 @@ const QuickMarcCreateWrapper = ({
     }
 
     return undefined;
-  };
+  }, [initialValues, locations, marcType, prepareForSubmit]);
 
   const onSubmit = useCallback(async (formValues) => {
     const formValuesForCreate = prepareForSubmit(formValues);

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.js
@@ -9,9 +9,7 @@ import { useShowCallout } from '@folio/stripes-acq-components';
 
 import QuickMarcEditor from './QuickMarcEditor';
 import getQuickMarcRecordStatus from './getQuickMarcRecordStatus';
-import {
-  QUICK_MARC_ACTIONS,
-} from './constants';
+import { QUICK_MARC_ACTIONS } from './constants';
 import { MARC_TYPES } from '../common/constants';
 import {
   hydrateMarcRecord,
@@ -50,34 +48,42 @@ const QuickMarcCreateWrapper = ({
   const showCallout = useShowCallout();
   const [httpError, setHttpError] = useState(null);
 
-  const onSubmit = useCallback(async (formValues) => {
+  const prepareForSubmit = (formValues) => {
     const formValuesToSave = removeDeletedRecords(formValues);
-    const controlFieldErrorMessage = checkControlFieldLength(formValuesToSave);
-
-    if (controlFieldErrorMessage) {
-      showCallout({ message: controlFieldErrorMessage, type: 'error' });
-
-      return null;
-    }
-
     const autopopulatedFormValues = autopopulateSubfieldSection(
       removeFieldsForDerive(formValuesToSave),
       initialValues,
       marcType,
     );
     const formValuesForCreate = cleanBytesFields(autopopulatedFormValues, initialValues, marcType);
+
+    return formValuesForCreate;
+  };
+
+  const validate = (formValues) => {
+    const formValuesForValidation = prepareForSubmit(formValues);
+    const controlFieldErrorMessage = checkControlFieldLength(formValuesForValidation);
+
+    if (controlFieldErrorMessage) {
+      return controlFieldErrorMessage;
+    }
+
     const validationErrorMessage = validateMarcRecord({
-      marcRecord: formValuesForCreate,
+      marcRecord: formValuesForValidation,
       initialValues,
       marcType,
       locations,
     });
 
     if (validationErrorMessage) {
-      showCallout({ message: validationErrorMessage, type: 'error' });
-
-      return null;
+      return validationErrorMessage;
     }
+
+    return undefined;
+  };
+
+  const onSubmit = useCallback(async (formValues) => {
+    const formValuesForCreate = prepareForSubmit(formValues);
 
     return mutator.quickMarcEditMarcRecord.POST(hydrateMarcRecord(formValuesForCreate))
       .then(async ({ qmRecordId }) => {
@@ -124,6 +130,7 @@ const QuickMarcCreateWrapper = ({
       action={action}
       marcType={marcType}
       httpError={httpError}
+      validate={validate}
     />
   );
 };

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.test.js
@@ -75,6 +75,7 @@ jest.mock('@folio/stripes/final-form', () => () => (Component) => ({ onSubmit, .
       form={{
         mutators: {},
         reset: jest.fn(),
+        getState: jest.fn().mockReturnValue({ values: formValues }),
       }}
       {...props}
     />

--- a/src/QuickMarcEditor/QuickMarcDeriveWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDeriveWrapper.js
@@ -169,7 +169,7 @@ const QuickMarcDeriveWrapper = ({
         setHttpError(parsedError);
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onClose, showCallout, stripes, linkingRules, action]);
+  }, [onClose, showCallout, stripes, linkingRules, action, prepareForSubmit]);
 
   return (
     <QuickMarcEditor

--- a/src/QuickMarcEditor/QuickMarcDeriveWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDeriveWrapper.js
@@ -92,7 +92,7 @@ const QuickMarcDeriveWrapper = ({
     });
   };
 
-  const prepareForSubmit = (formValues) => {
+  const prepareForSubmit = useCallback((formValues) => {
     const formValuesToSave = removeDeletedRecords(formValues);
     const clearFormValues = removeFieldsForDerive(formValuesToSave);
     const autopopulatedFormWithIndicators = autopopulateIndicators(clearFormValues);
@@ -104,9 +104,9 @@ const QuickMarcDeriveWrapper = ({
     const formValuesForDerive = cleanBytesFields(autopopulatedFormWithSubfields, initialValues, marcType);
 
     return formValuesForDerive;
-  };
+  }, [initialValues, marcType]);
 
-  const validate = (formValues) => {
+  const validate = useCallback((formValues) => {
     const formValuesForValidation = prepareForSubmit(formValues);
     const controlFieldErrorMessage = checkControlFieldLength(formValuesForValidation);
 
@@ -127,7 +127,7 @@ const QuickMarcDeriveWrapper = ({
     }
 
     return undefined;
-  };
+  }, [action, initialValues, linkingRules, stripes, prepareForSubmit]);
 
   const onSubmit = useCallback(async (formValues) => {
     const formValuesForDerive = prepareForSubmit(formValues);

--- a/src/QuickMarcEditor/QuickMarcDeriveWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcDeriveWrapper.test.js
@@ -109,6 +109,7 @@ jest.mock('@folio/stripes/final-form', () => () => (Component) => ({ onSubmit, .
       form={{
         mutators: {},
         reset: jest.fn(),
+        getState: jest.fn().mockReturnValue({ values: formValues }),
       }}
       {...props}
     />

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -81,7 +81,7 @@ const QuickMarcEditWrapper = ({
     }
 
     const validationErrorMessage = validateMarcRecord({
-      marcRecord: formValuesToSave,
+      marcRecord: formValuesForValidation,
       initialValues,
       marcType,
       locations,
@@ -188,7 +188,7 @@ const QuickMarcEditWrapper = ({
     marcType,
     mutator,
     linksCount,
-    location.search,
+    location,
   ]);
 
   useEffect(() => {

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -60,6 +60,35 @@ const QuickMarcEditWrapper = ({
 
   const { fetchLinksCount } = useAuthorityLinksCount();
 
+  const prepareForSubmit = (formValues) => {
+    const formValuesToSave = removeDeletedRecords(formValues);
+
+    return formValuesToSave;
+  };
+
+  const validate = (formValues) => {
+    const formValuesForValidation = prepareForSubmit(formValues);
+    const controlFieldErrorMessage = checkControlFieldLength(formValuesForValidation);
+
+    if (controlFieldErrorMessage) {
+      return controlFieldErrorMessage;
+    }
+
+    const validationErrorMessage = validateMarcRecord({
+      marcRecord: formValuesForValidation,
+      initialValues,
+      marcType,
+      locations,
+      linksCount,
+    });
+
+    if (validationErrorMessage) {
+      return validationErrorMessage;
+    }
+
+    return undefined;
+  };
+
   const onSubmit = useCallback(async (formValues) => {
     let is1xxOr010Updated = false;
 
@@ -67,26 +96,7 @@ const QuickMarcEditWrapper = ({
       is1xxOr010Updated = are010Or1xxUpdated(initialValues.records, formValues.records);
     }
 
-    const formValuesToSave = removeDeletedRecords(formValues);
-    const controlFieldErrorMessage = checkControlFieldLength(formValuesToSave);
-    const validationErrorMessage = validateMarcRecord({
-      marcRecord: formValuesToSave,
-      initialValues,
-      marcType,
-      locations,
-      linksCount,
-    });
-
-    const errorMessage = controlFieldErrorMessage || validationErrorMessage;
-
-    if (errorMessage) {
-      showCallout({
-        message: errorMessage,
-        type: 'error',
-      });
-
-      return null;
-    }
+    const formValuesToSave = prepareForSubmit(formValues);
 
     const autopopulatedFormWithIndicators = autopopulateIndicators(formValuesToSave);
     const autopopulatedFormWithSubfields = autopopulateSubfieldSection(
@@ -161,7 +171,7 @@ const QuickMarcEditWrapper = ({
 
         setHttpError(parsedError);
       });
-  }, [showCallout, refreshPageData, location, initialValues, instance, locations, marcType, mutator, linksCount]);
+  }, [showCallout, refreshPageData, location, initialValues, instance, marcType, mutator, linksCount]);
 
   useEffect(() => {
     if (marcType === MARC_TYPES.AUTHORITY) {
@@ -184,6 +194,7 @@ const QuickMarcEditWrapper = ({
       httpError={httpError}
       externalRecordPath={externalRecordPath}
       linksCount={linksCount}
+      validate={validate}
     />
   );
 };

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -66,11 +66,11 @@ const QuickMarcEditWrapper = ({
   const { fetchLinksCount } = useAuthorityLinksCount();
   const { linkingRules } = useAuthorityLinkingRules();
 
-  const prepareForSubmit = (formValues) => {
+  const prepareForSubmit = useCallback((formValues) => {
     const formValuesToSave = removeDeletedRecords(formValues);
 
     return formValuesToSave;
-  };
+  }, []);
 
   const validate = useCallback((formValues) => {
     const formValuesForValidation = prepareForSubmit(formValues);
@@ -96,7 +96,7 @@ const QuickMarcEditWrapper = ({
     }
 
     return undefined;
-  }, [action, initialValues, linkingRules, linksCount, locations, marcType, stripes]);
+  }, [action, initialValues, linkingRules, linksCount, locations, marcType, stripes, prepareForSubmit]);
 
   const onSubmit = useCallback(async (formValues) => {
     let is1xxOr010Updated = false;
@@ -189,6 +189,7 @@ const QuickMarcEditWrapper = ({
     mutator,
     linksCount,
     location,
+    prepareForSubmit,
   ]);
 
   useEffect(() => {

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -72,7 +72,7 @@ const QuickMarcEditWrapper = ({
     return formValuesToSave;
   };
 
-  const validate = (formValues) => {
+  const validate = useCallback((formValues) => {
     const formValuesForValidation = prepareForSubmit(formValues);
     const controlFieldErrorMessage = checkControlFieldLength(formValuesForValidation);
 
@@ -96,7 +96,7 @@ const QuickMarcEditWrapper = ({
     }
 
     return undefined;
-  };
+  }, [action, initialValues, linkingRules, linksCount, locations, marcType, stripes]);
 
   const onSubmit = useCallback(async (formValues) => {
     let is1xxOr010Updated = false;

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -69,6 +69,7 @@ const QuickMarcEditor = ({
   form: {
     mutators,
     reset,
+    getState,
   },
   marcType,
   locations,
@@ -76,6 +77,7 @@ const QuickMarcEditor = ({
   externalRecordPath,
   confirmRemoveAuthorityLinking,
   linksCount,
+  validate,
 }) => {
   const history = useHistory();
   const location = useLocation();
@@ -142,6 +144,17 @@ const QuickMarcEditor = ({
   const confirmSubmit = useCallback((e, isKeepEditing = false) => {
     continueAfterSave.current = isKeepEditing;
 
+    const validationError = validate(getState().values);
+
+    if (validationError) {
+      showCallout({
+        message: validationError,
+        type: 'error',
+      });
+
+      return;
+    }
+
     if (deletedRecords.length) {
       setIsDeleteModalOpened(true);
 
@@ -165,6 +178,9 @@ const QuickMarcEditor = ({
     initialValues,
     linksCount,
     records,
+    getState,
+    validate,
+    showCallout,
   ]);
 
   const paneFooter = useMemo(() => {
@@ -486,6 +502,7 @@ QuickMarcEditor.propTypes = {
     errorType: PropTypes.string,
   }),
   confirmRemoveAuthorityLinking: PropTypes.bool,
+  validate: PropTypes.func.isRequired,
 };
 
 QuickMarcEditor.defaultProps = {

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -28,9 +28,7 @@ import {
   checkScope,
   Layer,
 } from '@folio/stripes/components';
-import {
-  useShowCallout,
-} from '@folio/stripes-acq-components';
+import { useShowCallout } from '@folio/stripes-acq-components';
 
 import { QuickMarcRecordInfo } from './QuickMarcRecordInfo';
 import { QuickMarcEditorRows } from './QuickMarcEditorRows';

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -291,7 +291,7 @@ describe('Given QuickMarcEditor', () => {
     });
   });
 
-  describe.only('when saving form with validation errors and deleted fields', () => {
+  describe('when saving form with validation errors and deleted fields', () => {
     beforeAll(() => {
       mockValidate.mockClear().mockReturnValue('Validation error');
     });

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -66,8 +66,8 @@ jest.mock('./QuickMarcRecordInfo', () => {
 
 const onCloseMock = jest.fn();
 const onSubmitMock = jest.fn(() => Promise.resolve({ version: 1 }));
-const mockValidate = jest.fn().mockReturnValue(undefined);
 const mockShowCallout = jest.fn();
+const mockValidate = jest.fn();
 
 useShowCallout.mockClear().mockReturnValue(mockShowCallout);
 
@@ -146,6 +146,10 @@ const renderQuickMarcEditor = (props) => (render(
 ));
 
 describe('Given QuickMarcEditor', () => {
+  beforeEach(() => {
+    mockValidate.mockClear().mockReturnValue(undefined);
+  });
+
   it('should render with no axe errors', async () => {
     const { container } = renderQuickMarcEditor();
 
@@ -292,7 +296,7 @@ describe('Given QuickMarcEditor', () => {
   });
 
   describe('when saving form with validation errors and deleted fields', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       mockValidate.mockClear().mockReturnValue('Validation error');
     });
 

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -60,6 +60,7 @@ jest.mock('./QuickMarcRecordInfo', () => {
 
 const onCloseMock = jest.fn();
 const onSubmitMock = jest.fn(() => Promise.resolve({ version: 1 }));
+const mockValidate = jest.fn().mockReturnValue(undefined);
 
 const instance = {
   id: faker.random.uuid(),
@@ -129,6 +130,7 @@ const renderQuickMarcEditor = (props) => (render(
       marcType={MARC_TYPES.BIB}
       locations={locations}
       linksCount={linksCount}
+      validate={mockValidate}
       {...props}
     />
   </Harness>,


### PR DESCRIPTION
## Description
Update handling form submit to validate record and show error messages first

## Screenshots

https://user-images.githubusercontent.com/19309423/213450482-e532de09-a57f-4c3a-abb0-d0d5de1c537e.mp4

https://user-images.githubusercontent.com/19309423/213450700-5c2bc510-6c1b-4a0e-b80b-a646f3c67063.mp4




## Issues
[UIQM-347](https://issues.folio.org/browse/UIQM-347)