### PR TITLE
UIQM-385 Edit/Derive quickMARC | Allow user to drag text boxes to view all content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [UIQM-349](https://issues.folio.org/browse/UIQM-349) Align the module with mod-search API breaking change
 * [UIQM-348](https://issues.folio.org/browse/UIQM-348) Change to Linked MARC authority record has been updated confirmation messaging
 * [UIQM-390](https://issues.folio.org/browse/UIQM-390) Fix exception when changing tag value to "010" in "MARC authority" record without "010" field
+* [UIQM-385](https://issues.folio.org/browse/UIQM-385) Edit/Derive quickMARC | Allow user to drag text boxes to view all content 
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -47,7 +47,10 @@ import {
   hasDeleteException,
 } from '../utils';
 import { useAuthorityLinking } from '../../hooks';
-import { QUICK_MARC_ACTIONS } from '../constants';
+import {
+  QUICK_MARC_ACTIONS,
+  LEADER_TAG,
+} from '../constants';
 import {
   MARC_TYPES,
   TAG_FIELD_MAX_LENGTH,
@@ -79,8 +82,14 @@ const QuickMarcEditorRows = ({
   const containerRef = useRef(null);
   const indexOfNewRow = useRef(null);
   const newRowRef = useRef(null);
+  const leaderInputWidth = useRef(null); // for max-width of resizable textareas
 
-  const { linkAuthority, unlinkAuthority, linkableBibFields, sourceFiles } = useAuthorityLinking();
+  const {
+    linkAuthority,
+    unlinkAuthority,
+    linkableBibFields,
+    sourceFiles,
+  } = useAuthorityLinking();
 
   const isNewRow = useCallback((row) => {
     return !initialValues.records.find(record => record.id === row.id);
@@ -95,6 +104,10 @@ const QuickMarcEditorRows = ({
       newRowRef.current.focus();
     });
   }, [addRecord]);
+
+  const setLeaderInputWidth = (el) => {
+    leaderInputWidth.current = el?.offsetWidth;
+  };
 
   const getNextFocusableElement = (row) => {
     const prevRow = row.previousElementSibling;
@@ -210,6 +223,7 @@ const QuickMarcEditorRows = ({
               );
             }
 
+            const isLeader = recordRow.tag === LEADER_TAG;
             const isDisabled = isReadOnly(recordRow, action, marcType);
             const withIndicators = !hasIndicatorException(recordRow);
             const withAddRowAction = hasAddException(recordRow, marcType);
@@ -374,7 +388,10 @@ const QuickMarcEditorRows = ({
                   }
                 </div>
 
-                <div className={styles.quickMarcEditorRowContent}>
+                <div
+                  className={styles.quickMarcEditorRowContent}
+                  ref={isLeader ? setLeaderInputWidth : null}
+                >
                   {
                     isMaterialCharsField && (
                       <MaterialCharsField
@@ -412,7 +429,10 @@ const QuickMarcEditorRows = ({
                     isContentField && (
                       recordRow._isLinked
                         ? (
-                          <SplitField name={name} />
+                          <SplitField
+                            name={name}
+                            maxWidth={leaderInputWidth.current}
+                          />
                         )
                         : (
                           <Field

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -82,7 +82,7 @@ const QuickMarcEditorRows = ({
   const containerRef = useRef(null);
   const indexOfNewRow = useRef(null);
   const newRowRef = useRef(null);
-  const leaderInputWidth = useRef(null); // for max-width of resizable textareas
+  const rowContentWidth = useRef(null); // for max-width of resizable textareas
 
   const {
     linkAuthority,
@@ -105,8 +105,8 @@ const QuickMarcEditorRows = ({
     });
   }, [addRecord]);
 
-  const setLeaderInputWidth = (el) => {
-    leaderInputWidth.current = el?.offsetWidth;
+  const setRowContentWidthOnce = (el) => {
+    rowContentWidth.current = el?.offsetWidth;
   };
 
   const getNextFocusableElement = (row) => {
@@ -390,7 +390,7 @@ const QuickMarcEditorRows = ({
 
                 <div
                   className={styles.quickMarcEditorRowContent}
-                  ref={isLeader ? setLeaderInputWidth : null}
+                  ref={isLeader ? setRowContentWidthOnce : null}
                 >
                   {
                     isMaterialCharsField && (
@@ -431,7 +431,7 @@ const QuickMarcEditorRows = ({
                         ? (
                           <SplitField
                             name={name}
-                            maxWidth={leaderInputWidth.current}
+                            maxWidth={rowContentWidth.current}
                           />
                         )
                         : (

--- a/src/QuickMarcEditor/QuickMarcEditorRows/SplitField/SplitField.css
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/SplitField/SplitField.css
@@ -1,5 +1,12 @@
 .splitFieldWrapper {
-  display: inline-block;
   width: auto;
   margin-right: 15px;
+  resize: horizontal;
+  max-height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.splitFieldRoot {
+  display: inline-block;
 }

--- a/src/QuickMarcEditor/QuickMarcEditorRows/SplitField/SplitField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/SplitField/SplitField.js
@@ -4,16 +4,18 @@ import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 
-import { TextField } from '@folio/stripes/components';
+import { TextArea } from '@folio/stripes/components';
 
 import css from './SplitField.css';
 
 const propTypes = {
   name: PropTypes.string.isRequired,
+  maxWidth: PropTypes.number,
 };
 
 const SplitField = ({
   name,
+  maxWidth,
 }) => {
   const intl = useIntl();
 
@@ -21,13 +23,14 @@ const SplitField = ({
     return (
       <Field
         className={css.splitFieldWrapper}
-        component={TextField}
-        fullWidth
+        component={TextArea}
+        rootClass={css.splitFieldRoot}
         hasClearIcon={false}
         dirty={false}
         aria-label={intl.formatMessage({ id: 'ui-quick-marc.record.subfield' })}
         marginBottom0
         parse={v => v}
+        style={{ maxWidth: maxWidth - 15 }} // 15px for margin-right
         {...fieldProps}
       />
     );
@@ -43,6 +46,7 @@ const SplitField = ({
           {renderSubfieldGroup({
             disabled: true,
             name: `${name}.subfieldGroups.controlled`,
+            fitContent: true,
           })}
           {renderSubfieldGroup({
             disabled: false,
@@ -51,6 +55,7 @@ const SplitField = ({
           {renderSubfieldGroup({
             disabled: true,
             name: `${name}.subfieldGroups.zeroSubfield`,
+            fitContent: true,
           })}
           {renderSubfieldGroup({
             disabled: false,

--- a/src/QuickMarcEditor/QuickMarcEditorRows/SplitField/SplitField.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/SplitField/SplitField.test.js
@@ -39,10 +39,10 @@ describe('Given SplitField', () => {
   it('should disable controlled and zero subfield inputs', async () => {
     const { container } = renderSplitField();
 
-    const controlled = container.querySelector('input[name="test.subfieldGroups.controlled"]');
-    const uncontrolledAlpha = container.querySelector('input[name="test.subfieldGroups.uncontrolledAlpha"]');
-    const uncontrolledNumber = container.querySelector('input[name="test.subfieldGroups.uncontrolledNumber"]');
-    const zeroSubfield = container.querySelector('input[name="test.subfieldGroups.zeroSubfield"]');
+    const controlled = container.querySelector('textarea[name="test.subfieldGroups.controlled"]');
+    const uncontrolledAlpha = container.querySelector('textarea[name="test.subfieldGroups.uncontrolledAlpha"]');
+    const uncontrolledNumber = container.querySelector('textarea[name="test.subfieldGroups.uncontrolledNumber"]');
+    const zeroSubfield = container.querySelector('textarea[name="test.subfieldGroups.zeroSubfield"]');
 
     expect(controlled.disabled).toBeTruthy();
     expect(uncontrolledAlpha.disabled).toBeFalsy();


### PR DESCRIPTION
## Description
Allow linked fields to be resized

## Screenshots

https://user-images.githubusercontent.com/19309423/215756983-977d4bb0-3a1c-4a51-b5d6-fc4286cafb9f.mp4



## Issues
[UIQM-385](https://issues.folio.org/browse/UIQM-385)

## Related PRs
https://github.com/folio-org/stripes-components/pull/1976