### PR TITLE
UIQM-530 Create/Edit/Derive MARC bib/holdings/authority - Allow a user to move 00X fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * [UIQM-554](https://issues.folio.org/browse/UIQM-554) Don't pass any arguments to the onClose callback when clicking the Cancel panel button.
 * [UIQM-556](https://issues.folio.org/browse/UIQM-556) Edit Shared MARC authority record, update Shared & Local Instances.
 * [UIQM-558](https://issues.folio.org/browse/UIQM-558) *BREAKING* bump `react-intl` to `v6.4.4`.
+* [UIQM-530](https://issues.folio.org/browse/UIQM-530) Create/Edit/Derive MARC bib/holdings/authority - Allow a user to move 00X fields.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -18,14 +18,14 @@ export const hasAddException = (recordRow, marcType = MARC_TYPES.BIB) => {
   return ADD_EXCEPTION_ROWS[marcType].has(recordRow.tag);
 };
 
-const MOVE_EXCEPTION_ROWS = new Set([LEADER_TAG, '001', '005', '008']);
-
-const MOVE_EXCEPTION_ROWS_FOR_DERIVE = new Set([LEADER_TAG, '001', '003', '005', '008']);
+const MOVE_EXCEPTION_ROWS = {
+  [QUICK_MARC_ACTIONS.CREATE]: new Set([LEADER_TAG]),
+  [QUICK_MARC_ACTIONS.EDIT]: new Set([LEADER_TAG]),
+  [QUICK_MARC_ACTIONS.DERIVE]: new Set([LEADER_TAG]),
+};
 
 export const hasMoveException = (recordRow, sibling, action = QUICK_MARC_ACTIONS.EDIT) => {
-  const rows = action === QUICK_MARC_ACTIONS.DERIVE
-    ? MOVE_EXCEPTION_ROWS_FOR_DERIVE
-    : MOVE_EXCEPTION_ROWS;
+  const rows = MOVE_EXCEPTION_ROWS[action];
 
   return (
     !sibling

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
@@ -37,11 +37,10 @@ describe('QuickMarcEditorRows utils', () => {
   describe('hasMoveException', () => {
     it('should be true for exeptional row', () => {
       expect(utils.hasMoveException({ tag: LEADER_TAG })).toBeTruthy();
-      expect(utils.hasMoveException({ tag: '001' })).toBeTruthy();
     });
 
-    it('should be true for 003 tag for derive action', () => {
-      expect(utils.hasMoveException({ tag: '003' }, { tag: '014' }, QUICK_MARC_ACTIONS.DERIVE)).toBeTruthy();
+    it('should be false for 0XX fields', () => {
+      expect(utils.hasMoveException({ tag: '001' }, { tag: '005' })).toBeFalsy();
     });
 
     it('should be false for common rows', () => {


### PR DESCRIPTION
## Description
Create/Edit/Derive MARC bib/holdings/authority - Allow a user to move 00X fields

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/14e01444-9e17-4796-b579-c12cdd15fde0



## Issues
[UIQM-530](https://issues.folio.org/browse/UIQM-530)