### PR TITLE
UIQM-509: Autopopulate subfields when Creating MARC records.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [UIQM-326](https://issues.folio.org/browse/UIQM-326) Add auto-linking MARC bib fields.
 * [UIQM-443](https://issues.folio.org/browse/UIQM-443) Auto-linking MARC bib. Handling multiple authority records matches.
 * [UIQM-436](https://issues.folio.org/browse/UIQM-436) Auto-linking MARC bib. Handling multiple subfield 0.
+* [UIQM-509](https://issues.folio.org/browse/UIQM-509) Autopopulate subfields when Creating MARC records.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/QuickMarcEditor/QuickMarcCreateWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcCreateWrapper.js
@@ -29,6 +29,7 @@ import {
   autopopulateFixedField,
   autopopulatePhysDescriptionField,
   autopopulateMaterialCharsField,
+  autopopulateIndicators,
 } from './utils';
 
 const propTypes = {
@@ -63,6 +64,7 @@ const QuickMarcCreateWrapper = ({
     const formValuesForCreate = flow(
       removeDeletedRecords,
       removeFieldsForDerive,
+      autopopulateIndicators,
       marcRecord => autopopulateFixedField(marcRecord, marcType),
       autopopulatePhysDescriptionField,
       autopopulateMaterialCharsField,


### PR DESCRIPTION
## Description
Autopopulate subfields when Creating MARC records.

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/bc04845e-deff-4d0d-a8b9-56ab1fe3d732


## Issues
[UIQM-509](https://issues.folio.org/browse/UIQM-509)