### PR TITLE
UIQM-545  Change tenant id to central when opening details of Shared Authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [UIQM-542](https://issues.folio.org/browse/UIQM-542) Bump plugin-find-authority and stripes-acq-components.
 * [UIQM-535](https://issues.folio.org/browse/UIQM-535) Update Node.js to v18 in GitHub Actions.
 * [UIQM-544](https://issues.folio.org/browse/UIQM-544) Add "Local" or "Shared" to flag MARC authorities.
+* [UIQM-545](https://issues.folio.org/browse/UIQM-545) Change tenant id to central when opening details of Shared Authority.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/QuickMarcView/MarcContent/MarcContent.js
+++ b/src/QuickMarcView/MarcContent/MarcContent.js
@@ -6,10 +6,18 @@ import MarcField from '../MarcField';
 import { isControlField } from '../utils';
 import styles from './MarcContent.css';
 
+const propTypes = {
+  isPrint: PropTypes.bool,
+  marcTitle: PropTypes.node.isRequired,
+  marc: PropTypes.object.isRequired,
+  tenantId: PropTypes.string,
+};
+
 const MarcContent = ({
   marcTitle,
   marc,
   isPrint,
+  tenantId,
 }) => {
   const showLinkIcon = marc.recordType === 'MARC_BIB';
   const parsedContent = marc.parsedRecord.content;
@@ -43,6 +51,7 @@ const MarcContent = ({
               field={field}
               key={idx}
               showLinkIcon={showLinkIcon}
+              tenantId={tenantId}
             />
           ))}
         </tbody>
@@ -51,11 +60,7 @@ const MarcContent = ({
   );
 };
 
-MarcContent.propTypes = {
-  isPrint: PropTypes.bool,
-  marcTitle: PropTypes.node.isRequired,
-  marc: PropTypes.object.isRequired,
-};
+MarcContent.propTypes = propTypes;
 
 MarcContent.defaultProps = {
   isPrint: false,

--- a/src/QuickMarcView/MarcField.js
+++ b/src/QuickMarcView/MarcField.js
@@ -9,17 +9,26 @@ import PropTypes from 'prop-types';
 import { AppIcon } from '@folio/stripes/core';
 import { Tooltip } from '@folio/stripes/components';
 
-import { normalizeIndicator } from './utils';
-import styles from './MarcField.css';
 import { useAuthorityLinking } from '../hooks';
+import { normalizeIndicator } from './utils';
+
+import styles from './MarcField.css';
+
+const propTypes = {
+  field: PropTypes.object.isRequired,
+  isPrint: PropTypes.bool,
+  showLinkIcon: PropTypes.bool.isRequired,
+  tenantId: PropTypes.string,
+};
 
 const MarcField = ({
   field,
   showLinkIcon,
   isPrint,
+  tenantId,
 }) => {
   const intl = useIntl();
-  const { linkableBibFields } = useAuthorityLinking();
+  const { linkableBibFields } = useAuthorityLinking({ tenantId });
 
   const fieldTag = Object.keys(field)[0];
   const hasIndicators = typeof field[fieldTag] !== 'string';
@@ -104,11 +113,7 @@ const MarcField = ({
   );
 };
 
-MarcField.propTypes = {
-  field: PropTypes.object.isRequired,
-  isPrint: PropTypes.bool,
-  showLinkIcon: PropTypes.bool.isRequired,
-};
+MarcField.propTypes = propTypes;
 
 MarcField.defaultProps = {
   isPrint: false,

--- a/src/QuickMarcView/QuickMarcView.js
+++ b/src/QuickMarcView/QuickMarcView.js
@@ -24,6 +24,7 @@ const propTypes = {
   ]),
   onClose: PropTypes.func.isRequired,
   paneWidth: PropTypes.string,
+  tenantId: PropTypes.string,
 };
 
 const QuickMarcView = ({
@@ -36,6 +37,7 @@ const QuickMarcView = ({
   paneWidth,
   lastMenu,
   isPaneset,
+  tenantId,
 }) => {
   const renderContent = () => (
     <Pane
@@ -53,6 +55,7 @@ const QuickMarcView = ({
       <MarcContent
         marcTitle={marcTitle}
         marc={marc}
+        tenantId={tenantId}
       />
     </Pane>
   );


### PR DESCRIPTION
## Description
 Change tenant id to central when opening details of Shared Authority

## Issues
[UIQM-545](https://issues.folio.org/browse/UIQM-545)

## Related PRs
https://github.com/folio-org/ui-plugin-find-authority/pull/74
https://github.com/folio-org/stripes-authority-components/pull/99
https://github.com/folio-org/ui-marc-authorities/pull/306