### PR TITLE
UIQM-386: Forbid creation of field 010 $a when 001 is linked and 010 is absent.

### DIFF
--- a/src/QuickMarcEditor/QuickMarcEditWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.test.js
@@ -95,6 +95,11 @@ const mockRecords = {
       id: 'LDR',
     },
     {
+      tag: '001',
+      content: '971255',
+      isProtected: true,
+    },
+    {
       tag: '005',
       content: '20120323070509.0',
     },
@@ -446,7 +451,7 @@ describe('Given QuickMarcEditWrapper', () => {
             linksCount: 1,
           });
 
-          await act(async () => { fireEvent.change(getByTestId('content-field-7'), { target: { value: '$a Civil war edited' } }); });
+          await act(async () => { fireEvent.change(getByTestId('content-field-8'), { target: { value: '$a Civil war edited' } }); });
           await act(async () => { fireEvent.click(getByText('ui-quick-marc.record.save.continue')); });
 
           expect(getByText('ui-quick-marc.update-linked-bib-fields.modal.label')).toBeDefined();

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -297,7 +297,7 @@ const QuickMarcEditor = ({
         const headingContent = currentHeading?.content || initialHeading?.content;
 
         formattedMessageValues = {
-          title: getContentSubfieldValue(headingContent).$a,
+          title: getContentSubfieldValue(headingContent).$a?.[0],
         };
       } else {
         formattedMessageValues = instance;

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -57,7 +57,7 @@ export const getContentSubfieldValue = (content) => {
       const key = `$${str[0]}`;
       const value = acc[key]
         ? flatten([acc[key], str.substring(2).trim()]) // repeatable subfields will be stored as an array
-        : str.substring(2).trim();
+        : [str.substring(2).trim()];
 
       return {
         ...acc,
@@ -76,7 +76,7 @@ export const is010$aCreated = (initial, updated) => {
   const initial010 = initial.find(rec => rec.tag === '010');
   const updated010 = updated.find(rec => rec.tag === '010');
 
-  return !initial010 && updated010 && !!getContentSubfieldValue(updated010.content).$a;
+  return !initial010 && updated010 && !!getContentSubfieldValue(updated010.content).$a?.[0];
 };
 
 export const is010$aUpdated = (initial, updated) => {
@@ -85,7 +85,7 @@ export const is010$aUpdated = (initial, updated) => {
 
   return initial010 &&
     updated010 &&
-    getContentSubfieldValue(initial010.content).$a !== getContentSubfieldValue(updated010.content).$a;
+    getContentSubfieldValue(initial010.content).$a?.[0] !== getContentSubfieldValue(updated010.content).$a?.[0];
 };
 
 export const parseHttpError = async (httpError) => {
@@ -558,7 +558,7 @@ const validateMarcHoldingsRecord = (marcRecords, locations) => {
 const getIs$tRemoved = (content) => {
   const contentSubfieldValue = getContentSubfieldValue(content);
 
-  return !('$t' in contentSubfieldValue) || !contentSubfieldValue.$t;
+  return !('$t' in contentSubfieldValue) || !contentSubfieldValue.$t[0];
 };
 
 const validateMarcAuthority1xxField = (initialRecords, formValuesToSave) => {
@@ -570,7 +570,7 @@ const validateMarcAuthority1xxField = (initialRecords, formValuesToSave) => {
     return <FormattedMessage id="ui-quick-marc.record.error.1xx.change" values={{ tag: initialTag }} />;
   }
 
-  const hasInitially$t = !!getContentSubfieldValue(initialContent).$t;
+  const hasInitially$t = !!getContentSubfieldValue(initialContent).$t?.[0];
   const has$tToSave = '$t' in getContentSubfieldValue(contentToSave);
   const is$tAdded = !hasInitially$t && has$tToSave;
   const is$tRemoved = hasInitially$t && getIs$tRemoved(contentToSave);
@@ -934,9 +934,7 @@ export const groupSubfields = (field, authorityControlledSubfields = []) => {
     const isZero = /\$0/.test(subfield[0]);
     const isNine = /\$9/.test(subfield[0]);
 
-    const fieldContent = Array.isArray(subfield[1])
-      ? subfield[1].reduce((content, value) => [content, `${subfield[0]} ${value}`].join(' '), '')
-      : `${subfield[0]} ${subfield[1]}`;
+    const fieldContent = subfield[1].reduce((content, value) => [content, `${subfield[0]} ${value}`].join(' '), '');
 
     const formattedSubfield = {
       content: fieldContent,
@@ -1008,7 +1006,7 @@ export const is010LinkedToBibRecord = (initialRecords, naturalId) => {
     return false;
   }
 
-  const initial010$a = getContentSubfieldValue(initial010Field.content).$a;
+  const initial010$a = getContentSubfieldValue(initial010Field.content).$a?.[0];
 
   return naturalId === initial010$a?.replaceAll(' ', '');
 };

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -72,6 +72,13 @@ const is001LinkedToBibRecord = (initialRecords, naturalId) => {
   return naturalId === field001.content.replaceAll(' ', '');
 };
 
+export const is010$aCreated = (initial, updated) => {
+  const initial010 = initial.find(rec => rec.tag === '010');
+  const updated010 = updated.find(rec => rec.tag === '010');
+
+  return !initial010 && updated010 && !!getContentSubfieldValue(updated010.content).$a;
+};
+
 export const is010$aUpdated = (initial, updated) => {
   const initial010 = initial.find(rec => rec.tag === '010');
   const updated010 = updated.find(rec => rec.tag === '010');
@@ -580,7 +587,10 @@ const validateMarcAuthority1xxField = (initialRecords, formValuesToSave) => {
 };
 
 const validateAuthority010Field = (initialRecords, records, naturalId) => {
-  if (is010$aUpdated(initialRecords, records) && is001LinkedToBibRecord(initialRecords, naturalId)) {
+  if (
+    is001LinkedToBibRecord(initialRecords, naturalId)
+    && (is010$aCreated(initialRecords, records) || is010$aUpdated(initialRecords, records))
+  ) {
     return <FormattedMessage id="ui-quick-marc.record.error.010.edit$a" />;
   }
 

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -746,7 +746,6 @@ describe('QuickMarcEditor utils', () => {
     describe('when record is MARC Authority record', () => {
       it('should not return error message when record is valid', () => {
         const initialValues = { records: [] };
-        const location = { search: '' };
         const record = {
           leader: '04706cxm a22008651i 4500',
           records: [
@@ -765,7 +764,6 @@ describe('QuickMarcEditor utils', () => {
           marcRecord: record,
           initialValues,
           marcType: MARC_TYPES.AUTHORITY,
-          location,
         })).not.toBeDefined();
       });
 
@@ -817,7 +815,6 @@ describe('QuickMarcEditor utils', () => {
 
       describe('when authority linked to bib record', () => {
         const linksCount = 1;
-        const location = { search: '?authRefType=Authorized' };
         const initialValues = {
           leader: '04706cxm a22008651i 4500',
           records: [
@@ -841,7 +838,6 @@ describe('QuickMarcEditor utils', () => {
             marcRecord: record,
             initialValues,
             marcType: MARC_TYPES.AUTHORITY,
-            location,
             linksCount,
           }).props.id).toBe('ui-quick-marc.record.error.1xx.change');
         });
@@ -855,7 +851,6 @@ describe('QuickMarcEditor utils', () => {
             marcRecord: record,
             initialValues,
             marcType: MARC_TYPES.AUTHORITY,
-            location,
             linksCount,
           }).props.id).toBe('ui-quick-marc.record.error.1xx.add$t');
         });
@@ -873,7 +868,6 @@ describe('QuickMarcEditor utils', () => {
             marcRecord: record,
             initialValues: newInitialValues,
             marcType: MARC_TYPES.AUTHORITY,
-            location,
             linksCount: 1,
           }).props.id).toBe('ui-quick-marc.record.error.1xx.remove$t');
         });
@@ -891,7 +885,6 @@ describe('QuickMarcEditor utils', () => {
             marcRecord: record,
             initialValues: newInitialValues,
             marcType: MARC_TYPES.AUTHORITY,
-            location,
             linksCount,
           }).props.id).toBe('ui-quick-marc.record.error.1xx.remove$t');
         });
@@ -920,7 +913,34 @@ describe('QuickMarcEditor utils', () => {
             marcRecord: record,
             initialValues: newInitialValues,
             marcType: MARC_TYPES.AUTHORITY,
-            location,
+            linksCount,
+            naturalId: 'n83073672',
+          }).props.id).toBe('ui-quick-marc.record.error.010.edit$a');
+        });
+
+        it('should return an error if 010 $a created and 001 is linked', () => {
+          const newInitialValues = {
+            ...initialValues,
+            records: [
+              ...initialValues.records,
+              {
+                content: 'n  83073672 ',
+                tag: '001',
+              },
+            ],
+          };
+
+          const record = cloneDeep(newInitialValues);
+
+          record.records.push({
+            tag: '010',
+            content: '$a 63943573',
+          });
+
+          expect(utils.validateMarcRecord({
+            marcRecord: record,
+            initialValues: newInitialValues,
+            marcType: MARC_TYPES.AUTHORITY,
             linksCount,
             naturalId: 'n83073672',
           }).props.id).toBe('ui-quick-marc.record.error.010.edit$a');

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1857,12 +1857,12 @@ describe('QuickMarcEditor utils', () => {
 
   describe('getContentSubfieldValue', () => {
     it('should return splited string by subfields into object', () => {
-      expect(utils.getContentSubfieldValue('$a Test Title')).toEqual({ $a: 'Test Title' });
+      expect(utils.getContentSubfieldValue('$a Test Title')).toEqual({ $a: ['Test Title'] });
     });
 
     it('should return repeatable subfields as an array', () => {
       expect(utils.getContentSubfieldValue('$a Test Title $b Repeat 1 $b Repeat 2')).toEqual({
-        $a: 'Test Title',
+        $a: ['Test Title'],
         $b: ['Repeat 1', 'Repeat 2'],
       });
     });

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -15,9 +15,7 @@ import {
 } from '../../QuickMarcEditor/utils';
 
 const joinSubfields = (subfields) => Object.keys(subfields).reduce((content, key) => {
-  const subfield = Array.isArray(subfields[key])
-    ? subfields[key].join(` ${key} `) // if the subfield is repeatable - join the items with subfield key
-    : subfields[key];
+  const subfield = subfields[key].join(` ${key} `);
 
   return [content, `${key} ${subfield}`].join(' ');
 }, '').trim();
@@ -43,7 +41,7 @@ const useAuthorityLinking = () => {
 
       if (subfieldModification) {
         bibSubfields[formatSubfieldCode(subfieldModification.target)] = authSubfields[formatSubfieldCode(subfieldCode)];
-      } else if (authSubfields[formatSubfieldCode(subfieldCode)]) {
+      } else if (authSubfields[formatSubfieldCode(subfieldCode)]?.[0]) {
         bibSubfields[formatSubfieldCode(subfieldCode)] = authSubfields[formatSubfieldCode(subfieldCode)];
       } else {
         delete bibSubfields[formatSubfieldCode(subfieldCode)];
@@ -95,7 +93,7 @@ const useAuthorityLinking = () => {
 
       // should be valid when subfield exists and rule requires it
       // and not valid when subfield doesn't exist and rule requires it to be empty
-      const isValid = Boolean(authoritySubfields[formatSubfieldCode(ruleSubfield)]) === subfieldShouldExist;
+      const isValid = Boolean(authoritySubfields[formatSubfieldCode(ruleSubfield)]?.[0]) === subfieldShouldExist;
 
       return isValid;
     });
@@ -121,11 +119,11 @@ const useAuthorityLinking = () => {
 
     copySubfieldsFromAuthority(bibSubfields, linkedAuthorityField, bibField.tag);
 
-    if (!bibSubfields.$0 || bibSubfields.$0 !== authorityRecord.naturalId) {
-      bibSubfields.$0 = newZeroSubfield;
+    if (!bibSubfields.$0 || bibSubfields.$0[0] !== authorityRecord.naturalId) {
+      bibSubfields.$0 = [newZeroSubfield];
     }
 
-    bibSubfields.$9 = authorityRecord.id;
+    bibSubfields.$9 = [authorityRecord.id];
     bibField.prevContent = bibField.content;
     bibField.content = joinSubfields(bibSubfields);
   }, [copySubfieldsFromAuthority, sourceFiles]);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose

- Forbid creation of field 010 $a when 001 is linked and 010 is absent.
- Revise the `getContentSubfieldValue` to return an array of subfields instead of a string.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-386](https://issues.folio.org/browse/UIQM-386?focusedCommentId=157307&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-157307)

## Screencast

https://user-images.githubusercontent.com/77053927/217550769-b3002b71-7a9c-478a-90c4-2468a48287ce.mp4



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
