### PR TITLE
UIQM-550: Use onClose prop when a derived record is saved to have one source of truth to remove unnecessary params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [UIQM-544](https://issues.folio.org/browse/UIQM-544) Add "Local" or "Shared" to flag MARC authorities.
 * [UIQM-545](https://issues.folio.org/browse/UIQM-545) Change tenant id to central when opening details of Shared Authority.
 * [UIQM-547](https://issues.folio.org/browse/UIQM-547) Link Shared/Local MARC bib record to Shared/Local Authority record.
+* [UIQM-550](https://issues.folio.org/browse/UIQM-550) Use onClose prop when a derived record is saved to have one source of truth to remove unnecessary params.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/QuickMarcEditor/QuickMarcDeriveWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDeriveWrapper.js
@@ -3,7 +3,6 @@ import React, {
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
 import flow from 'lodash/flow';
 
 import { useShowCallout } from '@folio/stripes-acq-components';
@@ -35,10 +34,8 @@ import { useAuthorityLinkingRules } from '../queries';
 
 const propTypes = {
   action: PropTypes.oneOf(Object.values(QUICK_MARC_ACTIONS)).isRequired,
-  history: ReactRouterPropTypes.history.isRequired,
   initialValues: PropTypes.object.isRequired,
   instance: PropTypes.object,
-  location: ReactRouterPropTypes.location.isRequired,
   marcType: PropTypes.oneOf(Object.values(MARC_TYPES)).isRequired,
   mutator: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
@@ -50,8 +47,6 @@ const QuickMarcDeriveWrapper = ({
   onClose,
   initialValues,
   mutator,
-  history,
-  location,
   marcType,
 }) => {
   const showCallout = useShowCallout();
@@ -97,13 +92,6 @@ const QuickMarcDeriveWrapper = ({
     return undefined;
   }, [prepareForSubmit, initialValues, linkableBibFields, linkingRules]);
 
-  const redirectToRecord = (externalId) => {
-    history.push({
-      pathname: `/inventory/view/${externalId}`,
-      search: location.search,
-    });
-  };
-
   const onSubmit = useCallback(async (formValues) => {
     const formValuesToProcess = flow(
       prepareForSubmit,
@@ -131,10 +119,7 @@ const QuickMarcDeriveWrapper = ({
 
     return mutator.quickMarcEditMarcRecord.POST(formValuesForDerive)
       .then(async ({ qmRecordId }) => {
-        history.push({
-          pathname: '/inventory/view/id',
-          search: location.search,
-        });
+        onClose('id'); // https://issues.folio.org/browse/UIQM-82
 
         try {
           const { externalId } = await getQuickMarcRecordStatus({
@@ -147,9 +132,9 @@ const QuickMarcDeriveWrapper = ({
 
           if (recordHasLinks(formValuesForDerive.fields)) {
             saveLinksToNewRecord(mutator, externalId, formValuesForDerive)
-              .finally(() => redirectToRecord(externalId));
+              .finally(() => onClose(externalId));
           } else {
-            redirectToRecord(externalId);
+            onClose(externalId);
           }
         } catch (e) {
           showCallout({

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -97,11 +97,11 @@ const QuickMarcEditorContainer = ({
   const showCallout = useShowCallout();
   const { fetchLinksCount } = useAuthorityLinksCount({ marcType });
 
-  const closeEditor = useCallback(() => {
+  const closeEditor = useCallback((id) => {
     if (marcType === MARC_TYPES.HOLDINGS && action !== QUICK_MARC_ACTIONS.CREATE) {
       onClose(`${instanceId}/${externalId}`);
     } else {
-      onClose(externalId);
+      onClose(id || externalId);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [externalId, onClose]);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Previously, when saving a derived record, the `shared` url parameter was not removed due to using custom behavior on close, not from `ui-inventory`. And if the record is opened again, and it is local, the request was with central tenant, which is wrong and the record could not be found.

Use `onClose` prop from `ui-inventory` when a derived record is saved to have one source of truth to remove unnecessary params.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issue
[UIQM-550](https://issues.folio.org/browse/UIQM-550)

## Related PRs
https://github.com/folio-org/ui-inventory/pull/2249

## Screencast


https://github.com/folio-org/ui-quick-marc/assets/77053927/c9c78015-192d-4957-ba6c-0ef8e30f2753



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
