### PR TITLE
UIQM-419 Make Leader validation error message consistent for all MARC types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [UIQM-448](https://issues.folio.org/browse/UIQM-448) Fix validation of 001 fields when creating/deriving/editing all record types.
 * [UIQM-463](https://issues.folio.org/browse/UIQM-463) Upgrade to new interfaces.
 * [UIQM-470](https://issues.folio.org/browse/UIQM-470) Add permission for editing MARC Holdings records.
+* [UIQM-419](https://issues.folio.org/browse/UIQM-419) Make Leader validation error message consistent for all MARC types.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/QuickMarcEditor/constants.js
+++ b/src/QuickMarcEditor/constants.js
@@ -35,6 +35,7 @@ export const LEADER_VALUES_FOR_POSITION = {
 export const LEADER_DOCUMENTATION_LINKS = {
   [MARC_TYPES.BIB]: 'https://loc.gov/marc/bibliographic/bdleader.html',
   [MARC_TYPES.HOLDINGS]: 'https://www.loc.gov/marc/holdings/hdleader.html',
+  [MARC_TYPES.AUTHORITY]: 'https://www.loc.gov/marc/authority/adleader.html',
 };
 
 export const QUICK_MARC_ACTIONS = {

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import { Link } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import omit from 'lodash/omit';
 import compact from 'lodash/compact';
@@ -20,7 +21,7 @@ import {
   HOLDINGS_FIXED_FIELD_DEFAULT_VALUES,
   CORRESPONDING_HEADING_TYPE_TAGS,
   LEADER_VALUES_FOR_POSITION,
-  NON_BREAKING_SPACE,
+  LEADER_DOCUMENTATION_LINKS,
   ELVL_BYTE,
   CREATE_BIB_RECORD_DEFAULT_FIELD_TAGS,
   BIB_FIXED_FIELD_DEFAULT_VALUES,
@@ -422,19 +423,37 @@ const getInvalidLeaderPositions = (leader, marcType) => {
   return failedPositions;
 };
 
+const joinFailedPositions = (failedPositions) => {
+  const formattedFailedPositions = failedPositions.map(position => `Leader ${position < 10 ? '0' : ''}${position}`);
+
+  const last = formattedFailedPositions.pop();
+  const joinedPositions = formattedFailedPositions.length > 0
+    ? formattedFailedPositions.join(', ') + ' and ' + last
+    : last;
+
+  return joinedPositions;
+};
+
 const validateLeaderPositions = (leader, marcType) => {
   const failedPositions = getInvalidLeaderPositions(leader, marcType);
+  const joinedPositions = joinFailedPositions(failedPositions);
 
   if (failedPositions.length) {
     return (
       <FormattedMessage
         id="ui-quick-marc.record.error.leader.invalidPositionValue"
         values={{
-          value: leader[failedPositions[0]],
-          position: failedPositions[0],
-          values: LEADER_VALUES_FOR_POSITION[marcType][failedPositions[0]]
-            .filter(pos => pos !== NON_BREAKING_SPACE)
-            .join(', '),
+          positions: joinedPositions,
+          link: (
+            <Link
+              to={{
+                pathname: LEADER_DOCUMENTATION_LINKS[marcType],
+              }}
+              target="_blank"
+            >
+              {LEADER_DOCUMENTATION_LINKS[marcType]}
+            </Link>
+          ),
         }}
       />
     );

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -226,14 +226,14 @@ describe('QuickMarcEditor utils', () => {
   describe('validateLeader', () => {
     it('should return an error message when position 18 is invalid', () => {
       expect(
-        utils.validateLeader('04706cam a2200865Iia4500', '04706dam a2200865nfa4500').props.values.position,
-      ).toBe('18');
+        utils.validateLeader('04706cam a2200865Iia4500', '04706dam a2200865nfa4500').props.values.positions,
+      ).toBe('Leader 18');
     });
 
     it('should return an error message when position 19 is invalid', () => {
       expect(
-        utils.validateLeader('04706cam a2200865Ici4500', '04706dam a2200865nai4500').props.values.position,
-      ).toBe('19');
+        utils.validateLeader('04706cam a2200865Ici4500', '04706dam a2200865nai4500').props.values.positions,
+      ).toBe('Leader 19');
     });
 
     it('should not return error message when leader is valid', () => {

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -168,7 +168,7 @@
   "record.error.leader.forbiddenBytes.holdings": "Record cannot be saved. Please check the Leader. Only positions 5, 6, 17, 18 can be edited in the Leader.",
   "record.error.leader.forbiddenBytes.authority": "Record cannot be saved. Please check the Leader. Only positions 5, 17, 18 can be edited in the Leader.",
   "record.error.leader.fixedFieldMismatch": "Record cannot be saved. The Leader and 008 do not match.",
-  "record.error.leader.invalidPositionValue": "Record cannot be saved. Wrong value \"{value}\" on position {position} of the Leader. Allowed only: [{values}]",
+  "record.error.leader.invalidPositionValue": "Record cannot be saved. Please enter a valid {positions}. Valid values are listed at {link}",
   "record.error.leader.initial.invalidPositionValue": "Record cannot be saved. Cannot edit 008 due to invalid {positions}. Please update this record's {positions}. Valid values are listed at {link}",
   "record.error.bib.leader.invalid005PositionValue": "Record cannot be saved. Invalid value entered for position 5.",
   "record.error.controlField.multiple": "Record cannot be saved. Can only have one MARC 001.",


### PR DESCRIPTION
## Description
Make Leader validation error message consistent for all MARC types.

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/1c492540-2fc9-441c-926e-7be91c65ea04


## Issues
[UIQM-419](https://issues.folio.org/browse/UIQM-419)