### PR TITLE
UIQM-492 Fix error when changing field type from 00X to content and vice versa.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [UIQM-419](https://issues.folio.org/browse/UIQM-419) Make Leader validation error message consistent for all MARC types.
 * [UIQM-465](https://issues.folio.org/browse/UIQM-465) Bib Rec. / Field 008 / Ctrl / Removed unused Ctrl field.
 * [UIQM-464](https://issues.folio.org/browse/UIQM-464) Create Orig Bib Record: Populate new record with 008.
+* [UIQM-492](https://issues.folio.org/browse/UIQM-492) Fix error when changing field type from 00X to content and vice versa.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -51,6 +51,7 @@ import {
   is1XXUpdated,
   is010$aUpdated,
   is010LinkedToBibRecord,
+  updateRecordAtIndex,
 } from './utils';
 import { useAuthorityLinking } from '../hooks';
 
@@ -565,6 +566,11 @@ export default stripesFinalForm({
     },
     restoreRecord: ([{ index }], state, tools) => {
       const records = restoreRecordAtIndex(index, state);
+
+      tools.changeValue(state, 'records', () => records);
+    },
+    updateRecord: ([{ index, field }], state, tools) => {
+      const records = updateRecordAtIndex(index, field, state);
 
       tools.changeValue(state, 'records', () => records);
     },

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -42,6 +42,8 @@ import {
   isPhysDescriptionRecord,
   isReadOnly,
   hasDeleteException,
+  isLocationRow,
+  isContentRow,
 } from '../utils';
 import { useAuthorityLinking } from '../../hooks';
 import {
@@ -68,6 +70,7 @@ const QuickMarcEditorRows = ({
     deleteRecord,
     moveRecord,
     restoreRecord,
+    updateRecord,
   },
   marcType,
   instance,
@@ -118,6 +121,31 @@ const QuickMarcEditorRows = ({
     return prevRow.querySelector('[data-icon="delete-row"]') ||
       prevRow.querySelector('[data-icon="move-up"]');
   };
+
+  const onTagChange = useCallback(({ target }) => {
+    const index = parseInt(target.dataset.index, 10);
+    const { value } = target;
+
+    const wasContentField = isContentRow(fields[index], marcType);
+    const isContentField = isContentRow({ ...fields[index], tag: value }, marcType); // type of content after we apply new tag value
+
+    // if type of field isn't changed we don't need to make any updates to content
+    if (wasContentField === isContentField) {
+      return;
+    }
+
+    const newContent = fields[index]._fieldTypeSwapContent || '';
+
+    updateRecord({
+      index,
+      field: {
+        ...fields[index],
+        tag: value,
+        content: newContent,
+        _fieldTypeSwapContent: fields[index].content,
+      },
+    });
+  }, [fields, marcType, updateRecord]);
 
   const deleteRow = useCallback(({ target }) => {
     const index = parseInt(target.dataset.index, 10);
@@ -231,8 +259,8 @@ const QuickMarcEditorRows = ({
             const isMaterialCharsField = isMaterialCharsRecord(recordRow);
             const isPhysDescriptionField = isPhysDescriptionRecord(recordRow);
             const isFixedField = isFixedFieldRow(recordRow);
-            const isLocationField = marcType === MARC_TYPES.HOLDINGS && recordRow.tag === '852';
-            const isContentField = !(isLocationField || isFixedField || isMaterialCharsField || isPhysDescriptionField);
+            const isLocationField = isLocationRow(recordRow, marcType);
+            const isContentField = isContentRow(recordRow, marcType);
             const isMARCFieldProtections = marcType !== MARC_TYPES.HOLDINGS && action === QUICK_MARC_ACTIONS.EDIT;
             const isProtectedField = recordRow.isProtected;
             const isLinkVisible = checkCanBeLinked(stripes, marcType, linkableBibFields, recordRow.tag);
@@ -348,6 +376,8 @@ const QuickMarcEditorRows = ({
                     fullWidth
                     disabled={isDisabled || !idx}
                     hasClearIcon={false}
+                    onChange={onTagChange}
+                    data-testid={`tag-field-${idx}`}
                   />
                 </div>
 
@@ -441,6 +471,7 @@ const QuickMarcEditorRows = ({
                             disabled={isDisabled}
                             id={`content-field-${idx}`}
                             component={ContentField}
+                            data-testid={`content-field-${idx}`}
                           />
                         )
                     )
@@ -518,6 +549,7 @@ QuickMarcEditorRows.propTypes = {
     _isDeleted: PropTypes.bool,
     _isLinked: PropTypes.bool,
     _isAdded: PropTypes.bool,
+    _fieldTypeSwapContent: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   })),
   mutators: PropTypes.shape({
     addRecord: PropTypes.func.isRequired,
@@ -527,6 +559,7 @@ QuickMarcEditorRows.propTypes = {
     markRecordUnlinked: PropTypes.func.isRequired,
     moveRecord: PropTypes.func.isRequired,
     restoreRecord: PropTypes.func.isRequired,
+    updateRecord: PropTypes.func.isRequired,
   }),
   marcType: PropTypes.oneOf(Object.values(MARC_TYPES)).isRequired,
 };

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   render,
   fireEvent,
-  act,
 } from '@testing-library/react';
 import { Form } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   render,
   fireEvent,
+  act,
 } from '@testing-library/react';
 import { Form } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
@@ -103,6 +104,7 @@ const initValues = [
     tag: '240',
     _isLinked: false,
     indicators: [],
+    content: '',
   },
   {
     id: '7',
@@ -125,6 +127,7 @@ const initValues = [
     },
     _isLinked: false,
     tag: '100',
+    content: '',
   },
 ];
 
@@ -138,6 +141,7 @@ const addRecordMock = jest.fn().mockImplementation(({ index }) => {
 const deleteRecordMock = jest.fn();
 const moveRecordMock = jest.fn();
 const markRecordDeletedMock = jest.fn();
+const mockUpdateRecord = jest.fn();
 
 const getComponent = (props) => (
   <Harness>
@@ -162,8 +166,9 @@ const getComponent = (props) => (
             markRecordLinked: jest.fn(),
             markRecordUnlinked: jest.fn(),
             restoreRecord: jest.fn(),
+            updateRecord: mockUpdateRecord,
           }}
-          subtype="test"
+          subtype="m"
           {...props}
         />
       )}
@@ -375,6 +380,26 @@ describe('Given QuickMarcEditorRows', () => {
       expect(mockSendCallout).toHaveBeenCalledWith({
         type: 'error',
         message: 'validation error',
+      });
+    });
+  });
+
+  describe('when changing tag from 00X to any text content field', () => {
+    it('should change field content to empty string and save old value', () => {
+      const { getByTestId } = renderQuickMarcEditorRows();
+
+      const tagField006 = getByTestId('tag-field-1');
+
+      fireEvent.change(tagField006, { target: { value: '700' } });
+
+      expect(mockUpdateRecord).toHaveBeenCalledWith({
+        index: 1,
+        field: {
+          id: '4',
+          tag: '700',
+          content: '',
+          _fieldTypeSwapContent: {},
+        },
       });
     });
   });

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -52,6 +52,13 @@ export const isLastRecord = recordRow => {
 export const isFixedFieldRow = recordRow => recordRow.tag === '008';
 export const isMaterialCharsRecord = recordRow => recordRow.tag === '006';
 export const isPhysDescriptionRecord = recordRow => recordRow.tag === '007';
+export const isLocationRow = (recordRow, marcType) => marcType === MARC_TYPES.HOLDINGS && recordRow.tag === '852';
+export const isContentRow = (recordRow, marcType) => {
+  return !(isLocationRow(recordRow, marcType)
+    || isFixedFieldRow(recordRow)
+    || isMaterialCharsRecord(recordRow)
+    || isPhysDescriptionRecord(recordRow));
+};
 
 export const getContentSubfieldValue = (content = '') => {
   return content.split(/\$/)
@@ -970,6 +977,14 @@ export const restoreRecordAtIndex = (index, state) => {
     ...records[index],
     _isDeleted: false,
   };
+
+  return records;
+};
+
+export const updateRecordAtIndex = (index, field, state) => {
+  const records = [...state.formState.values.records];
+
+  records[index] = field;
 
   return records;
 };


### PR DESCRIPTION
## Description
Listen to field tag change events and save content to new `_fieldTypeSwapContent` property.
When changing from 00X to content fields - save old content and set content to empty string

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/2f7745ff-1c9d-4f30-9265-cc82a088ab3c

## Issues
[UIQM-492](https://issues.folio.org/browse/UIQM-492)