### PR TITLE
UIQM-337: Controlled subfield is displayed as not controlled after linking of MARC Bib field with MARC Authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [UIQM-341](https://issues.folio.org/browse/UIQM-341) Error handling | Edit/Derive a new MARC bib record | User adds an invalid $9
 * [UIQM-368](https://issues.folio.org/browse/UIQM-368) Bump stripes to 8.0.0 for Orchid/2023-R1
 * [UIQM-359](https://issues.folio.org/browse/UIQM-359) Change to Linked MARC authority record has been updated confirmation messaging
+* [UIQM-337](https://issues.folio.org/browse/UIQM-337) Controlled subfield is displayed as not controlled after linking of MARC Bib field with MARC Authority
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -34,20 +34,6 @@ const useAuthorityLinking = () => {
     return linkingRules.find(rule => rule.bibField === bibTag && rule.authorityField === authorityTag);
   }, [linkingRules]);
 
-  const removeSubfieldsIfThereAreNotInAuthority = useCallback((bibSubfields, authField, bibTag) => {
-    const authSubfields = getContentSubfieldValue(authField.content);
-    const linkingRule = findLinkingRule(bibTag, authField.tag);
-
-    Object.keys(bibSubfields).forEach(subfieldCode => {
-      if (
-        linkingRule.authoritySubfields.includes(subfieldCode.replace('$', '')) &&
-        !(subfieldCode in authSubfields)
-      ) {
-        delete bibSubfields[subfieldCode];
-      }
-    });
-  }, [findLinkingRule]);
-
   const copySubfieldsFromAuthority = useCallback((bibSubfields, authField, bibTag) => {
     const linkingRule = findLinkingRule(bibTag, authField.tag);
     const authSubfields = getContentSubfieldValue(authField.content);
@@ -59,6 +45,8 @@ const useAuthorityLinking = () => {
         bibSubfields[formatSubfieldCode(subfieldModification.target)] = authSubfields[formatSubfieldCode(subfieldCode)];
       } else if (authSubfields[formatSubfieldCode(subfieldCode)]) {
         bibSubfields[formatSubfieldCode(subfieldCode)] = authSubfields[formatSubfieldCode(subfieldCode)];
+      } else {
+        delete bibSubfields[formatSubfieldCode(subfieldCode)];
       }
     });
 
@@ -131,8 +119,6 @@ const useAuthorityLinking = () => {
       newZeroSubfield = authorityRecord.naturalId;
     }
 
-    removeSubfieldsIfThereAreNotInAuthority(bibSubfields, linkedAuthorityField, bibField.tag);
-
     copySubfieldsFromAuthority(bibSubfields, linkedAuthorityField, bibField.tag);
 
     if (!bibSubfields.$0 || bibSubfields.$0 !== authorityRecord.naturalId) {
@@ -142,7 +128,7 @@ const useAuthorityLinking = () => {
     bibSubfields.$9 = authorityRecord.id;
     bibField.prevContent = bibField.content;
     bibField.content = joinSubfields(bibSubfields);
-  }, [copySubfieldsFromAuthority, sourceFiles, removeSubfieldsIfThereAreNotInAuthority]);
+  }, [copySubfieldsFromAuthority, sourceFiles]);
 
   const linkAuthority = useCallback((authority, authoritySource, field) => {
     const linkedAuthorityField = getLinkableAuthorityField(authoritySource, field);

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -12,7 +12,7 @@ jest.mock('../../queries', () => ({
     linkingRules: [{
       bibField: '100',
       authorityField: '100',
-      authoritySubfields: ['a', 'b', 't'],
+      authoritySubfields: ['a', 'b', 't', 'd'],
       subfieldModifications: [],
       validation: {},
     }],
@@ -40,7 +40,7 @@ const wrapper = ({ children }) => (
 const authoritySource = {
   fields: [{
     tag: '100',
-    content: '$a authority value $t field for modification',
+    content: '$a authority value $b fakeB $t field for modification',
   }],
 };
 
@@ -61,6 +61,33 @@ describe('Given useAuthorityLinking', () => {
     });
   });
 
+  describe('when calling linkAuthority and some subfields are in the linking rule but not in authority', () => {
+    it('should return field without invalid subfields', () => {
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const authSource = {
+        fields: [{
+          tag: '100',
+          content: '$a Beethoven, Ludwig van',
+        }],
+      };
+      const authority = {
+        id: 'authority-id',
+        sourceFileId: '1',
+        naturalId: 'n0001',
+      };
+      const field = {
+        tag: '100',
+        content: '$a Beethoven, Ludwig van, $d 1770-1827, $e composer.',
+      };
+
+      expect(result.current.linkAuthority(authority, authSource, field)).toMatchObject({
+        content: '$a Beethoven, Ludwig van $e composer. $0 http://some.url/n0001 $9 authority-id',
+        authorityControlledSubfields: ['a', 'b', 't', 'd'],
+      });
+    });
+  });
+
   describe('when calling linkAuthority with not existing $0 subfield', () => {
     it('should return field with new $0 and $9 subfields and authority subfields', () => {
       const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
@@ -76,8 +103,8 @@ describe('Given useAuthorityLinking', () => {
       };
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b some other value $t field for modification $0 http://some.url/n0001 $9 authority-id',
-        authorityControlledSubfields: ['a', 'b', 't'],
+        content: '$a authority value $b fakeB $t field for modification $0 http://some.url/n0001 $9 authority-id',
+        authorityControlledSubfields: ['a', 'b', 't', 'd'],
       });
     });
   });
@@ -97,8 +124,8 @@ describe('Given useAuthorityLinking', () => {
       };
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b some other value $0 http://some.url/n0001 $9 authority-id $t field for modification',
-        authorityControlledSubfields: ['a', 'b', 't'],
+        content: '$a authority value $b fakeB $0 http://some.url/n0001 $9 authority-id $t field for modification',
+        authorityControlledSubfields: ['a', 'b', 't', 'd'],
       });
     });
   });
@@ -118,8 +145,8 @@ describe('Given useAuthorityLinking', () => {
       };
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b some other value $e author $e illustrator $t field for modification $0 http://some.url/n0001 $9 authority-id',
-        authorityControlledSubfields: ['a', 'b', 't'],
+        content: '$a authority value $b fakeB $e author $e illustrator $t field for modification $0 http://some.url/n0001 $9 authority-id',
+        authorityControlledSubfields: ['a', 'b', 't', 'd'],
       });
     });
   });
@@ -156,7 +183,7 @@ describe('Given useAuthorityLinking', () => {
       };
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b some other value $e author $e illustrator $c field for modification $0 http://some.url/n0001 $9 authority-id',
+        content: '$a authority value $b fakeB $e author $e illustrator $c field for modification $0 http://some.url/n0001 $9 authority-id',
         authorityControlledSubfields: ['a', 'b', 'c'],
       });
     });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Subfields that are in the linking rules but not in the authority should be removed.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issue
[UIQM-337](https://issues.folio.org/browse/UIQM-337)

## Screencast




https://user-images.githubusercontent.com/77053927/213513370-26ad4d09-dc14-442e-8306-96c009cbda97.mp4





## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
