### PR TITLE
UIQM-445 Fix missing permission to view MARC Authority icon in MARC bib source view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UIQM-420](https://issues.folio.org/browse/UIQM-420) Remove initial values for Find Authority plugin References filter.
 * [UIQM-428](https://issues.folio.org/browse/UIQM-428) Show an error message in modal after linking.
 * [UIQM-424](https://issues.folio.org/browse/UIQM-424) Disable pressing `Enter` for linked fields.
+* [UIQM-445](https://issues.folio.org/browse/UIQM-445) Fix missing permission to view MARC Authority icon in MARC bib source view
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "subPermissions": [
           "records-editor.records.item.get",
           "inventory.instances.item.get",
-          "instance-authority-links.instances.collection.get"
+          "instance-authority-links.instances.collection.get",
+          "instance-authority.linking-rules.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Description
Added missing permission to get linking rules to display MARC Authority links

## Issues
[UIQM-445](https://issues.folio.org/browse/UIQM-445)