### PR TITLE
UIQM-459 Make 008 field required for MARC bibliographic/authority/holdings records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [UIQM-465](https://issues.folio.org/browse/UIQM-465) Bib Rec. / Field 008 / Ctrl / Removed unused Ctrl field.
 * [UIQM-464](https://issues.folio.org/browse/UIQM-464) Create Orig Bib Record: Populate new record with 008.
 * [UIQM-492](https://issues.folio.org/browse/UIQM-492) Fix error when changing field type from 00X to content and vice versa.
+* [UIQM-459](https://issues.folio.org/browse/UIQM-459) Make 008 field required for MARC bibliographic/authority/holdings records.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -534,6 +534,20 @@ export const validateLeader = (prevLeader = '', leader = '', marcType = MARC_TYP
   return undefined;
 };
 
+export const validateFixedField = (marcRecords) => {
+  const fixedFields = marcRecords.filter(isFixedFieldRow);
+
+  if (!fixedFields.length) {
+    return <FormattedMessage id="ui-quick-marc.record.error.008.empty" />;
+  }
+
+  if (fixedFields.length > 1) {
+    return <FormattedMessage id="ui-quick-marc.record.error.008.multiple" />;
+  }
+
+  return undefined;
+};
+
 export const getLocationValue = (value) => {
   const matches = value?.match(/\$b\s+([^$\s]+\/?)+/) || [];
 
@@ -890,6 +904,12 @@ export const validateMarcRecord = ({
 
   if (leaderError) {
     return leaderError;
+  }
+
+  const fixedFieldError = validateFixedField(marcRecords);
+
+  if (fixedFieldError) {
+    return fixedFieldError;
   }
 
   let validationResult;

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -178,6 +178,8 @@
   "record.error.010.removed": "Cannot delete 010. It is required.",
   "record.error.010.$aRemoved": "Cannot remove 010 $a for this record.",
   "record.error.010.$aOnlyOne": "010 can only have one $a.",
+  "record.error.008.empty": "Record cannot be saved without 008 field",
+  "record.error.008.multiple": "Record cannot be saved with more than one 008 field",
   "record.error.heading.empty": "Record cannot be saved without 1XX field.",
   "record.error.heading.multiple": "Record cannot be saved. Cannot have multiple 1XXs",
   "record.error.title.multiple": "Record cannot be saved with more than one field 245.",


### PR DESCRIPTION
## Description
Make 008 field required for MARC bibliographic/authority/holdings records
Allow only one 008 field for MARC bibliographic/authority/holdings records

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/9b67c3f9-5186-48d2-a2d6-9f99efe8007f

## Issues
[UIQM-459](https://issues.folio.org/browse/UIQM-459)