### PR TITLE
UIQM-341: Show an error when entering '$'9

### DIFF
--- a/src/QuickMarcEditor/QuickMarcDeriveWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDeriveWrapper.js
@@ -5,12 +5,10 @@ import React, {
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
-import { useStripes } from '@folio/stripes/core';
 import { useShowCallout } from '@folio/stripes-acq-components';
 
 import QuickMarcEditor from './QuickMarcEditor';
 import getQuickMarcRecordStatus from './getQuickMarcRecordStatus';
-import { useAuthorityLinkingRules } from '../queries';
 import {
   QUICK_MARC_ACTIONS,
 } from './constants';
@@ -53,10 +51,7 @@ const QuickMarcDeriveWrapper = ({
   marcType,
 }) => {
   const showCallout = useShowCallout();
-  const stripes = useStripes();
   const [httpError, setHttpError] = useState(null);
-
-  const { linkingRules } = useAuthorityLinkingRules();
 
   const saveLinksToNewRecord = async (externalId, marcRecord) => {
     // request derived Instance record
@@ -117,9 +112,6 @@ const QuickMarcDeriveWrapper = ({
     const validationErrorMessage = validateMarcRecord({
       marcRecord: formValuesForValidation,
       initialValues,
-      linkingRules,
-      stripes,
-      action,
     });
 
     if (validationErrorMessage) {
@@ -127,7 +119,7 @@ const QuickMarcDeriveWrapper = ({
     }
 
     return undefined;
-  }, [action, initialValues, linkingRules, stripes, prepareForSubmit]);
+  }, [initialValues, prepareForSubmit]);
 
   const onSubmit = useCallback(async (formValues) => {
     const formValuesForDerive = prepareForSubmit(formValues);
@@ -169,7 +161,7 @@ const QuickMarcDeriveWrapper = ({
         setHttpError(parsedError);
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onClose, showCallout, stripes, linkingRules, action, prepareForSubmit]);
+  }, [onClose, showCallout, prepareForSubmit]);
 
   return (
     <QuickMarcEditor

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -6,15 +6,11 @@ import React, {
 import { useLocation } from 'react-router';
 import PropTypes from 'prop-types';
 
-import { useStripes } from '@folio/stripes/core';
 import { useShowCallout } from '@folio/stripes-acq-components';
 
 import QuickMarcEditor from './QuickMarcEditor';
 
-import {
-  useAuthorityLinksCount,
-  useAuthorityLinkingRules,
-} from '../queries';
+import { useAuthorityLinksCount } from '../queries';
 import { QUICK_MARC_ACTIONS } from './constants';
 import {
   EXTERNAL_INSTANCE_APIS,
@@ -59,12 +55,10 @@ const QuickMarcEditWrapper = ({
 }) => {
   const showCallout = useShowCallout();
   const location = useLocation();
-  const stripes = useStripes();
   const [httpError, setHttpError] = useState(null);
   const [linksCount, setLinksCount] = useState(0);
 
   const { fetchLinksCount } = useAuthorityLinksCount();
-  const { linkingRules } = useAuthorityLinkingRules();
 
   const prepareForSubmit = useCallback((formValues) => {
     const formValuesToSave = removeDeletedRecords(formValues);
@@ -86,9 +80,6 @@ const QuickMarcEditWrapper = ({
       marcType,
       locations,
       linksCount,
-      linkingRules,
-      stripes,
-      action,
     });
 
     if (validationErrorMessage) {
@@ -96,7 +87,7 @@ const QuickMarcEditWrapper = ({
     }
 
     return undefined;
-  }, [action, initialValues, linkingRules, linksCount, locations, marcType, stripes, prepareForSubmit]);
+  }, [initialValues, linksCount, locations, marcType, prepareForSubmit]);
 
   const onSubmit = useCallback(async (formValues) => {
     let is1xxOr010Updated = false;

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -403,48 +403,31 @@ export const validateSubfield = (marcRecords, initialMarcRecords) => {
   return undefined;
 };
 
-const getFieldWithEntered$9 = (marcRecords) => {
-  return marcRecords.find(field => {
+const validate$9 = (marcRecords) => {
+  const hasEntered$9 = marcRecords.some(field => {
     if (typeof field.content !== 'string') {
-      return null;
+      return false;
     }
 
     if (field.subfieldGroups) {
       const uncontrolledSubfields = ['uncontrolledAlpha', 'uncontrolledNumber'];
 
-      const hasEntered$9 = uncontrolledSubfields.some(subfield => {
-        return field.subfieldGroups[subfield] && getContentSubfieldValue(field.subfieldGroups[subfield]).$9;
+      return uncontrolledSubfields.some(subfield => {
+        return field.subfieldGroups[subfield] && '$9' in getContentSubfieldValue(field.subfieldGroups[subfield]);
       });
-
-      return hasEntered$9 ? field : null;
     }
 
-    return getContentSubfieldValue(field.content).$9 ? field : null;
+    return '$9' in getContentSubfieldValue(field.content);
   });
-};
 
-const validate$9 = (marcRecords, linkingRules, stripes, marcType, action) => {
-  const fieldWithEntered$9 = getFieldWithEntered$9(marcRecords);
-
-  if (!fieldWithEntered$9) {
-    return null;
-  }
-
-  const linkableBibFields = linkingRules.map(rule => rule.bibField);
-  const canBeLinked = checkCanBeLinked(stripes, marcType, action, linkableBibFields, fieldWithEntered$9.tag);
-
-  if (fieldWithEntered$9._isLinked) {
-    return <FormattedMessage id="ui-quick-marc.record.error.$9.nonRepeatable" />;
-  }
-
-  if (canBeLinked) {
+  if (hasEntered$9) {
     return <FormattedMessage id="ui-quick-marc.record.error.$9" />;
   }
 
-  return <FormattedMessage id="ui-quick-marc.record.error.$9.cannotBeLinked" />;
+  return null;
 };
 
-const validateMarcBibRecord = (marcRecords, linkingRules, stripes, marcType, action) => {
+const validateMarcBibRecord = (marcRecords) => {
   const titleRecords = marcRecords.filter(({ tag }) => tag === '245');
 
   if (titleRecords.length === 0) {
@@ -455,7 +438,7 @@ const validateMarcBibRecord = (marcRecords, linkingRules, stripes, marcType, act
     return <FormattedMessage id="ui-quick-marc.record.error.title.multiple" />;
   }
 
-  const $9Error = validate$9(marcRecords, linkingRules, stripes, marcType, action);
+  const $9Error = validate$9(marcRecords);
 
   if ($9Error) {
     return $9Error;
@@ -549,9 +532,6 @@ export const validateMarcRecord = ({
   marcType = MARC_TYPES.BIB,
   locations = [],
   linksCount,
-  linkingRules,
-  stripes,
-  action,
 }) => {
   const marcRecords = marcRecord.records || [];
   const initialMarcRecords = initialValues.records;
@@ -566,7 +546,7 @@ export const validateMarcRecord = ({
   let validationResult;
 
   if (marcType === MARC_TYPES.BIB) {
-    validationResult = validateMarcBibRecord(marcRecords, linkingRules, stripes, marcType, action);
+    validationResult = validateMarcBibRecord(marcRecords);
   } else if (marcType === MARC_TYPES.HOLDINGS) {
     validationResult = validateMarcHoldingsRecord(marcRecords, locations);
   } else if (marcType === MARC_TYPES.AUTHORITY) {

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -374,7 +374,7 @@ describe('QuickMarcEditor utils', () => {
       }).props.id).toBe('ui-quick-marc.record.error.title.multiple');
     });
 
-    describe('$9', () => {
+    describe('when $9 entered', () => {
       const initialValues = {
         leader: '04706cam a2200865Ii 4500',
         records: [
@@ -413,10 +413,7 @@ describe('QuickMarcEditor utils', () => {
           {
             'tag': '600',
             'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc.',
-            'indicators': [
-              '0',
-              '0',
-            ],
+            'indicators': ['0', '0'],
             'isProtected': false,
             'id': '402c0aec-5e1b-49a3-83a2-da788f48b27a',
             '_isDeleted': false,
@@ -425,55 +422,26 @@ describe('QuickMarcEditor utils', () => {
         ],
       };
 
-      const linkingRules = [{ 'bibField': '100' }, { 'bibField': '600' }];
-      const stripes = { hasPerm: jest.fn().mockReturnValue(true) };
+      it('should return an error for an already linked field', () => {
+        const record = cloneDeep(initialValues);
 
-      describe('when $9 entered to the already linked field', () => {
-        it('should return the error', () => {
-          const record = cloneDeep(initialValues);
+        record.records[3].subfieldGroups.uncontrolledAlpha = '$9 fakeValue';
 
-          record.records[3].subfieldGroups.uncontrolledAlpha = '$9 fakeValue';
-
-          expect(utils.validateMarcRecord({
-            marcRecord: record,
-            initialValues,
-            linkingRules,
-            stripes,
-            action: 'edit',
-          }).props.id).toBe('ui-quick-marc.record.error.$9.nonRepeatable');
-        });
+        expect(utils.validateMarcRecord({
+          marcRecord: record,
+          initialValues,
+        }).props.id).toBe('ui-quick-marc.record.error.$9');
       });
 
-      describe('when $9 entered to the field that can be linked', () => {
-        it('should return the error', () => {
-          const record = cloneDeep(initialValues);
+      it('should return an error for a not linked field', () => {
+        const record = cloneDeep(initialValues);
 
-          record.records[4].content += ' $9 fakeValue';
+        record.records[4].content += ' $9 fakeValue';
 
-          expect(utils.validateMarcRecord({
-            marcRecord: record,
-            initialValues,
-            linkingRules,
-            stripes,
-            action: 'edit',
-          }).props.id).toBe('ui-quick-marc.record.error.$9');
-        });
-      });
-
-      describe('when $9 entered to the field that can not be linked', () => {
-        it('should return the error', () => {
-          const record = cloneDeep(initialValues);
-
-          record.records[2].content += '$9 fakeValue';
-
-          expect(utils.validateMarcRecord({
-            marcRecord: record,
-            initialValues,
-            linkingRules,
-            stripes,
-            action: 'edit',
-          }).props.id).toBe('ui-quick-marc.record.error.$9.cannotBeLinked');
-        });
+        expect(utils.validateMarcRecord({
+          marcRecord: record,
+          initialValues,
+        }).props.id).toBe('ui-quick-marc.record.error.$9');
       });
     });
 

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -182,12 +182,10 @@
   "record.error.tag.nonDigits": "Invalid MARC tag. Please try again.",
   "record.error.subfield": "Missing a subfield value for a MARC tag",
   "record.error.location.invalid": "852 $b contains an invalid Location code. Please try again.",
+  "record.error.$9": "$9 is not a valid subfield.",
   "record.error.1xx.change": "Cannot change the <b>saved MARC authority field {tag}</b> because it controls a bibliographic field(s). To change this 1XX, you must unlink all controlled bibliographic fields.",
   "record.error.1xx.add$t": "Cannot add a <b>$t to the ${tag} field</b> because it controls a bibliographic field(s) that cannot control this subfield. To change this 1XX value, you must unlink all controlled bibliographic fields that cannot control $t.",
   "record.error.1xx.remove$t": "Cannot remove <b>$t from the ${tag} field</b> because it controls a bibliographic field(s) that requires  this subfield. To change this 1XX value, you must unlink all controlled bibliographic fields that requires $t to be controlled.",
-  "record.error.$9": "$9 that was entered for a field is not valid. Please remove what you have entered or revise it.",
-  "record.error.$9.cannotBeLinked": "$9 that was entered for a field is not valid because the field cannot be controlled. Please remove what you have entered.",
-  "record.error.$9.nonRepeatable": "$9 is not a repeatable subfield. Please remove what you have entered or revise it.",
 
   "record.delete.confirmLabel": "Continue with save",
   "record.delete.cancelLabel": "Restore deleted field(s)",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Show an error when entering $9
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issue

[UIQM-341](https://issues.folio.org/browse/UIQM-341?focusedCommentId=155410&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-155410)

## Screencast




https://user-images.githubusercontent.com/77053927/213707979-7100d8e1-d528-4457-a69e-ca35b5a034b4.mp4





## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
