### PR TITLE
UIQM-348: Remove the ability to delete field 010 and subfield 010 $a when 010 is linked

### DIFF
--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -72,6 +72,18 @@ const is001LinkedToBibRecord = (initialRecords, naturalId) => {
   return naturalId === field001.content.replaceAll(' ', '');
 };
 
+export const is010LinkedToBibRecord = (initialRecords, naturalId) => {
+  const initial010Field = initialRecords.find(record => record.tag === '010');
+
+  if (!initial010Field) {
+    return false;
+  }
+
+  const initial010$a = getContentSubfieldValue(initial010Field.content).$a?.[0];
+
+  return naturalId === initial010$a?.replaceAll(' ', '');
+};
+
 export const is010$aCreated = (initial, updated) => {
   const initial010 = initial.find(rec => rec.tag === '010');
   const updated010 = updated.find(rec => rec.tag === '010');
@@ -587,6 +599,22 @@ const validateMarcAuthority1xxField = (initialRecords, formValuesToSave) => {
 };
 
 const validateAuthority010Field = (initialRecords, records, naturalId) => {
+  if (is010LinkedToBibRecord(initialRecords, naturalId)) {
+    const field010 = records.find(field => field.tag === '010');
+
+    if (!field010) {
+      return <FormattedMessage id="ui-quick-marc.record.error.010.removed" />;
+    }
+
+    const is010$aRemoved = !getContentSubfieldValue(field010.content).$a?.[0];
+
+    if (is010$aRemoved) {
+      return <FormattedMessage id="ui-quick-marc.record.error.010.$aRemoved" />;
+    }
+
+    return undefined;
+  }
+
   if (
     is001LinkedToBibRecord(initialRecords, naturalId)
     && (is010$aCreated(initialRecords, records) || is010$aUpdated(initialRecords, records))
@@ -997,18 +1025,6 @@ export const splitFields = marcRecord => {
       };
     }),
   };
-};
-
-export const is010LinkedToBibRecord = (initialRecords, naturalId) => {
-  const initial010Field = initialRecords.find(record => record.tag === '010');
-
-  if (!initial010Field) {
-    return false;
-  }
-
-  const initial010$a = getContentSubfieldValue(initial010Field.content).$a?.[0];
-
-  return naturalId === initial010$a?.replaceAll(' ', '');
 };
 
 export const is1XXUpdated = (initial, updated) => {

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -945,6 +945,82 @@ describe('QuickMarcEditor utils', () => {
             naturalId: 'n83073672',
           }).props.id).toBe('ui-quick-marc.record.error.010.edit$a');
         });
+
+        it('should return an error if 010 $a removed and 010 is linked', () => {
+          const newInitialValues = {
+            ...initialValues,
+            records: [
+              ...initialValues.records,
+              {
+                content: '7394284',
+                tag: '001',
+              },
+              {
+                tag: '010',
+                content: '$a n 83073672 $k naf',
+              },
+            ],
+          };
+
+          const record = {
+            ...initialValues,
+            records: [
+              ...initialValues.records,
+              {
+                content: '7394284',
+                tag: '001',
+              },
+              {
+                tag: '010',
+                content: '$a  $k naf',
+              },
+            ],
+          };
+
+          expect(utils.validateMarcRecord({
+            marcRecord: record,
+            initialValues: newInitialValues,
+            marcType: MARC_TYPES.AUTHORITY,
+            linksCount,
+            naturalId: 'n83073672',
+          }).props.id).toBe('ui-quick-marc.record.error.010.$aRemoved');
+        });
+
+        it('should return an error if 010 field is deleted and 010 is linked', () => {
+          const newInitialValues = {
+            ...initialValues,
+            records: [
+              ...initialValues.records,
+              {
+                content: '7394284',
+                tag: '001',
+              },
+              {
+                tag: '010',
+                content: '$a n 83073672',
+              },
+            ],
+          };
+
+          const record = {
+            ...initialValues,
+            records: [
+              ...initialValues.records,
+              {
+                content: '7394284',
+                tag: '001',
+              },
+            ],
+          };
+
+          expect(utils.validateMarcRecord({
+            marcRecord: record,
+            initialValues: newInitialValues,
+            marcType: MARC_TYPES.AUTHORITY,
+            linksCount,
+            naturalId: 'n83073672',
+          }).props.id).toBe('ui-quick-marc.record.error.010.removed');
+        });
       });
     });
   });

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -173,6 +173,8 @@
   "record.error.instanceHrid.multiple": "Record cannot be saved. Can only have one MARC 004.",
   "record.error.010Field.multiple": "Cannot save multiple 010 fields.",
   "record.error.010.edit$a": "Cannot add or edit 010 $a for an authority record linked to a bibliographic record. To make this change, you must unlink this authority record from bibliographic records.",
+  "record.error.010.removed": "Cannot delete 010. It is required.",
+  "record.error.010.$aRemoved": "Cannot remove 010 $a for this record.",
   "record.error.heading.empty": "Record cannot be saved without 1XX field.",
   "record.error.heading.multiple": "Record cannot be saved. Cannot have multiple 1XXs",
   "record.error.title.multiple": "Record cannot be saved with more than one field 245.",


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Remove the ability to delete field 010 and subfield 010 $a when 010 is linked.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-348 comment 1](https://issues.folio.org/browse/UIQM-348?focusedCommentId=157538&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-157538)
[UIQM-348 comment 2](https://issues.folio.org/browse/UIQM-348?focusedCommentId=157597&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-157597)
## Screencast



https://user-images.githubusercontent.com/77053927/217619550-807c4d6c-3639-4735-b221-da490deb5f1f.mp4


## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
