### PR TITLE
UIQM-348: Edit a MARC authority record | Do not allow user to delete 010 field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [UIQM-341](https://issues.folio.org/browse/UIQM-341) Error handling | Edit/Derive a new MARC bib record | User adds an invalid $9
 * [UIQM-368](https://issues.folio.org/browse/UIQM-368) Bump stripes to 8.0.0 for Orchid/2023-R1
 * [UIQM-359](https://issues.folio.org/browse/UIQM-359) Change to Linked MARC authority record has been updated confirmation messaging
+* [UIQM-348](https://issues.folio.org/browse/UIQM-348) Change to Linked MARC authority record has been updated confirmation messaging
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -1,6 +1,5 @@
 import React, {
   useCallback,
-  useEffect,
   useState,
 } from 'react';
 import { useLocation } from 'react-router';
@@ -10,7 +9,6 @@ import { useShowCallout } from '@folio/stripes-acq-components';
 
 import QuickMarcEditor from './QuickMarcEditor';
 
-import { useAuthorityLinksCount } from '../queries';
 import { QUICK_MARC_ACTIONS } from './constants';
 import {
   EXTERNAL_INSTANCE_APIS,
@@ -32,6 +30,7 @@ import {
 
 const propTypes = {
   action: PropTypes.oneOf(Object.values(QUICK_MARC_ACTIONS)).isRequired,
+  linksCount: PropTypes.number,
   refreshPageData: PropTypes.func.isRequired,
   externalRecordPath: PropTypes.string.isRequired,
   initialValues: PropTypes.object.isRequired,
@@ -49,6 +48,7 @@ const QuickMarcEditWrapper = ({
   initialValues,
   mutator,
   marcType,
+  linksCount,
   locations,
   refreshPageData,
   externalRecordPath,
@@ -56,9 +56,6 @@ const QuickMarcEditWrapper = ({
   const showCallout = useShowCallout();
   const location = useLocation();
   const [httpError, setHttpError] = useState(null);
-  const [linksCount, setLinksCount] = useState(0);
-
-  const { fetchLinksCount } = useAuthorityLinksCount();
 
   const prepareForSubmit = useCallback((formValues) => {
     const formValuesToSave = removeDeletedRecords(formValues);
@@ -182,14 +179,6 @@ const QuickMarcEditWrapper = ({
     location,
     prepareForSubmit,
   ]);
-
-  useEffect(() => {
-    if (marcType === MARC_TYPES.AUTHORITY) {
-      fetchLinksCount([instance.id])
-        .then(res => setLinksCount(res.links[0].totalLinks))
-        .catch(setHttpError);
-    }
-  }, [location.search, marcType, fetchLinksCount, instance.id]);
 
   return (
     <QuickMarcEditor

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.test.js
@@ -13,22 +13,10 @@ import arrayMutators from 'final-form-arrays';
 import '@folio/stripes-acq-components/test/jest/__mock__';
 
 import QuickMarcEditWrapper from './QuickMarcEditWrapper';
-import { useAuthorityLinksCount } from '../queries';
 import { QUICK_MARC_ACTIONS } from './constants';
 import { MARC_TYPES } from '../common/constants';
 
 import Harness from '../../test/jest/helpers/harness';
-
-const mockFetchLinksCount = jest.fn().mockResolvedValue();
-
-jest.mock('../queries', () => ({
-  ...jest.requireActual('../queries'),
-  useAuthorityLinksCount: jest.fn().mockReturnValue({
-    fetchLinksCount: jest.fn().mockResolvedValue({
-      links: [{ totalLinks: 0 }],
-    }),
-  }),
-}));
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
@@ -92,7 +80,7 @@ const mockRecords = {
     }, {
       tag: '005',
       content: '20221228135005.0',
-      id: '5aa1a643-b9f2-47e8-bb68-6c6457b5c9c5',
+      id: '5aa1a643-b9f2-47e8-bb68-6c6457b5c9c6',
     }, {
       tag: '999',
       indicators: ['f', 'f'],
@@ -445,29 +433,7 @@ describe('Given QuickMarcEditWrapper', () => {
   });
 
   describe('when is authority marc type', () => {
-    it('should make a request to get the number of links', async () => {
-      useAuthorityLinksCount.mockClear().mockReturnValue({
-        fetchLinksCount: mockFetchLinksCount,
-      });
-
-      renderQuickMarcEditWrapper({
-        instance,
-        mutator,
-        marcType: MARC_TYPES.AUTHORITY,
-      });
-
-      expect(mockFetchLinksCount).toHaveBeenCalledWith([instance.id]);
-    });
-
     describe('and record is linked to a bib record', () => {
-      beforeEach(() => {
-        useAuthorityLinksCount.mockClear().mockReturnValue({
-          fetchLinksCount: jest.fn().mockResolvedValue({
-            links: [{ totalLinks: 1 }],
-          }),
-        });
-      });
-
       describe('and changing 1XX field', () => {
         it('should display confirmation modal', async () => {
           const {
@@ -477,6 +443,7 @@ describe('Given QuickMarcEditWrapper', () => {
             instance,
             mutator,
             marcType: MARC_TYPES.AUTHORITY,
+            linksCount: 1,
           });
 
           await act(async () => { fireEvent.change(getByTestId('content-field-7'), { target: { value: '$a Civil war edited' } }); });

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -48,7 +48,9 @@ import {
   getCorrespondingMarcTag,
   getContentSubfieldValue,
   deleteRecordByIndex,
-  are010Or1xxUpdated,
+  is1XXUpdated,
+  is010Updated,
+  is010$aPopulatesBibField$0,
 } from './utils';
 import { useAuthorityLinking } from '../hooks';
 
@@ -159,10 +161,21 @@ const QuickMarcEditor = ({
       return;
     }
 
-    if (marcType === MARC_TYPES.AUTHORITY && linksCount > 0 && are010Or1xxUpdated(initialValues.records, records)) {
-      setIsUpdate0101xxfieldsAuthRecModalOpen(true);
+    if (marcType === MARC_TYPES.AUTHORITY && linksCount) {
+      if (is1XXUpdated(initialValues.records, records)) {
+        setIsUpdate0101xxfieldsAuthRecModalOpen(true);
 
-      return;
+        return;
+      }
+
+      if (
+        is010Updated(initialValues.records, records) &&
+        is010$aPopulatesBibField$0(initialValues.records, instance.naturalId)
+      ) {
+        setIsUpdate0101xxfieldsAuthRecModalOpen(true);
+
+        return;
+      }
     }
 
     handleSubmit(e)
@@ -179,6 +192,7 @@ const QuickMarcEditor = ({
     getState,
     validate,
     showCallout,
+    instance,
   ]);
 
   const paneFooter = useMemo(() => {
@@ -417,6 +431,7 @@ const QuickMarcEditor = ({
                     subtype={subtype}
                     marcType={marcType}
                     linksCount={linksCount}
+                    instance={instance}
                   />
                 </Col>
               </Row>
@@ -489,7 +504,7 @@ QuickMarcEditor.propTypes = {
     reset: PropTypes.func.isRequired,
   }),
   marcType: PropTypes.oneOf(Object.values(MARC_TYPES)).isRequired,
-  linksCount: PropTypes.number.isRequired,
+  linksCount: PropTypes.number,
   locations: PropTypes.arrayOf(PropTypes.object).isRequired,
   httpError: PropTypes.shape({
     code: PropTypes.string,

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -402,6 +402,7 @@ const QuickMarcEditor = ({
                     type={type}
                     subtype={subtype}
                     marcType={marcType}
+                    linksCount={linksCount}
                   />
                 </Col>
               </Row>

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -386,11 +386,14 @@ describe('Given QuickMarcEditor', () => {
     });
 
     describe('when 010 $a field is updated', () => {
+      const authority = { naturalId: 'n931006645' };
+
       describe('when click on save&close button', () => {
         it('should open confirmation modal', () => {
           const { getByTestId, getByText } = renderQuickMarcEditor({
             marcType: MARC_TYPES.AUTHORITY,
             linksCount: 1,
+            instance: authority,
           });
 
           const contentField = getByTestId('content-field-1');
@@ -405,6 +408,7 @@ describe('Given QuickMarcEditor', () => {
           const { queryByText, getByTestId, getByText } = renderQuickMarcEditor({
             marcType: MARC_TYPES.AUTHORITY,
             linksCount: 1,
+            instance: authority,
           });
 
           const contentField = getByTestId('content-field-1');
@@ -422,6 +426,7 @@ describe('Given QuickMarcEditor', () => {
           const { queryByText, getByTestId, getByText } = renderQuickMarcEditor({
             marcType: MARC_TYPES.AUTHORITY,
             linksCount: 1,
+            instance: authority,
             initialValues: {
               leader: 'assdfgs ds sdg',
               records: [
@@ -467,6 +472,7 @@ describe('Given QuickMarcEditor', () => {
           const { getByTestId, getByText } = renderQuickMarcEditor({
             marcType: MARC_TYPES.AUTHORITY,
             linksCount: 1,
+            instance: authority,
             initialValues: {
               leader: 'assdfgs ds sdg',
               records: [
@@ -509,6 +515,7 @@ describe('Given QuickMarcEditor', () => {
           const { queryByText, getByTestId, getByText } = renderQuickMarcEditor({
             marcType: MARC_TYPES.AUTHORITY,
             linksCount: 1,
+            instance: authority,
             initialValues: {
               leader: 'assdfgs ds sdg',
               records: [
@@ -554,6 +561,7 @@ describe('Given QuickMarcEditor', () => {
           const { queryByText, getByTestId, getByText } = renderQuickMarcEditor({
             marcType: MARC_TYPES.AUTHORITY,
             linksCount: 1,
+            instance: authority,
             initialValues: {
               leader: 'assdfgs ds sdg',
               records: [

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -68,6 +68,7 @@ const QuickMarcEditorRows = ({
     restoreRecord,
   },
   marcType,
+  linksCount,
 }) => {
   const stripes = useStripes();
   const intl = useIntl();
@@ -210,7 +211,7 @@ const QuickMarcEditorRows = ({
             const isDisabled = isReadOnly(recordRow, action, marcType);
             const withIndicators = !hasIndicatorException(recordRow);
             const withAddRowAction = hasAddException(recordRow, marcType);
-            const withDeleteRowAction = hasDeleteException(recordRow, marcType);
+            const withDeleteRowAction = hasDeleteException(recordRow, marcType, linksCount);
             const withMoveUpRowAction = hasMoveException(recordRow, fields[idx - 1]);
             const withMoveDownRowAction = hasMoveException(recordRow, fields[idx + 1]);
 
@@ -501,6 +502,7 @@ QuickMarcEditorRows.propTypes = {
     restoreRecord: PropTypes.func.isRequired,
   }),
   marcType: PropTypes.oneOf(Object.values(MARC_TYPES)).isRequired,
+  linksCount: PropTypes.number,
 };
 
 export default QuickMarcEditorRows;

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -34,16 +34,18 @@ import { DeletedRowPlaceholder } from './DeletedRowPlaceholder';
 import { LinkButton } from './LinkButton';
 import { SplitField } from './SplitField';
 import {
-  isReadOnly,
   hasIndicatorException,
   hasAddException,
-  hasDeleteException,
   hasMoveException,
+} from './utils';
+import {
+  checkCanBeLinked,
+  isFixedFieldRow,
   isMaterialCharsRecord,
   isPhysDescriptionRecord,
-  isFixedFieldRow,
-} from './utils';
-import { checkCanBeLinked } from '../utils';
+  isReadOnly,
+  hasDeleteException,
+} from '../utils';
 import { useAuthorityLinking } from '../../hooks';
 import { QUICK_MARC_ACTIONS } from '../constants';
 import {
@@ -69,6 +71,7 @@ const QuickMarcEditorRows = ({
   },
   marcType,
   linksCount,
+  instance,
 }) => {
   const stripes = useStripes();
   const intl = useIntl();
@@ -211,7 +214,7 @@ const QuickMarcEditorRows = ({
             const isDisabled = isReadOnly(recordRow, action, marcType);
             const withIndicators = !hasIndicatorException(recordRow);
             const withAddRowAction = hasAddException(recordRow, marcType);
-            const withDeleteRowAction = hasDeleteException(recordRow, marcType, linksCount);
+            const withDeleteRowAction = hasDeleteException(recordRow, marcType, linksCount, instance, initialValues);
             const withMoveUpRowAction = hasMoveException(recordRow, fields[idx - 1]);
             const withMoveDownRowAction = hasMoveException(recordRow, fields[idx + 1]);
 
@@ -480,6 +483,7 @@ const QuickMarcEditorRows = ({
 
 QuickMarcEditorRows.propTypes = {
   action: PropTypes.oneOf(Object.values(QUICK_MARC_ACTIONS)).isRequired,
+  instance: PropTypes.object,
   type: PropTypes.string.isRequired,
   subtype: PropTypes.string.isRequired,
   fields: PropTypes.arrayOf(PropTypes.shape({

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -16,6 +16,7 @@ import QuickMarcEditorRows from './QuickMarcEditorRows';
 import { LinkButton } from './LinkButton';
 import { useAuthorityLinking } from '../../hooks';
 import * as utils from './utils';
+import * as parentUtils from '../utils';
 import { QUICK_MARC_ACTIONS } from '../constants';
 import { MARC_TYPES } from '../../common/constants';
 
@@ -186,14 +187,14 @@ describe('Given QuickMarcEditorRows', () => {
   });
 
   it('should display row for each record value', () => {
-    const isReadOnlySpy = jest.spyOn(utils, 'isReadOnly');
+    const isReadOnlySpy = jest.spyOn(parentUtils, 'isReadOnly');
     const hasIndicatorExceptionSpy = jest.spyOn(utils, 'hasIndicatorException');
     const hasAddExceptionSpy = jest.spyOn(utils, 'hasAddException');
-    const hasDeleteExceptionSpy = jest.spyOn(utils, 'hasDeleteException');
+    const hasDeleteExceptionSpy = jest.spyOn(parentUtils, 'hasDeleteException');
     const hasMoveExceptionSpy = jest.spyOn(utils, 'hasMoveException');
-    const isFixedRowSpy = jest.spyOn(utils, 'isFixedFieldRow');
-    const isMaterialCharsRecordSpy = jest.spyOn(utils, 'isPhysDescriptionRecord');
-    const isPhysDescriptionRecordSpy = jest.spyOn(utils, 'isMaterialCharsRecord');
+    const isFixedRowSpy = jest.spyOn(parentUtils, 'isFixedFieldRow');
+    const isMaterialCharsRecordSpy = jest.spyOn(parentUtils, 'isPhysDescriptionRecord');
+    const isPhysDescriptionRecordSpy = jest.spyOn(parentUtils, 'isMaterialCharsRecord');
 
     renderQuickMarcEditorRows();
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -4,47 +4,6 @@ import {
 } from '../constants';
 import { MARC_TYPES } from '../../common/constants';
 
-export const isLastRecord = recordRow => {
-  return (
-    recordRow.tag === '999'
-    && recordRow.indicators
-    && recordRow.indicators[0] === 'f'
-    && recordRow.indicators[1] === 'f'
-  );
-};
-
-const READ_ONLY_ROWS = new Set(['001', '005']);
-
-const READ_ONLY_ROWS_FOR_DERIVE = new Set(['001', '005']);
-
-const READ_ONLY_ROWS_FOR_HOLDINGS = new Set(['001', '004', '005']);
-
-const READ_ONLY_ROWS_FOR_AUTHORITIES = new Set(['001', '005']);
-
-export const isReadOnly = (
-  recordRow,
-  action = QUICK_MARC_ACTIONS.EDIT,
-  marcType = MARC_TYPES.BIB,
-) => {
-  let rows;
-
-  if (marcType === MARC_TYPES.BIB && recordRow._isLinked) {
-    return true;
-  }
-
-  if (marcType === MARC_TYPES.BIB) {
-    rows = action === QUICK_MARC_ACTIONS.DERIVE
-      ? READ_ONLY_ROWS_FOR_DERIVE
-      : READ_ONLY_ROWS;
-  } else if (marcType === MARC_TYPES.HOLDINGS) {
-    rows = READ_ONLY_ROWS_FOR_HOLDINGS;
-  } else {
-    rows = READ_ONLY_ROWS_FOR_AUTHORITIES;
-  }
-
-  return rows.has(recordRow.tag) || isLastRecord(recordRow);
-};
-
 const INDICATOR_EXEPTION_ROWS = new Set([LEADER_TAG, '001', '002', '003', '004', '005', '006', '007', '008', '009']);
 
 export const hasIndicatorException = recordRow => INDICATOR_EXEPTION_ROWS.has(recordRow.tag);
@@ -57,26 +16,6 @@ const ADD_EXCEPTION_ROWS = {
 
 export const hasAddException = (recordRow, marcType = MARC_TYPES.BIB) => {
   return ADD_EXCEPTION_ROWS[marcType].has(recordRow.tag);
-};
-
-const DELETE_EXCEPTION_ROWS = {
-  [MARC_TYPES.AUTHORITY]: new Set([LEADER_TAG, '001', '003', '005', '008']),
-  [MARC_TYPES.HOLDINGS]: new Set([LEADER_TAG, '001', '003', '004', '005', '008', '852']),
-  [MARC_TYPES.BIB]: new Set([LEADER_TAG, '001', '003', '005', '008', '245']),
-};
-
-const is1XXField = (tag) => tag && tag[0] === '1';
-
-export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB, linksCount = 0) => {
-  const rows = DELETE_EXCEPTION_ROWS[marcType];
-
-  if (marcType === MARC_TYPES.AUTHORITY) {
-    if (is1XXField(recordRow.tag) || (recordRow.tag === '010' && linksCount > 0)) {
-      return true;
-    }
-  }
-
-  return rows.has(recordRow.tag) || isLastRecord(recordRow);
 };
 
 const MOVE_EXCEPTION_ROWS = new Set([LEADER_TAG, '001', '005', '008']);
@@ -94,7 +33,3 @@ export const hasMoveException = (recordRow, sibling, action = QUICK_MARC_ACTIONS
     || rows.has(sibling.tag)
   );
 };
-
-export const isMaterialCharsRecord = recordRow => recordRow.tag === '006';
-export const isPhysDescriptionRecord = recordRow => recordRow.tag === '007';
-export const isFixedFieldRow = recordRow => recordRow.tag === '008';

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -67,10 +67,14 @@ const DELETE_EXCEPTION_ROWS = {
 
 const is1XXField = (tag) => tag[0] === '1';
 
-export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB) => {
+export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB, linksCount = 0) => {
   const rows = DELETE_EXCEPTION_ROWS[marcType];
 
-  if (marcType === MARC_TYPES.AUTHORITY && is1XXField(recordRow.tag)) return true;
+  if (marcType === MARC_TYPES.AUTHORITY) {
+    if (is1XXField(recordRow.tag) || (recordRow.tag === '010' && linksCount > 0)) {
+      return true;
+    }
+  }
 
   return rows.has(recordRow.tag) || isLastRecord(recordRow);
 };

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
@@ -106,6 +106,9 @@ describe('QuickMarcEditorRows utils', () => {
       it('should be true for 1XX tags', () => {
         expect(utils.hasDeleteException({ tag: '150' }, MARC_TYPES.AUTHORITY)).toBeTruthy();
       });
+      it('should be true for tag 010 that populates bib field(s)', () => {
+        expect(utils.hasDeleteException({ tag: '010' }, MARC_TYPES.AUTHORITY, 1)).toBeTruthy();
+      });
     });
   });
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
@@ -7,48 +7,6 @@ import { MARC_TYPES } from '../../common/constants';
 import * as utils from './utils';
 
 describe('QuickMarcEditorRows utils', () => {
-  describe('isReadOnly', () => {
-    it('should be true for record start', () => {
-      expect(utils.isReadOnly({ tag: '001' })).toBeTruthy();
-    });
-
-    describe('when record type equals BIB', () => {
-      it('should be true for tag 004', () => {
-        expect(utils.isReadOnly({ tag: '004' })).toBeFalsy();
-      });
-    });
-
-    describe('when record type equals HOLDINGS', () => {
-      it('should be true for tag 004', () => {
-        expect(utils.isReadOnly(
-          { tag: '004' },
-          QUICK_MARC_ACTIONS.EDIT,
-          MARC_TYPES.HOLDINGS,
-        )).toBeTruthy();
-      });
-    });
-
-    it('should be true for tag 005 (Date and Time of Latest Transaction)', () => {
-      expect(utils.isReadOnly({ tag: '005' })).toBeTruthy();
-    });
-
-    it('should be true for record end', () => {
-      expect(utils.isReadOnly({ tag: '999', indicators: ['f', 'f'] })).toBeTruthy();
-    });
-
-    it('should be false for record rows', () => {
-      expect(utils.isReadOnly({ tag: LEADER_TAG })).toBeFalsy();
-      expect(utils.isReadOnly({ tag: '002' })).toBeFalsy();
-      expect(utils.isReadOnly({ tag: '050' })).toBeFalsy();
-      expect(utils.isReadOnly({ tag: '998' })).toBeFalsy();
-      expect(utils.isReadOnly({ tag: '999' })).toBeFalsy();
-    });
-
-    it('should be true for tag LDR on derive page', () => {
-      expect(utils.isReadOnly({ tag: '005' }, QUICK_MARC_ACTIONS.DERIVE)).toBeTruthy();
-    });
-  });
-
   describe('hasIndicatorException', () => {
     it('should be true for exeptional row', () => {
       expect(utils.hasIndicatorException({ tag: '001' })).toBeTruthy();
@@ -76,42 +34,6 @@ describe('QuickMarcEditorRows utils', () => {
     });
   });
 
-  describe('hasDeleteException', () => {
-    it('should be true for exeptional row', () => {
-      expect(utils.hasDeleteException({ tag: LEADER_TAG })).toBeTruthy();
-      expect(utils.hasDeleteException({ tag: '001' })).toBeTruthy();
-    });
-
-    it('should be true for record end', () => {
-      expect(utils.hasDeleteException({ tag: '999', indicators: ['f', 'f'] })).toBeTruthy();
-    });
-
-    it('should be false for exeptional row', () => {
-      expect(utils.hasDeleteException({ tag: '010' })).toBeFalsy();
-    });
-
-    describe('when record type equals BIB', () => {
-      it('should be true for tag 245', () => {
-        expect(utils.hasDeleteException({ tag: '245' }, MARC_TYPES.BIB)).toBeTruthy();
-      });
-    });
-
-    describe('when record type equals HOLDINGS', () => {
-      it('should be true for tag 004', () => {
-        expect(utils.hasDeleteException({ tag: '004' }, MARC_TYPES.HOLDINGS)).toBeTruthy();
-      });
-    });
-
-    describe('when record type equals AUTHORITY', () => {
-      it('should be true for 1XX tags', () => {
-        expect(utils.hasDeleteException({ tag: '150' }, MARC_TYPES.AUTHORITY)).toBeTruthy();
-      });
-      it('should be true for tag 010 that populates bib field(s)', () => {
-        expect(utils.hasDeleteException({ tag: '010' }, MARC_TYPES.AUTHORITY, 1)).toBeTruthy();
-      });
-    });
-  });
-
   describe('hasMoveException', () => {
     it('should be true for exeptional row', () => {
       expect(utils.hasMoveException({ tag: LEADER_TAG })).toBeTruthy();
@@ -124,36 +46,6 @@ describe('QuickMarcEditorRows utils', () => {
 
     it('should be false for common rows', () => {
       expect(utils.hasMoveException({ tag: '010' }, { tag: '011' })).toBeFalsy();
-    });
-  });
-
-  describe('isMaterialCharsRecord', () => {
-    it('should be true for exeptional row', () => {
-      expect(utils.isMaterialCharsRecord({ tag: '006' })).toBeTruthy();
-    });
-
-    it('should be false for common rows', () => {
-      expect(utils.isMaterialCharsRecord({ tag: '010' })).toBeFalsy();
-    });
-  });
-
-  describe('isPhysDescriptionRecord', () => {
-    it('should be true for exeptional row', () => {
-      expect(utils.isPhysDescriptionRecord({ tag: '007' })).toBeTruthy();
-    });
-
-    it('should be false for common rows', () => {
-      expect(utils.isPhysDescriptionRecord({ tag: '010' })).toBeFalsy();
-    });
-  });
-
-  describe('isFixedFieldRow', () => {
-    it('should be true for exeptional row', () => {
-      expect(utils.isFixedFieldRow({ tag: '008' })).toBeTruthy();
-    });
-
-    it('should be false for common rows', () => {
-      expect(utils.isFixedFieldRow({ tag: '010' })).toBeFalsy();
     });
   });
 });

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -10,12 +10,6 @@ import toPairs from 'lodash/toPairs';
 import flatten from 'lodash/flatten';
 
 import {
-  isLastRecord,
-  isFixedFieldRow,
-  isMaterialCharsRecord,
-  isPhysDescriptionRecord,
-} from './QuickMarcEditorRows/utils';
-import {
   LEADER_TAG,
   FIELD_TAGS_TO_REMOVE,
   FIELDS_TAGS_WITHOUT_DEFAULT_SUBFIELDS,
@@ -37,6 +31,19 @@ import {
   MARC_TYPES,
   ERROR_TYPES,
 } from '../common/constants';
+
+export const isLastRecord = recordRow => {
+  return (
+    recordRow.tag === '999'
+    && recordRow.indicators
+    && recordRow.indicators[0] === 'f'
+    && recordRow.indicators[1] === 'f'
+  );
+};
+
+export const isFixedFieldRow = recordRow => recordRow.tag === '008';
+export const isMaterialCharsRecord = recordRow => recordRow.tag === '006';
+export const isPhysDescriptionRecord = recordRow => recordRow.tag === '007';
 
 export const getContentSubfieldValue = (content) => {
   return content.split(/\$/)
@@ -899,6 +906,13 @@ export const splitFields = marcRecord => {
   };
 };
 
+export const is010$aPopulatesBibField$0 = (initialRecords, naturalId) => {
+  const initial010Field = initialRecords.find(record => record.tag === '010');
+  const initial010$a = getContentSubfieldValue(initial010Field.content).$a;
+
+  return naturalId === initial010$a?.replaceAll(' ', '');
+};
+
 export const is010Updated = (initial, updated) => {
   const initial010 = initial.find(rec => rec.tag === '010');
   const updated010 = updated.find(rec => rec.tag === '010');
@@ -927,4 +941,59 @@ export const is1XXUpdated = (initial, updated) => {
 
 export const are010Or1xxUpdated = (initial, updated) => {
   return is010Updated(initial, updated) || is1XXUpdated(initial, updated);
+};
+
+const DELETE_EXCEPTION_ROWS = {
+  [MARC_TYPES.AUTHORITY]: new Set([LEADER_TAG, '001', '003', '005', '008']),
+  [MARC_TYPES.HOLDINGS]: new Set([LEADER_TAG, '001', '003', '004', '005', '008', '852']),
+  [MARC_TYPES.BIB]: new Set([LEADER_TAG, '001', '003', '005', '008', '245']),
+};
+
+const is1XXField = (tag) => tag && tag[0] === '1';
+
+export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB, linksCount, authority, initialValues) => {
+  const rows = DELETE_EXCEPTION_ROWS[marcType];
+
+  if (marcType === MARC_TYPES.AUTHORITY) {
+    if (
+      is1XXField(recordRow.tag) ||
+      (recordRow.tag === '010' && linksCount && is010$aPopulatesBibField$0(initialValues.records, authority.naturalId))
+    ) {
+      return true;
+    }
+  }
+
+  return rows.has(recordRow.tag) || isLastRecord(recordRow);
+};
+
+const READ_ONLY_ROWS = new Set(['001', '005']);
+
+const READ_ONLY_ROWS_FOR_DERIVE = new Set(['001', '005']);
+
+const READ_ONLY_ROWS_FOR_HOLDINGS = new Set(['001', '004', '005']);
+
+const READ_ONLY_ROWS_FOR_AUTHORITIES = new Set(['001', '005']);
+
+export const isReadOnly = (
+  recordRow,
+  action = QUICK_MARC_ACTIONS.EDIT,
+  marcType = MARC_TYPES.BIB,
+) => {
+  let rows;
+
+  if (marcType === MARC_TYPES.BIB && recordRow._isLinked) {
+    return true;
+  }
+
+  if (marcType === MARC_TYPES.BIB) {
+    rows = action === QUICK_MARC_ACTIONS.DERIVE
+      ? READ_ONLY_ROWS_FOR_DERIVE
+      : READ_ONLY_ROWS;
+  } else if (marcType === MARC_TYPES.HOLDINGS) {
+    rows = READ_ONLY_ROWS_FOR_HOLDINGS;
+  } else {
+    rows = READ_ONLY_ROWS_FOR_AUTHORITIES;
+  }
+
+  return rows.has(recordRow.tag) || isLastRecord(recordRow);
 };

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -919,24 +919,18 @@ export const splitFields = marcRecord => {
   };
 };
 
-export const are010Or1xxUpdated = (initial, updated) => {
-  let is010Updated = false;
-  let is1XXUpdated = false;
+export const is010Updated = (initial, updated) => {
+  const initial010 = initial.find(rec => rec.tag === '010');
+  const updated010 = updated.find(rec => rec.tag === '010');
 
-  const authRec010Tag = '010';
-  const initial010 = initial.find(rec => rec.tag === authRec010Tag);
-  const updated010 = updated.find(rec => rec.tag === authRec010Tag);
-
-  if (initial010 &&
+  return initial010 &&
     updated010 &&
-    getContentSubfieldValue(initial010.content).$a !== getContentSubfieldValue(updated010.content).$a
-  ) {
-    is010Updated = true;
-  }
+    getContentSubfieldValue(initial010.content).$a !== getContentSubfieldValue(updated010.content).$a;
+};
 
-  const authRec1XXTagStartsWith = '1';
-  const initial1xxRecords = initial.filter(rec => rec.tag[0] === authRec1XXTagStartsWith);
-  const updated1xxRecords = updated.filter(rec => rec.tag[0] === authRec1XXTagStartsWith);
+export const is1XXUpdated = (initial, updated) => {
+  const initial1xxRecords = initial.filter(rec => rec.tag[0] === '1');
+  const updated1xxRecords = updated.filter(rec => rec.tag[0] === '1');
 
   const updated1xxArr = [];
 
@@ -948,9 +942,9 @@ export const are010Or1xxUpdated = (initial, updated) => {
     }
   });
 
-  if (updated1xxArr.length) {
-    is1XXUpdated = true;
-  }
+  return !!updated1xxArr.length;
+};
 
-  return is010Updated || is1XXUpdated;
+export const are010Or1xxUpdated = (initial, updated) => {
+  return is010Updated(initial, updated) || is1XXUpdated(initial, updated);
 };

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1755,4 +1755,87 @@ describe('QuickMarcEditor utils', () => {
       expect(utils.are010Or1xxUpdated(initial, updated)).toBeTruthy();
     });
   });
+
+  describe('hasDeleteException', () => {
+    it('should be true for exeptional row', () => {
+      expect(utils.hasDeleteException({ tag: LEADER_TAG })).toBeTruthy();
+      expect(utils.hasDeleteException({ tag: '001' })).toBeTruthy();
+    });
+
+    it('should be true for record end', () => {
+      expect(utils.hasDeleteException({ tag: '999', indicators: ['f', 'f'] })).toBeTruthy();
+    });
+
+    it('should be false for exeptional row', () => {
+      expect(utils.hasDeleteException({ tag: '010' })).toBeFalsy();
+    });
+
+    describe('when record type equals BIB', () => {
+      it('should be true for tag 245', () => {
+        expect(utils.hasDeleteException({ tag: '245' }, MARC_TYPES.BIB)).toBeTruthy();
+      });
+    });
+
+    describe('when record type equals HOLDINGS', () => {
+      it('should be true for tag 004', () => {
+        expect(utils.hasDeleteException({ tag: '004' }, MARC_TYPES.HOLDINGS)).toBeTruthy();
+      });
+    });
+
+    describe('when record type equals AUTHORITY', () => {
+      it('should be true for 1XX tags', () => {
+        expect(utils.hasDeleteException({ tag: '150' }, MARC_TYPES.AUTHORITY)).toBeTruthy();
+      });
+
+      it('should be true for tag 010 that populates bib field(s)', () => {
+        const authority = { naturalId: 'n79018119' };
+        const initialValues = { records: [{ tag: '010', content: '$a n  79018119' }] };
+        const linksCount = 1;
+
+        expect(utils.hasDeleteException({ tag: '010' }, MARC_TYPES.AUTHORITY, linksCount, authority, initialValues)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('isReadOnly', () => {
+    it('should be true for record start', () => {
+      expect(utils.isReadOnly({ tag: '001' })).toBeTruthy();
+    });
+
+    describe('when record type equals BIB', () => {
+      it('should be true for tag 004', () => {
+        expect(utils.isReadOnly({ tag: '004' })).toBeFalsy();
+      });
+    });
+
+    describe('when record type equals HOLDINGS', () => {
+      it('should be true for tag 004', () => {
+        expect(utils.isReadOnly(
+          { tag: '004' },
+          QUICK_MARC_ACTIONS.EDIT,
+          MARC_TYPES.HOLDINGS,
+        )).toBeTruthy();
+      });
+    });
+
+    it('should be true for tag 005 (Date and Time of Latest Transaction)', () => {
+      expect(utils.isReadOnly({ tag: '005' })).toBeTruthy();
+    });
+
+    it('should be true for record end', () => {
+      expect(utils.isReadOnly({ tag: '999', indicators: ['f', 'f'] })).toBeTruthy();
+    });
+
+    it('should be false for record rows', () => {
+      expect(utils.isReadOnly({ tag: LEADER_TAG })).toBeFalsy();
+      expect(utils.isReadOnly({ tag: '002' })).toBeFalsy();
+      expect(utils.isReadOnly({ tag: '050' })).toBeFalsy();
+      expect(utils.isReadOnly({ tag: '998' })).toBeFalsy();
+      expect(utils.isReadOnly({ tag: '999' })).toBeFalsy();
+    });
+
+    it('should be true for tag LDR on derive page', () => {
+      expect(utils.isReadOnly({ tag: '005' }, QUICK_MARC_ACTIONS.DERIVE)).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
When the authority record controls a bib record and 010 $a populates any bib field $0:
- do not allow a user to delete the 010 field;
- and if a user edits 010 $a then show the modal.

## Description
- moved child utils to the parent one to fix circle dependency
- moved useAuthorityLinksCount to the parent component to hide the trash icon until the page loads.

## Issues
[UIQM-348](https://issues.folio.org/browse/UIQM-348)

## Screencast






https://user-images.githubusercontent.com/77053927/214580295-cb016162-2772-4160-aa2b-c5c879e9c60f.mp4







<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
