### PR TITLE
UIQM-326: Take uncontrolled subfields from the current field, not from suggested one.

### DIFF
--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -1327,7 +1327,7 @@ export const groupSubfields = (field, authorityControlledSubfields = []) => {
     const isZero = /\$0/.test(subfield[0]);
     const isNine = /\$9/.test(subfield[0]);
 
-    const fieldContent = subfield[1].reduce((content, value) => [content, `${subfield[0]} ${value}`].join(' '), '');
+    const fieldContent = subfield[1].reduce((content, value) => [content, `${subfield[0]} ${value}`].join(' ').trimStart(), '');
 
     const formattedSubfield = {
       content: fieldContent,

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -4,6 +4,7 @@ import {
 } from 'react';
 import get from 'lodash/get';
 import omit from 'lodash/omit';
+import pick from 'lodash/pick';
 
 import {
   useAuthoritySourceFiles,
@@ -157,10 +158,17 @@ const useAuthorityLinking = () => {
       const linkingRule = linkingRules.find(rule => rule.id === suggestedField.linkDetails?.linkingRuleId);
       const controlledSubfields = getControlledSubfields(linkingRule);
 
+      // take uncontrolled subfields from the current field, not from suggested one
+      const subfieldGroups = {
+        ...groupSubfields(suggestedField, controlledSubfields),
+        ...pick(groupSubfields(field, controlledSubfields), 'uncontrolledAlpha', 'uncontrolledNumber'),
+      };
+
       return {
         ...field,
         ...suggestedField,
-        subfieldGroups: groupSubfields(suggestedField, controlledSubfields),
+        content: Object.values(subfieldGroups).filter(Boolean).join(' '),
+        subfieldGroups,
         prevContent: field.content,
       };
     }

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -30,6 +30,12 @@ jest.mock('../../queries', () => ({
       authorityField: '150',
       authoritySubfields: ['a', 'b', 'g'],
       autoLinkingEnabled: false,
+    }, {
+      id: 17,
+      bibField: '711',
+      authorityField: '111',
+      authoritySubfields: ['a', 'c', 'e', 'q', 'f', 'h', 'k', 'l', 'p', 's', 't', 'd', 'g', 'n'],
+      autoLinkingEnabled: true,
     }],
     isLoading: false,
   }),
@@ -256,7 +262,7 @@ describe('Given useAuthorityLinking', () => {
       expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([
         {
           'tag': '100',
-          'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+          'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
           'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
           'indicators': ['1', '\\'],
           'isProtected': false,
@@ -278,7 +284,7 @@ describe('Given useAuthorityLinking', () => {
           },
         }, {
           'tag': '600',
-          'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+          'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
           'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
           'indicators': ['0', '0'],
           'isProtected': false,
@@ -292,7 +298,7 @@ describe('Given useAuthorityLinking', () => {
             'status': 'NEW',
           },
           'subfieldGroups': {
-            'controlled': '$a Brown, Benjamin,  $d 1966-',
+            'controlled': '$a Brown, Benjamin, $d 1966-',
             'uncontrolledAlpha': '$v Comic books, strips, etc.',
             'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
             'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
@@ -349,7 +355,7 @@ describe('Given useAuthorityLinking', () => {
           '_isLinked': false,
         }, {
           'tag': '600',
-          'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+          'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
           'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
           'indicators': ['0', '0'],
           'isProtected': false,
@@ -363,7 +369,7 @@ describe('Given useAuthorityLinking', () => {
             'status': 'NEW',
           },
           'subfieldGroups': {
-            'controlled': '$a Brown, Benjamin,  $d 1966-',
+            'controlled': '$a Brown, Benjamin, $d 1966-',
             'uncontrolledAlpha': '$v Comic books, strips, etc.',
             'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
             'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
@@ -445,7 +451,7 @@ describe('Given useAuthorityLinking', () => {
           },
         }, {
           'tag': '600',
-          'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+          'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
           'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
           'indicators': ['0', '0'],
           'isProtected': false,
@@ -459,7 +465,7 @@ describe('Given useAuthorityLinking', () => {
             'status': 'NEW',
           },
           'subfieldGroups': {
-            'controlled': '$a Brown, Benjamin,  $d 1966-',
+            'controlled': '$a Brown, Benjamin, $d 1966-',
             'uncontrolledAlpha': '$v Comic books, strips, etc.',
             'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
             'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
@@ -524,7 +530,7 @@ describe('Given useAuthorityLinking', () => {
           '_isLinked': false,
         }, {
           'tag': '600',
-          'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+          'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
           'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
           'indicators': ['0', '0'],
           'isProtected': false,
@@ -538,7 +544,7 @@ describe('Given useAuthorityLinking', () => {
             'status': 'NEW',
           },
           'subfieldGroups': {
-            'controlled': '$a Brown, Benjamin,  $d 1966-',
+            'controlled': '$a Brown, Benjamin, $d 1966-',
             'uncontrolledAlpha': '$v Comic books, strips, etc.',
             'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
             'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
@@ -600,7 +606,7 @@ describe('Given useAuthorityLinking', () => {
           '_isLinked': false,
         }, {
           'tag': '600',
-          'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+          'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
           'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
           'indicators': ['0', '0'],
           'isProtected': false,
@@ -614,7 +620,7 @@ describe('Given useAuthorityLinking', () => {
             'status': 'NEW',
           },
           'subfieldGroups': {
-            'controlled': '$a Brown, Benjamin,  $d 1966-',
+            'controlled': '$a Brown, Benjamin, $d 1966-',
             'uncontrolledAlpha': '$v Comic books, strips, etc.',
             'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
             'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
@@ -774,7 +780,7 @@ describe('Given useAuthorityLinking', () => {
           },
           {
             'tag': '600',
-            'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
             'prevContent': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
             'linkDetails': {
               'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
@@ -783,7 +789,7 @@ describe('Given useAuthorityLinking', () => {
               'status': 'NEW',
             },
             'subfieldGroups': {
-              'controlled': '$a Brown, Benjamin,  $d 1966-',
+              'controlled': '$a Brown, Benjamin, $d 1966-',
               'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
               'uncontrolledAlpha': '$v Comic books, strips, etc.',
               'uncontrolledNumber': '',
@@ -828,6 +834,63 @@ describe('Given useAuthorityLinking', () => {
         '_isDeleted': false,
         '_isLinked': false,
       }]);
+    });
+  });
+
+  describe('when calling autoLinkAuthority', () => {
+    it('should take uncontrolled subfields from the current field, not from suggested one', () => {
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const fields = [
+        {
+          'tag': '711',
+          'content': '$j something $0 n2008001084 $2 fast $f test',
+          'indicators': ['\\', '\\'],
+          'isProtected': false,
+          'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+          '_isDeleted': false,
+          '_isLinked': false,
+        },
+      ];
+
+      const suggestedFields = [
+        {
+          'tag': '711',
+          'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Roma Council $c Basilica $d 1962-1965 : $n (2nd : $9 5d80ecfa-7370-460e-9e27-3883a7656fe1 $j test',
+          'linkDetails': {
+            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'authorityNaturalId': 'n2008001084',
+            'linkingRuleId': 17,
+            'status': 'NEW',
+          },
+        },
+      ];
+
+      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([
+        {
+          'tag': '711',
+          'content': '$a Roma Council $c Basilica $d 1962-1965 : $n (2nd : $j something $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1 $2 fast',
+          'indicators': ['\\', '\\'],
+          'prevContent': '$j something $0 n2008001084 $2 fast $f test',
+          'isProtected': false,
+          'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+          '_isDeleted': false,
+          '_isLinked': false,
+          'linkDetails': {
+            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'authorityNaturalId': 'n2008001084',
+            'linkingRuleId': 17,
+            'status': 'NEW',
+          },
+          'subfieldGroups': {
+            'controlled': '$a Roma Council $c Basilica $d 1962-1965 : $n (2nd :',
+            'uncontrolledAlpha': '$j something',
+            'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
+            'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+            'uncontrolledNumber': '$2 fast',
+          },
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Take uncontrolled subfields from the current field, not from suggested one.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Screencast


https://github.com/folio-org/ui-quick-marc/assets/77053927/3073d391-9ef8-4c5c-81d8-258a4ebe2388



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
