### PR TITLE
UIQM-457 "Base URL" doesn't add to linked field when "$0" exactly matches with "naturalId"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [UIQM-449](https://issues.folio.org/browse/UIQM-449) Link Authority: Pre-populate search/browse box with bib subfield values 
 * [UIQM-415](https://issues.folio.org/browse/UIQM-415) Create original bib record in quickMARC UI
 * [UIQM-412](https://issues.folio.org/browse/UIQM-412) Fix translation format: MARC field number isn't highlighted in bold
+* [UIQM-457](https://issues.folio.org/browse/UIQM-457) Always replace bib $0 with Authority's baseURL + naturalId.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -117,11 +117,9 @@ const useAuthorityLinking = () => {
       newZeroSubfield = authorityRecord.naturalId;
     }
 
-    copySubfieldsFromAuthority(bibSubfields, linkedAuthorityField, bibField.tag);
+    bibSubfields.$0 = [newZeroSubfield];
 
-    if (!bibSubfields.$0 || bibSubfields.$0[0] !== authorityRecord.naturalId) {
-      bibSubfields.$0 = [newZeroSubfield];
-    }
+    copySubfieldsFromAuthority(bibSubfields, linkedAuthorityField, bibField.tag);
 
     bibSubfields.$9 = [authorityRecord.id];
     bibField.linkingRuleId = linkingRule.id;

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -103,7 +103,7 @@ describe('Given useAuthorityLinking', () => {
       };
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b fakeB $t field for modification $0 some.url/n0001 $9 authority-id',
+        content: '$a authority value $b fakeB $0 some.url/n0001 $t field for modification $9 authority-id',
         authorityControlledSubfields: ['a', 'b', 't', 'd'],
       });
     });
@@ -130,6 +130,27 @@ describe('Given useAuthorityLinking', () => {
     });
   });
 
+  describe('when calling linkAuthority with matched $0 subfield and authority.naturalId', () => {
+    it('should return field with new $0 and $9 subfields and authority subfields', () => {
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const authority = {
+        id: 'authority-id',
+        sourceFileId: '1',
+        naturalId: 'n0001',
+      };
+      const field = {
+        tag: '100',
+        content: '$a some value $b some other value $0 n0001 $9 authority-other-id',
+      };
+
+      expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
+        content: '$a authority value $b fakeB $0 some.url/n0001 $9 authority-id $t field for modification',
+        authorityControlledSubfields: ['a', 'b', 't', 'd'],
+      });
+    });
+  });
+
   describe('when calling linkAuthority with repeated subfields', () => {
     it('should return field with correctly formatted subfields', () => {
       const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
@@ -145,7 +166,7 @@ describe('Given useAuthorityLinking', () => {
       };
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b fakeB $e author $e illustrator $t field for modification $0 some.url/n0001 $9 authority-id',
+        content: '$a authority value $b fakeB $e author $e illustrator $0 some.url/n0001 $t field for modification $9 authority-id',
         authorityControlledSubfields: ['a', 'b', 't', 'd'],
       });
     });
@@ -183,7 +204,7 @@ describe('Given useAuthorityLinking', () => {
       };
 
       expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b fakeB $e author $e illustrator $c field for modification $0 some.url/n0001 $9 authority-id',
+        content: '$a authority value $b fakeB $e author $e illustrator $0 some.url/n0001 $c field for modification $9 authority-id',
         authorityControlledSubfields: ['a', 'b', 'c'],
       });
     });


### PR DESCRIPTION
## Description
Always replace `$0` with authority's `naturalId`

## Screenshots

https://user-images.githubusercontent.com/19309423/234007571-8bebe2e4-298a-429b-b56c-32406d28f423.mp4


## Issues
[UIQM-457](https://issues.folio.org/browse/UIQM-457)