### PR TITLE
Use sonarcloud-github-action v1.8 to fix error with incorrect node version

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -171,7 +171,7 @@ jobs:
         run: git fetch --no-tags ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} +refs/heads/${{ env.DEFAULT_BRANCH }}:refs/remotes/origin/${{ env.DEFAULT_BRANCH }}
 
       - name: Run SonarCloud scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@v1.8
         with:
           args: >
             -Dsonar.organization=folio-org

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -114,7 +114,7 @@ jobs:
         run: git fetch --no-tags ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} +refs/heads/${{ env.DEFAULT_BRANCH }}:refs/remotes/origin/${{ env.DEFAULT_BRANCH }}
 
       - name: Run SonarCloud scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@v1.8
         with:
           args: >
             -Dsonar.organization=folio-org


### PR DESCRIPTION
## Description
Use `sonarcloud-github-action v1.8` that doesn't require Node >=14
