### PR TITLE
UIQM-410 FE - Edit/Derive a MARC bib - Returns an error when MARC LDR_19 value is 'b' or 'c'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change history for ui-quick-marc
 
-## [7.0.0](IN PROGRESS)
+## [6.1.0](IN PROGRESS)
 
 * [UIQM-395](https://issues.folio.org/browse/UIQM-395) Adding multiple "$a" in "010" field of linked "MARC Authority" leads to error.
 * [UIQM-250](https://issues.folio.org/browse/UIQM-250) Updated invalid Leader position values error messages to be more informative.
+* [UIQM-410](https://issues.folio.org/browse/UIQM-410) Add support for values 'b' and 'c' in Bib Leader/19
 
 ## [6.0.0](https://github.com/folio-org/ui-quick-marc/tree/v6.0.0) (2023-02-23)
 

--- a/src/QuickMarcEditor/constants.js
+++ b/src/QuickMarcEditor/constants.js
@@ -17,7 +17,7 @@ export const LEADER_VALUES_FOR_POSITION = {
     7: ['a', 'b', 'c', 'd', 'i', 'm', 's'],
     8: ['\\', ' ', NON_BREAKING_SPACE, 'a'],
     18: ['\\', ' ', NON_BREAKING_SPACE, 'a', 'c', 'i', 'n', 'u'],
-    19: ['\\', ' ', NON_BREAKING_SPACE, 'a'],
+    19: ['\\', ' ', NON_BREAKING_SPACE, 'a', 'b', 'c'],
   },
   [MARC_TYPES.HOLDINGS]: {
     5: ['c', 'd', 'n'],


### PR DESCRIPTION
## Description
Add support for values 'b' and 'c' in Bib Leader/19

## Issues
[UIQM-410](https://issues.folio.org/browse/UIQM-410)