### PR TITLE
UIQM-373: Save buttons are not disabled after removing unsaved updates from linked field in "MARC bib" record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [UIQM-359](https://issues.folio.org/browse/UIQM-359) Change to Linked MARC authority record has been updated confirmation messaging
 * [UIQM-347](https://issues.folio.org/browse/UIQM-347) quickMARC | Show errors messages then show confirmation messages
 * [UIQM-337](https://issues.folio.org/browse/UIQM-337) Controlled subfield is displayed as not controlled after linking of MARC Bib field with MARC Authority
+* [UIQM-373](https://issues.folio.org/browse/UIQM-373) Save buttons are not disabled after removing unsaved updates from linked field in "MARC bib" record
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/SplitField/SplitField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/SplitField/SplitField.js
@@ -2,6 +2,7 @@ import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
 
 import { TextField } from '@folio/stripes/components';
 
@@ -26,13 +27,17 @@ const SplitField = ({
         dirty={false}
         aria-label={intl.formatMessage({ id: 'ui-quick-marc.record.subfield' })}
         marginBottom0
+        parse={v => v}
         {...fieldProps}
       />
     );
   };
 
   return (
-    <FieldArray name={`${name}.subfieldGroups`}>
+    <FieldArray
+      name={`${name}.subfieldGroups`}
+      isEqual={isEqual}
+    >
       {() => (
         <>
           {renderSubfieldGroup({


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Enable save buttons only when there are changes.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
## Issues
[UIQM-373](https://issues.folio.org/browse/UIQM-373)

## Screencast





https://user-images.githubusercontent.com/77053927/214044178-5e0da8b7-81fc-4dfe-9205-fd2279fc73de.mp4






## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
