### PR TITLE
UIQM-367: Show an error toast message when user enters a subfield that is/can be controlled by an authority record or is the linking match point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [UIQM-349](https://issues.folio.org/browse/UIQM-349) Align the module with mod-search API breaking change
 * [UIQM-348](https://issues.folio.org/browse/UIQM-348) Change to Linked MARC authority record has been updated confirmation messaging
 * [UIQM-390](https://issues.folio.org/browse/UIQM-390) Fix exception when changing tag value to "010" in "MARC authority" record without "010" field
+* [UIQM-367](https://issues.folio.org/browse/UIQM-367) Show an error toast message when user enters a subfield that is/can be controlled by an authority record or is the linking match point
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -445,6 +445,132 @@ describe('QuickMarcEditor utils', () => {
       });
     });
 
+    describe('when a user enters into the linked field subfield(s) that can be controlled', () => {
+      const initialValues = {
+        leader: '04706cam a2200865Ii 4500',
+        records: [
+          {
+            content: '04706cam a2200865Ii 4500',
+            tag: 'LDR',
+          },
+          {
+            tag: '008',
+            content: {
+              Desc: 'i',
+            },
+          },
+          {
+            tag: '245',
+          },
+          {
+            'tag': '100',
+            'content': '$a Kerouac, Jack, $d 1922-1969 $0 http://id.loc.gov/authorities/names/n80036674 $9 7e192d19-1e56-4f0e-9c06-8c601504377e',
+            'indicators': ['1', '\\'],
+            'isProtected': false,
+            'authorityId': '7e192d19-1e56-4f0e-9c06-8c601504377e',
+            'authorityNaturalId': 'n80036674',
+            'authorityControlledSubfields': ['a', 'b', 'c', 'd', 'j', 'q'],
+            'subfieldGroups': {
+              'controlled': '$a Kerouac, Jack, $d 1922-1969',
+              'uncontrolledAlpha': '',
+              'zeroSubfield': '$0 http://id.loc.gov/authorities/names/n80036674',
+              'nineSubfield': '$9 7e192d19-1e56-4f0e-9c06-8c601504377e',
+              'uncontrolledNumber': '',
+            },
+          },
+          {
+            'tag': '600',
+            'content': '$a Kerouac, Jack, $d 1922-1969 $0 http://id.loc.gov/authorities/names/n80036674 $9 7e192d19-1e56-4f0e-9c06-8c601504377e',
+            'indicators': ['1', '0'],
+            'isProtected': false,
+            'authorityId': '7e192d19-1e56-4f0e-9c06-8c601504377e',
+            'authorityNaturalId': 'n80036674',
+            'authorityControlledSubfields': ['a', 'b', 'c', 'd', 'g', 'j', 'q', 'f', 'h', 'k', 'l', 'm', 'n'],
+            'subfieldGroups': {
+              'controlled': '$a Kerouac, Jack, $d 1922-1969',
+              'uncontrolledAlpha': '',
+              'zeroSubfield': '$0 http://id.loc.gov/authorities/names/n80036674',
+              'nineSubfield': '$9 7e192d19-1e56-4f0e-9c06-8c601504377e',
+              'uncontrolledNumber': '',
+            },
+          },
+          {
+            'tag': '600',
+            'content': '$a Chin, Staceyann, $d 1972- $0 http://id.loc.gov/authorities/names/n2008052404 $9 2f4f9df2-3ee1-4fd7-8ab0-63bdc16f5c4a $2 fast',
+            'indicators': ['1', '7'],
+            'isProtected': false,
+            'authorityId': '2f4f9df2-3ee1-4fd7-8ab0-63bdc16f5c4a',
+            'authorityNaturalId': 'n2008052404',
+            'authorityControlledSubfields': ['a', 'b', 'c', 'd', 'g', 'j', 'q', 'f', 'h', 'k', 'l', 'm', 'n'],
+            'subfieldGroups': {
+              'controlled': '$a Chin, Staceyann, $d 1972-',
+              'uncontrolledAlpha': '',
+              'zeroSubfield': '$0 http://id.loc.gov/authorities/names/n2008052404',
+              'nineSubfield': '$9 2f4f9df2-3ee1-4fd7-8ab0-63bdc16f5c4a',
+              'uncontrolledNumber': '$2 fast',
+            },
+          },
+          {
+            'tag': '650',
+            'content': '$a Speaking Oratory $b debating $0 http://id.loc.gov/authorities/subjects/sh85095299 $9 40415102-4205-455d-94bd-d1a655f91e90 $2 fast',
+            'indicators': ['\\', '7'],
+            'isProtected': false,
+            'authorityId': '40415102-4205-455d-94bd-d1a655f91e90',
+            'authorityNaturalId': 'sh85095299',
+            'authorityControlledSubfields': ['a', 'b', 'g', 'v', 'x', 'y', 'z'],
+            'subfieldGroups': {
+              'controlled': '$a Speaking Oratory $b debating',
+              'uncontrolledAlpha': '',
+              'zeroSubfield': '$0 http://id.loc.gov/authorities/subjects/sh85095299',
+              'nineSubfield': '$9 40415102-4205-455d-94bd-d1a655f91e90',
+              'uncontrolledNumber': '$2 fast',
+            },
+          },
+        ],
+      };
+
+      it('should return an error', () => {
+        const record = cloneDeep(initialValues);
+
+        record.records[3].subfieldGroups.uncontrolledAlpha = '$q fakeValue1';
+
+        expect(utils.validateMarcRecord({
+          marcRecord: record,
+          initialValues,
+        }).props).toEqual({
+          id: 'ui-quick-marc.record.error.subfield(s)CantBeSaved',
+          values: {
+            fieldCount: 1,
+            fieldTags: 'MARC 100',
+            lastFieldTag: 'MARC 100',
+          },
+        });
+      });
+
+      describe('and there are fields with the same tags', () => {
+        it('should return an error without duplicate tags', () => {
+          const record = cloneDeep(initialValues);
+
+          record.records[3].subfieldGroups.uncontrolledAlpha = '$q fakeValue1';
+          record.records[4].subfieldGroups.uncontrolledAlpha = '$m fakeValue2';
+          record.records[5].subfieldGroups.uncontrolledAlpha = '$n fakeValue3';
+          record.records[6].subfieldGroups.uncontrolledAlpha = '$g fakeValue4';
+
+          expect(utils.validateMarcRecord({
+            marcRecord: record,
+            initialValues,
+          }).props).toEqual({
+            id: 'ui-quick-marc.record.error.subfield(s)CantBeSaved',
+            values: {
+              fieldCount: 3,
+              fieldTags: 'MARC 100, MARC 600',
+              lastFieldTag: 'MARC 650',
+            },
+          });
+        });
+      });
+    });
+
     describe('when record is MARC Holdings record', () => {
       it('should not return error message when record is valid', () => {
         const initialValues = { records: [] };

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -186,6 +186,7 @@
   "record.error.1xx.change": "Cannot change the <b>saved MARC authority field {tag}</b> because it controls a bibliographic field(s). To change this 1XX, you must unlink all controlled bibliographic fields.",
   "record.error.1xx.add$t": "Cannot add a <b>$t to the ${tag} field</b> because it controls a bibliographic field(s) that cannot control this subfield. To change this 1XX value, you must unlink all controlled bibliographic fields that cannot control $t.",
   "record.error.1xx.remove$t": "Cannot remove <b>$t from the ${tag} field</b> because it controls a bibliographic field(s) that requires  this subfield. To change this 1XX value, you must unlink all controlled bibliographic fields that requires $t to be controlled.",
+  "record.error.subfield(s)CantBeSaved": "<b>{fieldTags}{fieldCount, plural, one {} =2 { and {lastFieldTag}} other {, and {lastFieldTag}}}</b> has a subfield(s) that cannot be saved because the field is controlled by an authority record.",
 
   "record.delete.confirmLabel": "Continue with save",
   "record.delete.cancelLabel": "Restore deleted field(s)",


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Show an error toast message when a user enters a subfield that can be controlled.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-367](https://issues.folio.org/browse/UIQM-367)

## Screencast


https://user-images.githubusercontent.com/77053927/215699450-7c03db01-f101-4862-8f3f-ac9460a58cb7.mp4


## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
