### PR TITLE
UIQM-412 Fix translation format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [UIQM-429](https://issues.folio.org/browse/UIQM-429) Prevent many location in Marc holdings record.
 * [UIQM-449](https://issues.folio.org/browse/UIQM-449) Link Authority: Pre-populate search/browse box with bib subfield values 
 * [UIQM-415](https://issues.folio.org/browse/UIQM-415) Create original bib record in quickMARC UI
+* [UIQM-412](https://issues.folio.org/browse/UIQM-412) Fix translation format: MARC field number isn't highlighted in bold
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -232,7 +232,7 @@
   "record.link.validation.invalidHeading": "You have selected an invalid heading based on the bibliographic field you want controlled. Please revise your selection.",
   "record.unlink": "Unlink from MARC Authority record",
   "record.unlink.confirm.title": "Unlink from MARC authority record",
-  "record.unlink.confirm.message": "By selecting <b>Unlink</b>, then field {tag} will be unlinked from the MARC authority record. Are you sure you want to continue?",
+  "record.unlink.confirm.message": "By selecting <b>Unlink</b>, then field <b>{tag}</b> will be unlinked from the MARC authority record. Are you sure you want to continue?",
   "record.unlink.confirm.cancel": "Cancel",
   "record.unlink.confirm.confirm": "Unlink",
   "record.viewMarcAuthorityRecord": "View MARC authority record",


### PR DESCRIPTION
## Issue 
MARC field number isn't highlighted in bold in "Unlink from MARC authority record" modal
[UIQM-412](https://issues.folio.org/browse/UIQM-412)
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->


