### PR TITLE
UIQM-394: No delete icon for "010" field with valid value in "MARC authority" record not controlling any "MARC bib" record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [UIQM-348](https://issues.folio.org/browse/UIQM-348) Change to Linked MARC authority record has been updated confirmation messaging
 * [UIQM-390](https://issues.folio.org/browse/UIQM-390) Fix exception when changing tag value to "010" in "MARC authority" record without "010" field
 * [UIQM-367](https://issues.folio.org/browse/UIQM-367) Show an error toast message when user enters a subfield that is/can be controlled by an authority record or is the linking match point
+* [UIQM-394](https://issues.folio.org/browse/UIQM-394) No delete icon for "010" field with valid value in "MARC authority" record not controlling any "MARC bib" record
 
 ## [5.2.0](https://github.com/folio-org/ui-quick-marc/tree/v5.2.0) (2022-10-26)
 

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -447,6 +447,7 @@ const QuickMarcEditor = ({
                     subtype={subtype}
                     marcType={marcType}
                     instance={instance}
+                    linksCount={linksCount}
                   />
                 </Col>
               </Row>

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -71,6 +71,7 @@ const QuickMarcEditorRows = ({
   },
   marcType,
   instance,
+  linksCount,
 }) => {
   const stripes = useStripes();
   const intl = useIntl();
@@ -213,7 +214,7 @@ const QuickMarcEditorRows = ({
             const isDisabled = isReadOnly(recordRow, action, marcType);
             const withIndicators = !hasIndicatorException(recordRow);
             const withAddRowAction = hasAddException(recordRow, marcType);
-            const withDeleteRowAction = hasDeleteException(recordRow, marcType, instance, initialValues);
+            const withDeleteRowAction = hasDeleteException(recordRow, marcType, instance, initialValues, linksCount);
             const withMoveUpRowAction = hasMoveException(recordRow, fields[idx - 1]);
             const withMoveDownRowAction = hasMoveException(recordRow, fields[idx + 1]);
 
@@ -483,6 +484,7 @@ const QuickMarcEditorRows = ({
 QuickMarcEditorRows.propTypes = {
   action: PropTypes.oneOf(Object.values(QUICK_MARC_ACTIONS)).isRequired,
   instance: PropTypes.object,
+  linksCount: PropTypes.number,
   type: PropTypes.string.isRequired,
   subtype: PropTypes.string.isRequired,
   fields: PropTypes.arrayOf(PropTypes.shape({

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -1001,13 +1001,13 @@ const DELETE_EXCEPTION_ROWS = {
 
 const is1XXField = (tag) => tag && tag[0] === '1';
 
-export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB, authority, initialValues) => {
+export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB, authority, initialValues, linksCount) => {
   const rows = DELETE_EXCEPTION_ROWS[marcType];
 
   if (marcType === MARC_TYPES.AUTHORITY) {
     if (
       is1XXField(recordRow.tag) ||
-      (recordRow.tag === '010' && is010$aPopulatesBibField$0(initialValues.records, authority.naturalId))
+      (recordRow.tag === '010' && linksCount && is010$aPopulatesBibField$0(initialValues.records, authority.naturalId))
     ) {
       return true;
     }

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1916,8 +1916,9 @@ describe('QuickMarcEditor utils', () => {
       it('should be true for tag 010 that populates bib field(s)', () => {
         const authority = { naturalId: 'n79018119' };
         const initialValues = { records: [{ tag: '010', content: '$a n  79018119' }] };
+        const linksCount = 1;
 
-        expect(utils.hasDeleteException({ tag: '010' }, MARC_TYPES.AUTHORITY, authority, initialValues)).toBeTruthy();
+        expect(utils.hasDeleteException({ tag: '010' }, MARC_TYPES.AUTHORITY, authority, initialValues, linksCount)).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
It has to be possible to delete an authority field when it is not linked but 010 $a corresponds with any bib field's $0.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-394](https://issues.folio.org/browse/UIQM-394)
## Screencast



https://user-images.githubusercontent.com/77053927/216027377-6b573c41-8450-43df-8e51-cde6d6de812e.mp4





## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
