### PR TITLE
UIQM-347 Fix delete fields and confirm update links flow

### DIFF
--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -56,6 +56,16 @@ import css from './QuickMarcEditor.css';
 
 const spySubscription = { values: true };
 
+const CONFIRMATIONS = {
+  DELETE_RECORDS: 'DELETE_RECORDS',
+  UPDATE_LINKED: 'UPDATE_LINKED',
+};
+
+const REQUIRED_CONFIRMATIONS = {
+  [CONFIRMATIONS.DELETE_RECORDS]: true,
+  [CONFIRMATIONS.UPDATE_LINKED]: true,
+};
+
 const QuickMarcEditor = ({
   action,
   instance,
@@ -86,6 +96,7 @@ const QuickMarcEditor = ({
   const [isUpdate0101xxfieldsAuthRecModalOpen, setIsUpdate0101xxfieldsAuthRecModalOpen] = useState(false);
   const continueAfterSave = useRef(false);
   const formRef = useRef(null);
+  const confirmationChecks = useRef({ ...REQUIRED_CONFIRMATIONS });
 
   const { unlinkAuthority } = useAuthorityLinking();
 
@@ -129,10 +140,6 @@ const QuickMarcEditor = ({
     onClose();
   }, [redirectToVersion, onClose]);
 
-  const handleKeepEditingLinkedFields = () => {
-    setIsUpdate0101xxfieldsAuthRecModalOpen(false);
-  };
-
   const closeModals = () => {
     setIsDeleteModalOpened(false);
     setIsUpdate0101xxfieldsAuthRecModalOpen(false);
@@ -153,13 +160,15 @@ const QuickMarcEditor = ({
       return;
     }
 
-    if (deletedRecords.length) {
+    if (confirmationChecks.current[CONFIRMATIONS.DELETE_RECORDS] && deletedRecords.length) {
       setIsDeleteModalOpened(true);
 
       return;
     }
 
-    if (marcType === MARC_TYPES.AUTHORITY && linksCount > 0 && are010Or1xxUpdated(initialValues.records, records)) {
+    if (confirmationChecks.current[CONFIRMATIONS.UPDATE_LINKED]
+      && marcType === MARC_TYPES.AUTHORITY && linksCount > 0
+      && are010Or1xxUpdated(initialValues.records, records)) {
       setIsUpdate0101xxfieldsAuthRecModalOpen(true);
 
       return;
@@ -200,7 +209,10 @@ const QuickMarcEditor = ({
             buttonClass={css.saveContinueBtn}
             disabled={saveFormDisabled}
             id="quick-marc-record-save-edit"
-            onClick={(event) => confirmSubmit(event, true)}
+            onClick={(event) => {
+              confirmationChecks.current = { ...REQUIRED_CONFIRMATIONS };
+              confirmSubmit(event, true);
+            }}
             marginBottom0
           >
             <FormattedMessage id="ui-quick-marc.record.save.continue" />
@@ -210,7 +222,10 @@ const QuickMarcEditor = ({
           buttonStyle="primary mega"
           disabled={saveFormDisabled}
           id="quick-marc-record-save"
-          onClick={confirmSubmit}
+          onClick={(e) => {
+            confirmationChecks.current = { ...REQUIRED_CONFIRMATIONS };
+            confirmSubmit(e);
+          }}
           marginBottom0
         >
           <FormattedMessage id="stripes-acq-components.FormFooter.save" />
@@ -289,20 +304,22 @@ const QuickMarcEditor = ({
     deletedRecords.forEach(mutators.restoreRecord);
   };
 
-  const handleUpdateLinkedFields = (e) => {
-    handleSubmit(e)
-      .then(handleSubmitResponse)
-      .finally(closeModals);
+  const cancelUpdateLinks = () => {
+    setIsUpdate0101xxfieldsAuthRecModalOpen(false);
   };
 
-  const onConfirmModal = (e) => {
+  const confirmUpdateLinks = (e) => {
+    confirmationChecks.current[CONFIRMATIONS.UPDATE_LINKED] = false;
+    confirmSubmit(e, continueAfterSave.current);
+  };
+
+  const confirmDeleteFields = (e) => {
     setIsDeleteModalOpened(false);
-    handleSubmit(e)
-      .then(handleSubmitResponse)
-      .finally(closeModals);
+    confirmationChecks.current[CONFIRMATIONS.DELETE_RECORDS] = false;
+    confirmSubmit(e, continueAfterSave.current);
   };
 
-  const onCancelModal = () => {
+  const cancelDeleteFields = () => {
     setIsDeleteModalOpened(false);
 
     if (deletedRecords.length) {
@@ -310,6 +327,19 @@ const QuickMarcEditor = ({
     } else {
       reset();
     }
+  };
+
+  const cancelRemoveLinking = () => {
+    setIsUnlinkRecordsModalOpen(false);
+  };
+
+  const confirmRemoveLinking = () => {
+    // unlink all linked records
+    initialValues.records.filter(record => record._isLinked).forEach(record => {
+      unlinkAuthority(record);
+      mutators.markRecordUnlinked({ index: records.findIndex(rec => rec.id === record.id) });
+    });
+    setIsUnlinkRecordsModalOpen(false);
   };
 
   const changeRecords = useCallback(({ values }) => {
@@ -324,7 +354,8 @@ const QuickMarcEditor = ({
     handler: (e) => {
       if (!saveFormDisabled) {
         e.preventDefault();
-        confirmSubmit();
+        confirmationChecks.current = { ...REQUIRED_CONFIRMATIONS };
+        confirmSubmit(e, continueAfterSave.current);
       }
     },
   }, {
@@ -334,19 +365,6 @@ const QuickMarcEditor = ({
       onClose();
     },
   }]), [saveFormDisabled, confirmSubmit, onClose]);
-
-  const handleKeepLinking = () => {
-    setIsUnlinkRecordsModalOpen(false);
-  };
-
-  const handleRemoveLinking = () => {
-    // unlink all linked records
-    initialValues.records.filter(record => record._isLinked).forEach(record => {
-      unlinkAuthority(record);
-      mutators.markRecordUnlinked({ index: records.findIndex(rec => rec.id === record.id) });
-    });
-    setIsUnlinkRecordsModalOpen(false);
-  };
 
   useEffect(() => {
     if (!httpError) {
@@ -430,8 +448,8 @@ const QuickMarcEditor = ({
         message={getConfirmModalMessage()}
         confirmLabel={<FormattedMessage id="ui-quick-marc.record.delete.confirmLabel" />}
         cancelLabel={<FormattedMessage id="ui-quick-marc.record.delete.cancelLabel" />}
-        onConfirm={onConfirmModal}
-        onCancel={onCancelModal}
+        onConfirm={confirmDeleteFields}
+        onCancel={cancelDeleteFields}
       />
       {
         confirmRemoveAuthorityLinking && (
@@ -443,8 +461,8 @@ const QuickMarcEditor = ({
               message={<FormattedMessage id="ui-quick-marc.remove-authority-linking.modal.message" />}
               confirmLabel={<FormattedMessage id="ui-quick-marc.remove-authority-linking.modal.remove-linking" />}
               cancelLabel={<FormattedMessage id="ui-quick-marc.remove-authority-linking.modal.keep-linking" />}
-              onConfirm={handleRemoveLinking}
-              onCancel={handleKeepLinking}
+              onConfirm={confirmRemoveLinking}
+              onCancel={cancelRemoveLinking}
               buttonStyle="danger"
             />
           </IfPermission>
@@ -462,8 +480,8 @@ const QuickMarcEditor = ({
         }
         confirmLabel={<FormattedMessage id="ui-quick-marc.update-linked-bib-fields.modal.save" />}
         cancelLabel={<FormattedMessage id="ui-quick-marc.update-linked-bib-fields.modal.keep-editing" />}
-        onConfirm={handleUpdateLinkedFields}
-        onCancel={handleKeepEditingLinkedFields}
+        onConfirm={confirmUpdateLinks}
+        onCancel={cancelUpdateLinks}
       />
       <FormSpy
         subscription={spySubscription}


### PR DESCRIPTION
## Description
Fix delete fields and update links confirmations flow

## Approach
Create a state object `confirmationChecks` which stores flag which confirmations need to be run
After a check has been confirmed - set it's flag to `false`. Need this to skip this check when running `confirmSubmit` again
Reset `confirmationChecks` when clicking on submit buttons or using `mod+s` shortcut

## Screenshots

https://user-images.githubusercontent.com/19309423/214277355-2e853e34-55f9-4df3-ae38-0402ccd3816f.mp4


## Issues
[UIQM-347](https://issues.folio.org/browse/UIQM-347)