### PR TITLE
UIQM-559: Make auto-linking for the consortium.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [UIQM-552](https://issues.folio.org/browse/UIQM-552) Hide the Shared facet in the plugin for the shared bib record.
 * [UIQM-554](https://issues.folio.org/browse/UIQM-554) Don't pass any arguments to the onClose callback when clicking the Cancel panel button.
 * [UIQM-556](https://issues.folio.org/browse/UIQM-556) Edit Shared MARC authority record, update Shared & Local Instances.
+* [UIQM-559](https://issues.folio.org/browse/UIQM-559) Make auto-linking for the consortium.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/QuickMarcEditor/AutoLinkingButton/AutoLinkingButton.test.js
+++ b/src/QuickMarcEditor/AutoLinkingButton/AutoLinkingButton.test.js
@@ -13,9 +13,10 @@ import { AutoLinkingButton } from './AutoLinkingButton';
 import Harness from '../../../test/jest/helpers/harness';
 import { useAuthorityLinking } from '../../hooks';
 import { MARC_TYPES } from '../../common/constants';
+import { QUICK_MARC_ACTIONS } from '../constants';
 
-const mockFetchLinkSuggestions = jest.fn();
-const mockAutoLinkAuthority = jest.fn();
+const mockSetLoadingLinkSuggestions = jest.fn();
+const mockAutoLinkAuthority = jest.fn().mockResolvedValue();
 const mockMarkRecordsLinked = jest.fn();
 const mockShowCallout = jest.fn();
 
@@ -92,11 +93,12 @@ const formValues = {
 const renderComponent = (props = {}) => render(
   <Harness>
     <AutoLinkingButton
+      action={QUICK_MARC_ACTIONS.EDIT}
       marcType={MARC_TYPES.BIB}
       formValues={formValues}
       isLoadingLinkSuggestions={false}
       onMarkRecordsLinked={mockMarkRecordsLinked}
-      onFetchLinkSuggestions={mockFetchLinkSuggestions}
+      onSetIsLoadingLinkSuggestions={mockSetLoadingLinkSuggestions}
       {...props}
     />
   </Harness>,
@@ -111,6 +113,10 @@ describe('Given AutoLinkingButton', () => {
       autoLinkAuthority: mockAutoLinkAuthority,
     });
     IfPermission.mockImplementation(({ children }) => children);
+    mockAutoLinkAuthority.mockResolvedValue({
+      fields: [],
+      suggestedFields: [],
+    });
   });
 
   it('should render with no axe errors', async () => {
@@ -175,13 +181,13 @@ describe('Given AutoLinkingButton', () => {
   describe('when user clicks on the button', () => {
     describe('when auto-linking fails', () => {
       it('should show generic error message', async () => {
-        mockFetchLinkSuggestions.mockRejectedValue(null);
+        mockAutoLinkAuthority.mockRejectedValue(null);
 
         const { getByTestId } = renderComponent();
 
         await act(async () => { fireEvent.click(getByTestId('autoLinkingButton')); });
 
-        expect(mockFetchLinkSuggestions).toHaveBeenCalled();
+        expect(mockAutoLinkAuthority).toHaveBeenCalled();
         expect(mockShowCallout).toHaveBeenCalledWith({
           messageId: 'ui-quick-marc.records.error.autoLinking',
           type: 'error',
@@ -190,70 +196,40 @@ describe('Given AutoLinkingButton', () => {
     });
 
     it('should handle auto-linking', async () => {
-      const payload = {
-        leader: '05274cam\\a2201021\\i\\4500',
-        marcFormat: MARC_TYPES.BIB,
-        _actionType: 'view',
-        fields: [
+      const _formValues = {
+        records: [
           {
             'tag': '100',
-            'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-          },
-          {
+            'content': '$a Coates, Ta-Nehisi $e author. $0 n2008001084',
+            'indicators': ['1', '\\'],
+            'isProtected': false,
+            'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }, {
             'tag': '700',
-            'content': '$a Stelfreeze, Brian, $e artist. $0 no2005093867',
-          },
-          {
-            'tag': '700',
-            'content': '$a Sprouse, Chris, $e artist. $0 test2',
-          },
-          {
-            'tag': '700',
-            'content': '$a Martin, Laura $c (Comic book artist), $e colorist. $0 no2005093868 $0 n123456',
-          },
-        ],
-      };
-
-      const data = {
-        leader: '05274cam\\a2201021\\i\\4500',
-        suppressDiscovery: false,
-        _actionType: 'view',
-        fields: [
-          {
-            'tag': '100',
-            'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 125ef84d-c372-4508-bf9b-08c7f2a0b02e',
-            'linkDetails': {
-              'authorityId': '125ef84d-c372-4508-bf9b-08c7f2a0b02e',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 1,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '700',
-            'content': '$a Zhang, Xuejing $e artist. $0 id.loc.gov/authorities/names/no2005093867 $9 4fb6282f-771f-469b-b182-691432e6a45a',
-            'linkDetails': {
-              'authorityId': '4fb6282f-771f-469b-b182-691432e6a45a',
-              'authorityNaturalId': 'no2005093867',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-          {
+            'content': '$a Zhang, Xuejing $e artist. $0 id.loc.gov/authorities/names/no2005093867',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }, {
             'tag': '700',
             'content': '$a Sprouse, Chris, $e artist. $0 test2',
-            'linkDetails': {
-              'status': 'ERROR',
-              'errorCause': '101',
-            },
-          },
-          {
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'kt44d91c-6915-4609-9fd1-bbe470f47434',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }, {
             'tag': '700',
             'content': '$a Martin, Laura $c (Comic book artist), $e colorist. $0 no2005093868 $0 n123456',
-            'linkDetails': {
-              'status': 'ERROR',
-              'errorCause': '102',
-            },
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'nj44d91c-6915-4609-9fd1-bbe470f474pw',
+            '_isDeleted': false,
+            '_isLinked': false,
           },
         ],
       };
@@ -261,15 +237,95 @@ describe('Given AutoLinkingButton', () => {
       const fields = [
         {
           'tag': '100',
-          'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
+          'content': '$a Coates, Ta-Nehisi $e author. $0 n2008001084',
+          'indicators': ['1', '\\'],
+          'isProtected': false,
+          'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
+          '_isDeleted': false,
+          '_isLinked': false,
+          'linkDetails': {
+            'authorityId': '125ef84d-c372-4508-bf9b-08c7f2a0b02e',
+            'authorityNaturalId': 'n2008001084',
+            'linkingRuleId': 1,
+            'status': 'NEW',
+          },
+        }, {
+          'tag': '700',
+          'content': '$a Zhang, Xuejing $e artist. $0 id.loc.gov/authorities/names/no2005093867',
+          'indicators': ['0', '0'],
+          'isProtected': false,
+          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+          '_isDeleted': false,
+          '_isLinked': false,
+          'linkDetails': {
+            'authorityId': '4fb6282f-771f-469b-b182-691432e6a45a',
+            'authorityNaturalId': 'no2005093867',
+            'linkingRuleId': 15,
+            'status': 'NEW',
+          },
+        }, {
+          'tag': '700',
+          'content': '$a Sprouse, Chris, $e artist. $0 test2',
+          'indicators': ['0', '0'],
+          'isProtected': false,
+          'id': 'kt44d91c-6915-4609-9fd1-bbe470f47434',
+          '_isDeleted': false,
+          '_isLinked': false,
+          'linkDetails': {
+            'status': 'ERROR',
+            'errorCause': '101',
+          },
+        }, {
+          'tag': '700',
+          'content': '$a Martin, Laura $c (Comic book artist), $e colorist. $0 no2005093868 $0 n123456',
+          'indicators': ['0', '0'],
+          'isProtected': false,
+          'id': 'nj44d91c-6915-4609-9fd1-bbe470f474pw',
+          '_isDeleted': false,
+          '_isLinked': false,
+          'linkDetails': {
+            'status': 'ERROR',
+            'errorCause': '102',
+          },
+        },
+      ];
+
+      const suggestedFields = [
+        {
+          'tag': '100',
+          'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 125ef84d-c372-4508-bf9b-08c7f2a0b02e',
+          'linkDetails': {
+            'authorityId': '125ef84d-c372-4508-bf9b-08c7f2a0b02e',
+            'authorityNaturalId': 'n2008001084',
+            'linkingRuleId': 1,
+            'status': 'NEW',
+          },
         },
         {
           'tag': '700',
-          'content': '$a Stelfreeze, Brian, $e artist. $0 no2005093867',
+          'content': '$a Zhang, Xuejing $e artist. $0 id.loc.gov/authorities/names/no2005093867 $9 4fb6282f-771f-469b-b182-691432e6a45a',
+          'linkDetails': {
+            'authorityId': '4fb6282f-771f-469b-b182-691432e6a45a',
+            'authorityNaturalId': 'no2005093867',
+            'linkingRuleId': 15,
+            'status': 'NEW',
+          },
         },
         {
           'tag': '700',
           'content': '$a Sprouse, Chris, $e artist. $0 test2',
+          'linkDetails': {
+            'status': 'ERROR',
+            'errorCause': '101',
+          },
+        },
+        {
+          'tag': '700',
+          'content': '$a Martin, Laura $c (Comic book artist), $e colorist. $0 no2005093868 $0 n123456',
+          'linkDetails': {
+            'status': 'ERROR',
+            'errorCause': '102',
+          },
         },
       ];
 
@@ -302,15 +358,17 @@ describe('Given AutoLinkingButton', () => {
         },
       ];
 
-      mockFetchLinkSuggestions.mockResolvedValue(data);
-      mockAutoLinkAuthority.mockReturnValue(fields);
+      mockAutoLinkAuthority.mockResolvedValue({ fields, suggestedFields });
 
-      const { getByTestId } = renderComponent({ formValues });
+      const { getByTestId } = renderComponent({ formValues: _formValues });
 
-      await act(async () => { fireEvent.click(getByTestId('autoLinkingButton')); });
+      await act(async () => {
+        fireEvent.click(getByTestId('autoLinkingButton'));
+        expect(mockSetLoadingLinkSuggestions).toHaveBeenNthCalledWith(1, true);
+      });
 
-      expect(mockFetchLinkSuggestions).toHaveBeenCalledWith({ body: payload });
-      expect(mockAutoLinkAuthority).toHaveBeenCalledWith(formValues.records, data.fields);
+      expect(mockSetLoadingLinkSuggestions).toHaveBeenNthCalledWith(2, false);
+      expect(mockAutoLinkAuthority).toHaveBeenCalledWith(_formValues);
       expect(mockMarkRecordsLinked).toHaveBeenCalledWith({ fields });
       expect(mockShowCallout).toHaveBeenCalledTimes(3);
 

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -108,6 +108,7 @@ const QuickMarcEditor = ({
   const [isDeleteModalOpened, setIsDeleteModalOpened] = useState(false);
   const [isUnlinkRecordsModalOpen, setIsUnlinkRecordsModalOpen] = useState(false);
   const [isUpdate0101xxfieldsAuthRecModalOpen, setIsUpdate0101xxfieldsAuthRecModalOpen] = useState(false);
+  const [isLoadingLinkSuggestions, setIsLoadingLinkSuggestions] = useState(false);
   const continueAfterSave = useRef(false);
   const formRef = useRef(null);
   const confirmationChecks = useRef({ ...REQUIRED_CONFIRMATIONS });
@@ -115,11 +116,7 @@ const QuickMarcEditor = ({
   const searchParameters = new URLSearchParams(location.search);
   const isShared = searchParameters.get('shared') === 'true';
 
-  const {
-    unlinkAuthority,
-    fetchLinkSuggestions,
-    isLoadingLinkSuggestions,
-  } = useAuthorityLinking({ marcType, action });
+  const { unlinkAuthority } = useAuthorityLinking({ marcType, action });
 
   const deletedRecords = useMemo(() => {
     return records
@@ -454,8 +451,8 @@ const QuickMarcEditor = ({
                     marcType={marcType}
                     formValues={formValues}
                     isLoadingLinkSuggestions={isLoadingLinkSuggestions}
-                    onFetchLinkSuggestions={fetchLinkSuggestions}
                     onMarkRecordsLinked={mutators.markRecordsLinked}
+                    onSetIsLoadingLinkSuggestions={setIsLoadingLinkSuggestions}
                   />
                 </PaneMenu>
               )}

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -1573,14 +1573,3 @@ export const applyCentralTenantInHeaders = (location, stripes, marcType) => {
     && checkIfUserInMemberTenant(stripes)
   );
 };
-
-export const checkIfRecordWithCentralAndMemberSuggestions = ({ search, marcType, isMemberTenant, action }) => {
-  const searchParams = new URLSearchParams(search);
-  const isSharedRecord = searchParams.get('shared') === 'true';
-
-  return (
-    marcType === MARC_TYPES.BIB
-    && isMemberTenant
-    && (!isSharedRecord || (isSharedRecord && action === QUICK_MARC_ACTIONS.DERIVE))
-  );
-};

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -15,7 +15,7 @@ import {
 import { MARC_TYPES } from '../../common/constants';
 import { QUICK_MARC_ACTIONS } from '../../QuickMarcEditor/constants';
 
-const mockFetchLinkSuggestions = jest.fn();
+const mockFetchLinkSuggestions = jest.fn().mockResolvedValue({ fields: [] });
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -248,535 +248,41 @@ describe('Given useAuthorityLinking', () => {
   });
 
   describe('when calling autoLinkAuthority', () => {
-    it('should link fields', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const fields = [
-        {
-          'tag': '100',
-          'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-          'indicators': ['1', '\\'],
-          'isProtected': false,
-          'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }, {
-          'tag': '600',
-          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-        },
-      ];
-
-      const suggestedFields = [
-        {
-          'tag': '100',
-          'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-          'linkDetails': {
-            'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
-            'authorityNaturalId': 'n2008001084',
-            'linkingRuleId': 1,
-            'status': 'NEW',
-          },
-        }, {
-          'tag': '600',
-          'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-          'linkDetails': {
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'authorityNaturalId': 'nr2005025774',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-        },
-      ];
-
-      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([
-        {
-          'tag': '100',
-          'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-          'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-          'indicators': ['1', '\\'],
-          'isProtected': false,
-          'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
-          '_isDeleted': false,
-          '_isLinked': false,
-          'linkDetails': {
-            'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
-            'authorityNaturalId': 'n2008001084',
-            'linkingRuleId': 1,
-            'status': 'NEW',
-          },
-          'subfieldGroups': {
-            'controlled': '$a Coates, Ta-Nehisi',
-            'uncontrolledAlpha': '$e author.',
-            'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
-            'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-            'uncontrolledNumber': '',
-          },
-        }, {
-          'tag': '600',
-          'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-          'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-          'linkDetails': {
-            'authorityNaturalId': 'nr2005025774',
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-          'subfieldGroups': {
-            'controlled': '$a Brown, Benjamin, $d 1966-',
-            'uncontrolledAlpha': '$v Comic books, strips, etc.',
-            'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
-            'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'uncontrolledNumber': '',
-          },
-        },
-      ]);
-    });
-  });
-
-  describe('when calling autoLinkAuthority', () => {
-    it('should not link fields without $0', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const fields = [
-        {
-          'tag': '600',
-          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc.',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }, {
-          'tag': '600',
-          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-        },
-      ];
-
-      const suggestedFields = [{
-        'tag': '600',
-        'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-        'linkDetails': {
-          'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-          'authorityNaturalId': 'nr2005025774',
-          'linkingRuleId': 8,
-          'status': 'NEW',
-        },
-      }];
-
-      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([
-        {
-          'tag': '600',
-          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc.',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }, {
-          'tag': '600',
-          'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-          'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-          'linkDetails': {
-            'authorityNaturalId': 'nr2005025774',
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-          'subfieldGroups': {
-            'controlled': '$a Brown, Benjamin, $d 1966-',
-            'uncontrolledAlpha': '$v Comic books, strips, etc.',
-            'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
-            'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'uncontrolledNumber': '',
-          },
-        },
-      ]);
-    });
-  });
-
-  describe('when calling autoLinkAuthority', () => {
-    it('should link in the correct order', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const fields = [
-        {
-          'tag': '600',
-          'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-          'indicators': ['0', '7'],
-          'isProtected': false,
-          'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }, {
-          'tag': '600',
-          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-        },
-      ];
-
-      const suggestedFields = [
-        {
-          'tag': '600',
-          'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 1803fee8-dfd8-42b8-a292-681af0cadb77',
-          'linkDetails': {
-            'authorityNaturalId': 'n93100664',
-            'authorityId': '1803fee8-dfd8-42b8-a292-681af0cadb77',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-        }, {
-          'tag': '600',
-          'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-          'linkDetails': {
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'authorityNaturalId': 'nr2005025774',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-        },
-      ];
-
-      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([
-        {
-          'tag': '600',
-          'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 1803fee8-dfd8-42b8-a292-681af0cadb77',
-          'prevContent': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-          'indicators': ['0', '7'],
-          'isProtected': false,
-          'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-          '_isDeleted': false,
-          '_isLinked': false,
-          'linkDetails': {
-            'authorityNaturalId': 'n93100664',
-            'authorityId': '1803fee8-dfd8-42b8-a292-681af0cadb77',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-          'subfieldGroups': {
-            'controlled': '$a Yuan, Bing',
-            'uncontrolledAlpha': '',
-            'zeroSubfield': '$0 id.loc.gov/authorities/names/n93100664',
-            'nineSubfield': '$9 1803fee8-dfd8-42b8-a292-681af0cadb77',
-            'uncontrolledNumber': '',
-          },
-        }, {
-          'tag': '600',
-          'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-          'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-          'linkDetails': {
-            'authorityNaturalId': 'nr2005025774',
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-          'subfieldGroups': {
-            'controlled': '$a Brown, Benjamin, $d 1966-',
-            'uncontrolledAlpha': '$v Comic books, strips, etc.',
-            'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
-            'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'uncontrolledNumber': '',
-          },
-        },
-      ]);
-    });
-  });
-
-  describe('when calling autoLinkAuthority and returning an error for a field with the same tag', () => {
-    it('should link in the correct order', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const fields = [
-        {
-          'tag': '600',
-          'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-          'indicators': ['0', '7'],
-          'isProtected': false,
-          'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }, {
-          'tag': '600',
-          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-        },
-      ];
-
-      const suggestedFields = [
-        {
-          'tag': '600',
-          'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-          'linkDetails': {
-            'status': 'ERROR',
-          },
-        }, {
-          'tag': '600',
-          'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-          'linkDetails': {
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'authorityNaturalId': 'nr2005025774',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-        },
-      ];
-
-      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([
-        {
-          'tag': '600',
-          'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-          'indicators': ['0', '7'],
-          'isProtected': false,
-          'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }, {
-          'tag': '600',
-          'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-          'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-          'linkDetails': {
-            'authorityNaturalId': 'nr2005025774',
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-          'subfieldGroups': {
-            'controlled': '$a Brown, Benjamin, $d 1966-',
-            'uncontrolledAlpha': '$v Comic books, strips, etc.',
-            'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
-            'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'uncontrolledNumber': '',
-          },
-        },
-      ]);
-    });
-  });
-
-  describe('when calling autoLinkAuthority and there is no suggestion for a field with the same tag', () => {
-    it('should link in the correct order', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const fields = [
-        {
-          'tag': '600',
-          'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-          'indicators': ['0', '7'],
-          'isProtected': false,
-          'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }, {
-          'tag': '600',
-          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-        },
-      ];
-
-      const suggestedFields = [
-        {
-          'tag': '600',
-          'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-        }, {
-          'tag': '600',
-          'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-          'linkDetails': {
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'authorityNaturalId': 'nr2005025774',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-        },
-      ];
-
-      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([
-        {
-          'tag': '600',
-          'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-          'indicators': ['0', '7'],
-          'isProtected': false,
-          'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }, {
-          'tag': '600',
-          'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-          'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-          'linkDetails': {
-            'authorityNaturalId': 'nr2005025774',
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'linkingRuleId': 8,
-            'status': 'NEW',
-          },
-          'subfieldGroups': {
-            'controlled': '$a Brown, Benjamin, $d 1966-',
-            'uncontrolledAlpha': '$v Comic books, strips, etc.',
-            'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
-            'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'uncontrolledNumber': '',
-          },
-        },
-      ]);
-    });
-  });
-
-  describe('when calling autoLinkAuthority and there is a field with ERROR status and there is no $9', () => {
-    it('should be left as is', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const fields = [{
-        'tag': '600',
-        'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
-        'indicators': ['\\', '0'],
-        'isProtected': false,
-        'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
-        '_isDeleted': false,
-        '_isLinked': false,
-      }];
-
-      const suggestedFields = [{
-        'tag': '600',
-        'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
-        'linkDetails': {
-          'status': 'ERROR',
-          'errorCause': '101',
-        },
-      }];
-
-      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([{
-        'tag': '600',
-        'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
-        'indicators': ['\\', '0'],
-        'isProtected': false,
-        'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
-        '_isDeleted': false,
-        '_isLinked': false,
-      }]);
-    });
-  });
-
-  describe('when calling autoLinkAuthority and there is a field with ERROR status and there is $9', () => {
-    it('should get rid of the $9', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const fields = [{
-        'tag': '600',
-        'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135 $9 UUID',
-        'indicators': ['\\', '0'],
-        'isProtected': false,
-        'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
-        '_isDeleted': false,
-        '_isLinked': false,
-      }];
-
-      const suggestedFields = [{
-        'tag': '600',
-        'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135 $9 UUID',
-        'linkDetails': {
-          'status': 'ERROR',
-          'errorCause': '101',
-        },
-      }];
-
-      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([{
-        'tag': '600',
-        'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
-        'indicators': ['\\', '0'],
-        'isProtected': false,
-        'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
-        '_isDeleted': false,
-        '_isLinked': false,
-      }]);
-    });
-  });
-
-  describe('when there is already a linked field', () => {
-    describe('and the user enters $9 into the split uncontrolledNumber or uncontrolledAlpha field and calls autoLinkAuthority', () => {
-      it('should get rid of the $9', () => {
-        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-        const fields = [
+    it('should link fields', async () => {
+      const formValues = {
+        records: [
           {
             'tag': '100',
-            'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 0c63add7-b3f3-4eae-874d-c659acb95174',
+            'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
             'indicators': ['1', '\\'],
             'isProtected': false,
-            'id': 'cb867f32-c4ba-4714-91cb-6f828765b17a',
+            'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
             '_isDeleted': false,
-            '_isLinked': true,
+            '_isLinked': false,
+          }, {
+            'tag': '600',
+            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+          },
+        ],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [
+          {
+            'tag': '100',
+            'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
             'linkDetails': {
-              'authorityId': '0c63add7-b3f3-4eae-874d-c659acb95174',
+              'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
               'authorityNaturalId': 'n2008001084',
               'linkingRuleId': 1,
               'status': 'NEW',
             },
-            'subfieldGroups': {
-              'controlled': '$a Coates, Ta-Nehisi',
-              'uncontrolledAlpha': '$e author. $9 test',
-              'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
-              'nineSubfield': '$9 0c63add7-b3f3-4eae-874d-c659acb95174',
-              'uncontrolledNumber': '$9 test $2 test',
-            },
-            'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-          },
-          {
-            'tag': '600',
-            'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
-            'indicators': ['\\', '0'],
-            'isProtected': false,
-            'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
-            '_isDeleted': false,
-            '_isLinked': false,
-          },
-        ];
-
-        const suggestedFields = [
-          {
+          }, {
             'tag': '600',
             'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
             'linkDetails': {
@@ -786,19 +292,28 @@ describe('Given useAuthorityLinking', () => {
               'status': 'NEW',
             },
           },
-        ];
+        ],
+      };
 
-        expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const outcome = await result.current.autoLinkAuthority(formValues);
+
+      expect(outcome).toEqual({
+        fields: [
           {
             'tag': '100',
-            'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 0c63add7-b3f3-4eae-874d-c659acb95174',
+            'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+            'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
             'indicators': ['1', '\\'],
             'isProtected': false,
-            'id': 'cb867f32-c4ba-4714-91cb-6f828765b17a',
+            'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
             '_isDeleted': false,
-            '_isLinked': true,
+            '_isLinked': false,
             'linkDetails': {
-              'authorityId': '0c63add7-b3f3-4eae-874d-c659acb95174',
+              'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
               'authorityNaturalId': 'n2008001084',
               'linkingRuleId': 1,
               'status': 'NEW',
@@ -807,148 +322,736 @@ describe('Given useAuthorityLinking', () => {
               'controlled': '$a Coates, Ta-Nehisi',
               'uncontrolledAlpha': '$e author.',
               'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
-              'nineSubfield': '$9 0c63add7-b3f3-4eae-874d-c659acb95174',
-              'uncontrolledNumber': '$2 test',
+              'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'uncontrolledNumber': '',
             },
-            'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-          },
-          {
+          }, {
             'tag': '600',
             'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'prevContent': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
+            'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+            'linkDetails': {
+              'authorityNaturalId': 'nr2005025774',
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkingRuleId': 8,
+              'status': 'NEW',
+            },
+            'subfieldGroups': {
+              'controlled': '$a Brown, Benjamin, $d 1966-',
+              'uncontrolledAlpha': '$v Comic books, strips, etc.',
+              'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
+              'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'uncontrolledNumber': '',
+            },
+          },
+        ],
+        suggestedFields: linkSuggestionsResponse.fields,
+      });
+    });
+  });
+
+  describe('when calling autoLinkAuthority', () => {
+    it('should not link fields without $0', async () => {
+      const formValues = {
+        records: [
+          {
+            'tag': '600',
+            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc.',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }, {
+            'tag': '600',
+            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+          },
+        ],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [{
+          'tag': '600',
+          'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+          'linkDetails': {
+            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'authorityNaturalId': 'nr2005025774',
+            'linkingRuleId': 8,
+            'status': 'NEW',
+          },
+        }],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const outcome = await result.current.autoLinkAuthority(formValues);
+
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: [
+          {
+            'tag': '600',
+            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc.',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }, {
+            'tag': '600',
+            'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+            'linkDetails': {
+              'authorityNaturalId': 'nr2005025774',
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkingRuleId': 8,
+              'status': 'NEW',
+            },
+            'subfieldGroups': {
+              'controlled': '$a Brown, Benjamin, $d 1966-',
+              'uncontrolledAlpha': '$v Comic books, strips, etc.',
+              'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
+              'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'uncontrolledNumber': '',
+            },
+          },
+        ],
+      }));
+    });
+  });
+
+  describe('when calling autoLinkAuthority', () => {
+    it('should link in the correct order', async () => {
+      const formValues = {
+        records: [
+          {
+            'tag': '600',
+            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+            'indicators': ['0', '7'],
+            'isProtected': false,
+            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }, {
+            'tag': '600',
+            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+          },
+        ],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [
+          {
+            'tag': '600',
+            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 1803fee8-dfd8-42b8-a292-681af0cadb77',
+            'linkDetails': {
+              'authorityNaturalId': 'n93100664',
+              'authorityId': '1803fee8-dfd8-42b8-a292-681af0cadb77',
+              'linkingRuleId': 8,
+              'status': 'NEW',
+            },
+          }, {
+            'tag': '600',
+            'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
             'linkDetails': {
               'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
               'authorityNaturalId': 'nr2005025774',
               'linkingRuleId': 8,
               'status': 'NEW',
             },
+          },
+        ],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const outcome = await result.current.autoLinkAuthority(formValues);
+
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: [
+          {
+            'tag': '600',
+            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 1803fee8-dfd8-42b8-a292-681af0cadb77',
+            'prevContent': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+            'indicators': ['0', '7'],
+            'isProtected': false,
+            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            '_isDeleted': false,
+            '_isLinked': false,
+            'linkDetails': {
+              'authorityNaturalId': 'n93100664',
+              'authorityId': '1803fee8-dfd8-42b8-a292-681af0cadb77',
+              'linkingRuleId': 8,
+              'status': 'NEW',
+            },
+            'subfieldGroups': {
+              'controlled': '$a Yuan, Bing',
+              'uncontrolledAlpha': '',
+              'zeroSubfield': '$0 id.loc.gov/authorities/names/n93100664',
+              'nineSubfield': '$9 1803fee8-dfd8-42b8-a292-681af0cadb77',
+              'uncontrolledNumber': '',
+            },
+          }, {
+            'tag': '600',
+            'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+            'linkDetails': {
+              'authorityNaturalId': 'nr2005025774',
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkingRuleId': 8,
+              'status': 'NEW',
+            },
             'subfieldGroups': {
               'controlled': '$a Brown, Benjamin, $d 1966-',
-              'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
               'uncontrolledAlpha': '$v Comic books, strips, etc.',
-              'uncontrolledNumber': '',
               'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
+              'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'uncontrolledNumber': '',
             },
-            'indicators': ['\\', '0'],
+          },
+        ],
+      }));
+    });
+  });
+
+  describe('when calling autoLinkAuthority and returning an error for a field with the same tag', () => {
+    it('should link in the correct order', async () => {
+      const formValues = {
+        records: [
+          {
+            'tag': '600',
+            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+            'indicators': ['0', '7'],
             'isProtected': false,
-            'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
+            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }, {
+            'tag': '600',
+            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
             '_isDeleted': false,
             '_isLinked': false,
           },
-        ]);
+        ],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [
+          {
+            'tag': '600',
+            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+            'linkDetails': {
+              'status': 'ERROR',
+            },
+          }, {
+            'tag': '600',
+            'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'linkDetails': {
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'authorityNaturalId': 'nr2005025774',
+              'linkingRuleId': 8,
+              'status': 'NEW',
+            },
+          },
+        ],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const outcome = await result.current.autoLinkAuthority(formValues);
+
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: [
+          {
+            'tag': '600',
+            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+            'indicators': ['0', '7'],
+            'isProtected': false,
+            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }, {
+            'tag': '600',
+            'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+            'linkDetails': {
+              'authorityNaturalId': 'nr2005025774',
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkingRuleId': 8,
+              'status': 'NEW',
+            },
+            'subfieldGroups': {
+              'controlled': '$a Brown, Benjamin, $d 1966-',
+              'uncontrolledAlpha': '$v Comic books, strips, etc.',
+              'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
+              'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'uncontrolledNumber': '',
+            },
+          },
+        ],
+      }));
+    });
+  });
+
+  describe('when calling autoLinkAuthority and there is no suggestion for a field with the same tag', () => {
+    it('should link in the correct order', async () => {
+      const formValues = {
+        records: [
+          {
+            'tag': '600',
+            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+            'indicators': ['0', '7'],
+            'isProtected': false,
+            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }, {
+            'tag': '600',
+            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+          },
+        ],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [
+          {
+            'tag': '600',
+            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+          }, {
+            'tag': '600',
+            'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'linkDetails': {
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'authorityNaturalId': 'nr2005025774',
+              'linkingRuleId': 8,
+              'status': 'NEW',
+            },
+          },
+        ],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const outcome = await result.current.autoLinkAuthority(formValues);
+
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: [
+          {
+            'tag': '600',
+            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+            'indicators': ['0', '7'],
+            'isProtected': false,
+            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }, {
+            'tag': '600',
+            'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+            'linkDetails': {
+              'authorityNaturalId': 'nr2005025774',
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkingRuleId': 8,
+              'status': 'NEW',
+            },
+            'subfieldGroups': {
+              'controlled': '$a Brown, Benjamin, $d 1966-',
+              'uncontrolledAlpha': '$v Comic books, strips, etc.',
+              'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
+              'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'uncontrolledNumber': '',
+            },
+          },
+        ],
+      }));
+    });
+  });
+
+  describe('when calling autoLinkAuthority and there is a field with ERROR status and there is no $9', () => {
+    it('should be left as is', async () => {
+      const formValues = {
+        records: [{
+          'tag': '600',
+          'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
+          'indicators': ['\\', '0'],
+          'isProtected': false,
+          'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
+          '_isDeleted': false,
+          '_isLinked': false,
+        }],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [{
+          'tag': '600',
+          'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
+          'linkDetails': {
+            'status': 'ERROR',
+            'errorCause': '101',
+          },
+        }],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const outcome = await result.current.autoLinkAuthority(formValues);
+
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: formValues.records,
+      }));
+    });
+  });
+
+  describe('when calling autoLinkAuthority and there is a field with ERROR status and there is $9', () => {
+    it('should get rid of the $9', async () => {
+      const formValues = {
+        records: [{
+          'tag': '600',
+          'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135 $9 UUID',
+          'indicators': ['\\', '0'],
+          'isProtected': false,
+          'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
+          '_isDeleted': false,
+          '_isLinked': false,
+        }],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [{
+          'tag': '600',
+          'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135 $9 UUID',
+          'linkDetails': {
+            'status': 'ERROR',
+            'errorCause': '101',
+          },
+        }],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const outcome = await result.current.autoLinkAuthority(formValues);
+
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: [{
+          'tag': '600',
+          'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
+          'indicators': ['\\', '0'],
+          'isProtected': false,
+          'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
+          '_isDeleted': false,
+          '_isLinked': false,
+        }],
+      }));
+    });
+  });
+
+  describe('when there is already a linked field', () => {
+    describe('and the user enters $9 into the split uncontrolledNumber or uncontrolledAlpha field and calls autoLinkAuthority', () => {
+      it('should get rid of the $9', async () => {
+        const formValues = {
+          records: [
+            {
+              'tag': '100',
+              'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 0c63add7-b3f3-4eae-874d-c659acb95174',
+              'indicators': ['1', '\\'],
+              'isProtected': false,
+              'id': 'cb867f32-c4ba-4714-91cb-6f828765b17a',
+              '_isDeleted': false,
+              '_isLinked': true,
+              'linkDetails': {
+                'authorityId': '0c63add7-b3f3-4eae-874d-c659acb95174',
+                'authorityNaturalId': 'n2008001084',
+                'linkingRuleId': 1,
+                'status': 'NEW',
+              },
+              'subfieldGroups': {
+                'controlled': '$a Coates, Ta-Nehisi',
+                'uncontrolledAlpha': '$e author. $9 test',
+                'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
+                'nineSubfield': '$9 0c63add7-b3f3-4eae-874d-c659acb95174',
+                'uncontrolledNumber': '$9 test $2 test',
+              },
+              'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
+            },
+            {
+              'tag': '600',
+              'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
+              'indicators': ['\\', '0'],
+              'isProtected': false,
+              'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
+              '_isDeleted': false,
+              '_isLinked': false,
+            },
+          ],
+        };
+
+        const linkSuggestionsResponse = {
+          fields: [
+            {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkDetails': {
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'authorityNaturalId': 'nr2005025774',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+            },
+          ],
+        };
+
+        mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const outcome = await result.current.autoLinkAuthority(formValues);
+
+        expect(outcome).toEqual(expect.objectContaining({
+          fields: [
+            {
+              'tag': '100',
+              'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 0c63add7-b3f3-4eae-874d-c659acb95174',
+              'indicators': ['1', '\\'],
+              'isProtected': false,
+              'id': 'cb867f32-c4ba-4714-91cb-6f828765b17a',
+              '_isDeleted': false,
+              '_isLinked': true,
+              'linkDetails': {
+                'authorityId': '0c63add7-b3f3-4eae-874d-c659acb95174',
+                'authorityNaturalId': 'n2008001084',
+                'linkingRuleId': 1,
+                'status': 'NEW',
+              },
+              'subfieldGroups': {
+                'controlled': '$a Coates, Ta-Nehisi',
+                'uncontrolledAlpha': '$e author.',
+                'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
+                'nineSubfield': '$9 0c63add7-b3f3-4eae-874d-c659acb95174',
+                'uncontrolledNumber': '$2 test',
+              },
+              'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
+            },
+            {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'prevContent': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
+              'linkDetails': {
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'authorityNaturalId': 'nr2005025774',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+              'subfieldGroups': {
+                'controlled': '$a Brown, Benjamin, $d 1966-',
+                'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'uncontrolledAlpha': '$v Comic books, strips, etc.',
+                'uncontrolledNumber': '',
+                'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
+              },
+              'indicators': ['\\', '0'],
+              'isProtected': false,
+              'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
+              '_isDeleted': false,
+              '_isLinked': false,
+            },
+          ],
+        }));
       });
     });
   });
 
   describe('when calling autoLinkAuthority and there is a field that cannot be linked', () => {
-    it('should be left as is', () => {
+    it('should be left as is', async () => {
+      const formValues = {
+        records: [{
+          'tag': '600',
+          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+          'indicators': ['0', '0'],
+          'isProtected': false,
+          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+          '_isDeleted': false,
+          '_isLinked': false,
+        }],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [{
+          'tag': '600',
+          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+        }],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
       const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
 
-      const fields = [{
-        'tag': '600',
-        'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-        'indicators': ['0', '0'],
-        'isProtected': false,
-        'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-        '_isDeleted': false,
-        '_isLinked': false,
-      }];
+      const outcome = await result.current.autoLinkAuthority(formValues);
 
-      const suggestedFields = [{
-        'tag': '600',
-        'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-      }];
-
-      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([{
-        'tag': '600',
-        'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-        'indicators': ['0', '0'],
-        'isProtected': false,
-        'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-        '_isDeleted': false,
-        '_isLinked': false,
-      }]);
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: [{
+          'tag': '600',
+          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+          'indicators': ['0', '0'],
+          'isProtected': false,
+          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+          '_isDeleted': false,
+          '_isLinked': false,
+        }],
+      }));
     });
   });
 
   describe('when calling autoLinkAuthority', () => {
-    it('should take uncontrolled subfields from the current field, not from suggested one', () => {
+    it('should take uncontrolled subfields from the current field, not from suggested one', async () => {
+      const formValues = {
+        records: [
+          {
+            'tag': '711',
+            'content': '$j something $0 n2008001084 $2 fast $f test',
+            'indicators': ['\\', '\\'],
+            'isProtected': false,
+            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            '_isDeleted': false,
+            '_isLinked': false,
+          },
+        ],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [
+          {
+            'tag': '711',
+            'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Roma Council $c Basilica $d 1962-1965 : $n (2nd : $9 5d80ecfa-7370-460e-9e27-3883a7656fe1 $j test',
+            'linkDetails': {
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'authorityNaturalId': 'n2008001084',
+              'linkingRuleId': 17,
+              'status': 'NEW',
+            },
+          },
+        ],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
       const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
 
-      const fields = [
-        {
-          'tag': '711',
-          'content': '$j something $0 n2008001084 $2 fast $f test',
-          'indicators': ['\\', '\\'],
-          'isProtected': false,
-          'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-          '_isDeleted': false,
-          '_isLinked': false,
-        },
-      ];
+      const outcome = await result.current.autoLinkAuthority(formValues);
 
-      const suggestedFields = [
-        {
-          'tag': '711',
-          'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Roma Council $c Basilica $d 1962-1965 : $n (2nd : $9 5d80ecfa-7370-460e-9e27-3883a7656fe1 $j test',
-          'linkDetails': {
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'authorityNaturalId': 'n2008001084',
-            'linkingRuleId': 17,
-            'status': 'NEW',
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: [
+          {
+            'tag': '711',
+            'content': '$a Roma Council $c Basilica $d 1962-1965 : $n (2nd : $j something $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1 $2 fast',
+            'indicators': ['\\', '\\'],
+            'prevContent': '$j something $0 n2008001084 $2 fast $f test',
+            'isProtected': false,
+            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            '_isDeleted': false,
+            '_isLinked': false,
+            'linkDetails': {
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'authorityNaturalId': 'n2008001084',
+              'linkingRuleId': 17,
+              'status': 'NEW',
+            },
+            'subfieldGroups': {
+              'controlled': '$a Roma Council $c Basilica $d 1962-1965 : $n (2nd :',
+              'uncontrolledAlpha': '$j something',
+              'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
+              'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'uncontrolledNumber': '$2 fast',
+            },
           },
-        },
-      ];
-
-      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([
-        {
-          'tag': '711',
-          'content': '$a Roma Council $c Basilica $d 1962-1965 : $n (2nd : $j something $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1 $2 fast',
-          'indicators': ['\\', '\\'],
-          'prevContent': '$j something $0 n2008001084 $2 fast $f test',
-          'isProtected': false,
-          'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-          '_isDeleted': false,
-          '_isLinked': false,
-          'linkDetails': {
-            'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'authorityNaturalId': 'n2008001084',
-            'linkingRuleId': 17,
-            'status': 'NEW',
-          },
-          'subfieldGroups': {
-            'controlled': '$a Roma Council $c Basilica $d 1962-1965 : $n (2nd :',
-            'uncontrolledAlpha': '$j something',
-            'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
-            'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-            'uncontrolledNumber': '$2 fast',
-          },
-        },
-      ]);
+        ],
+      }));
     });
   });
 
   describe('when calling autoLinkAuthority', () => {
-    it('should return non-linkable fields too', () => {
+    it('should return non-linkable fields too', async () => {
+      const formValues = {
+        records: [{
+          'tag': 'LDR',
+          'content': '05274cam\\a2201021\\i\\4500',
+          'id': 'LDR',
+          '_isDeleted': false,
+          '_isLinked': false,
+        }],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
       const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
 
-      const fields = [{
-        'tag': 'LDR',
-        'content': '05274cam\\a2201021\\i\\4500',
-        'id': 'LDR',
-        '_isDeleted': false,
-        '_isLinked': false,
-      }];
+      const outcome = await result.current.autoLinkAuthority(formValues);
 
-      const suggestedFields = [];
-
-      expect(result.current.autoLinkAuthority(fields, suggestedFields)).toEqual([{
-        'tag': 'LDR',
-        'content': '05274cam\\a2201021\\i\\4500',
-        'id': 'LDR',
-        '_isDeleted': false,
-        '_isLinked': false,
-      }]);
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: [{
+          'tag': 'LDR',
+          'content': '05274cam\\a2201021\\i\\4500',
+          'id': 'LDR',
+          '_isDeleted': false,
+          '_isLinked': false,
+        }],
+      }));
     });
   });
 
@@ -2132,6 +2235,468 @@ describe('Given useAuthorityLinking', () => {
       expect(mockFetchLinkSuggestions).toHaveBeenCalledWith(expect.not.objectContaining({
         tenantId: expect.anything(),
       }));
+    });
+  });
+
+  describe('when a member tenant calls autoLinkAuthority and bib record is local', () => {
+    describe('and some of the fields can be linked with shared authority records', () => {
+      it('should take suggested fields from central tenant for those fields', async () => {
+        checkIfUserInMemberTenant.mockReturnValue(true);
+
+        const formValues = {
+          records: [
+            {
+              'tag': '100',
+              'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
+              'indicators': ['1', '\\'],
+              'isProtected': false,
+              'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
+              '_isDeleted': false,
+              '_isLinked': false,
+            }, {
+              'tag': '600',
+              'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
+              'indicators': ['0', '0'],
+              'isProtected': false,
+              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+              '_isDeleted': false,
+              '_isLinked': false,
+            },
+          ],
+        };
+
+        const linkSuggestionsResponse = {
+          fields: [
+            {
+              'tag': '100',
+              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'linkDetails': {
+                errorCause: '101',
+                status: 'ERROR',
+              },
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkDetails': {
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'authorityNaturalId': 'nr2005025774',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+            },
+          ],
+        };
+
+        const linkSuggestionsResponseFromCentralTenant = {
+          fields: [
+            {
+              'tag': '100',
+              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'linkDetails': {
+                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
+                'authorityNaturalId': 'n2008001084',
+                'linkingRuleId': 1,
+                'status': 'NEW',
+              },
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkDetails': {
+                errorCause: '101',
+                status: 'ERROR',
+              },
+            },
+          ],
+        };
+
+        useLinkSuggestions.mockReturnValue({
+          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
+        });
+
+        useLinkSuggestions.mockReturnValue({
+          fetchLinkSuggestions: mockFetchLinkSuggestions
+            .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
+        });
+
+        const { result } = renderHook(() => useAuthorityLinking({ marcType: MARC_TYPES.BIB }), { wrapper });
+
+        const outcome = await result.current.autoLinkAuthority(formValues);
+
+        expect(useLinkSuggestions).toHaveBeenNthCalledWith(1, { tenantId: '' });
+        expect(useLinkSuggestions).toHaveBeenNthCalledWith(2, { tenantId: 'consortia' });
+        expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(2);
+
+        expect(outcome).toEqual(expect.objectContaining({
+          fields: [
+            {
+              'tag': '100',
+              'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
+              'indicators': ['1', '\\'],
+              'isProtected': false,
+              'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
+              '_isDeleted': false,
+              '_isLinked': false,
+              'linkDetails': {
+                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
+                'authorityNaturalId': 'n2008001084',
+                'linkingRuleId': 1,
+                'status': 'NEW',
+              },
+              'subfieldGroups': {
+                'controlled': '$a Coates, Ta-Nehisi',
+                'uncontrolledAlpha': '$e author.',
+                'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
+                'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+                'uncontrolledNumber': '',
+              },
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
+              'indicators': ['0', '0'],
+              'isProtected': false,
+              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+              '_isDeleted': false,
+              '_isLinked': false,
+              'linkDetails': {
+                'authorityNaturalId': 'nr2005025774',
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+              'subfieldGroups': {
+                'controlled': '$a Brown, Benjamin, $d 1966-',
+                'uncontrolledAlpha': '$v Comic books, strips, etc.',
+                'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
+                'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'uncontrolledNumber': '',
+              },
+            },
+          ],
+        }));
+      });
+    });
+  });
+
+  describe('when a member tenant calls autoLinkAuthority and bib record is derived shared', () => {
+    describe('and some of the fields can be linked with shared authority records', () => {
+      it('should take suggested fields from central tenant for the fields linked with shared authority records', async () => {
+        checkIfUserInMemberTenant.mockReturnValue(true);
+        useLocation.mockReturnValue({ search: '?shared=true' });
+
+        const formValues = {
+          records: [
+            {
+              'tag': '100',
+              'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
+              'indicators': ['1', '\\'],
+              'isProtected': false,
+              'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
+              '_isDeleted': false,
+              '_isLinked': false,
+            }, {
+              'tag': '600',
+              'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
+              'indicators': ['0', '0'],
+              'isProtected': false,
+              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+              '_isDeleted': false,
+              '_isLinked': false,
+            },
+          ],
+        };
+
+        const linkSuggestionsResponse = {
+          fields: [
+            {
+              'tag': '100',
+              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'linkDetails': {
+                errorCause: '101',
+                status: 'ERROR',
+              },
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkDetails': {
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'authorityNaturalId': 'nr2005025774',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+            },
+          ],
+        };
+
+        const linkSuggestionsResponseFromCentralTenant = {
+          fields: [
+            {
+              'tag': '100',
+              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'linkDetails': {
+                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
+                'authorityNaturalId': 'n2008001084',
+                'linkingRuleId': 1,
+                'status': 'NEW',
+              },
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkDetails': {
+                errorCause: '101',
+                status: 'ERROR',
+              },
+            },
+          ],
+        };
+
+        useLinkSuggestions.mockReturnValue({
+          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
+        });
+
+        useLinkSuggestions.mockReturnValue({
+          fetchLinkSuggestions: mockFetchLinkSuggestions
+            .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
+        });
+
+        const { result } = renderHook(() => useAuthorityLinking({
+          marcType: MARC_TYPES.BIB,
+          action: QUICK_MARC_ACTIONS.DERIVE,
+        }), { wrapper });
+
+        const outcome = await result.current.autoLinkAuthority(formValues);
+
+        expect(useLinkSuggestions).toHaveBeenNthCalledWith(1, { tenantId: '' });
+        expect(useLinkSuggestions).toHaveBeenNthCalledWith(2, { tenantId: 'consortia' });
+        expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(2);
+
+        expect(outcome).toEqual(expect.objectContaining({
+          fields: [
+            {
+              'tag': '100',
+              'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
+              'indicators': ['1', '\\'],
+              'isProtected': false,
+              'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
+              '_isDeleted': false,
+              '_isLinked': false,
+              'linkDetails': {
+                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
+                'authorityNaturalId': 'n2008001084',
+                'linkingRuleId': 1,
+                'status': 'NEW',
+              },
+              'subfieldGroups': {
+                'controlled': '$a Coates, Ta-Nehisi',
+                'uncontrolledAlpha': '$e author.',
+                'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
+                'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+                'uncontrolledNumber': '',
+              },
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
+              'indicators': ['0', '0'],
+              'isProtected': false,
+              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+              '_isDeleted': false,
+              '_isLinked': false,
+              'linkDetails': {
+                'authorityNaturalId': 'nr2005025774',
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+              'subfieldGroups': {
+                'controlled': '$a Brown, Benjamin, $d 1966-',
+                'uncontrolledAlpha': '$v Comic books, strips, etc.',
+                'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
+                'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'uncontrolledNumber': '',
+              },
+            },
+          ],
+        }));
+      });
+    });
+  });
+
+  describe('when a member tenant calls autoLinkAuthority and bib record is local', () => {
+    describe('and some of the fields can be linked with shared authority records', () => {
+      describe('and the suggested field has an error status in both central and member tenants', () => {
+        it('should return the same field', async () => {
+          checkIfUserInMemberTenant.mockReturnValue(true);
+
+          const formValues = {
+            records: [
+              {
+                'tag': '100',
+                'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
+                'indicators': ['1', '\\'],
+                'isProtected': false,
+                'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
+                '_isDeleted': false,
+                '_isLinked': false,
+              },
+            ],
+          };
+
+          const linkSuggestionsResponse = {
+            fields: [
+              {
+                'tag': '100',
+                'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+                'linkDetails': {
+                  errorCause: '101',
+                  status: 'ERROR',
+                },
+              },
+            ],
+          };
+
+          const linkSuggestionsResponseFromCentralTenant = linkSuggestionsResponse;
+
+          useLinkSuggestions.mockReturnValue({
+            fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
+          });
+
+          useLinkSuggestions.mockReturnValue({
+            fetchLinkSuggestions: mockFetchLinkSuggestions
+              .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
+          });
+
+          const { result } = renderHook(() => useAuthorityLinking({ marcType: MARC_TYPES.BIB }), { wrapper });
+
+          const outcome = await result.current.autoLinkAuthority(formValues);
+
+          expect(useLinkSuggestions).toHaveBeenNthCalledWith(1, { tenantId: '' });
+          expect(useLinkSuggestions).toHaveBeenNthCalledWith(2, { tenantId: 'consortia' });
+          expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(2);
+
+          expect(outcome).toEqual(expect.objectContaining({
+            fields: formValues.records,
+          }));
+        });
+      });
+    });
+  });
+
+  describe('when a member tenant calls autoLinkAuthority and bib record is derived shared', () => {
+    describe('and some of the fields can be linked with shared authority records', () => {
+      it('should return the suggestedFields with those with error replaced', async () => {
+        checkIfUserInMemberTenant.mockReturnValue(true);
+
+        const formValues = {
+          records: [
+            {
+              'tag': '100',
+              'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
+              'indicators': ['1', '\\'],
+              'isProtected': false,
+              'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
+              '_isDeleted': false,
+              '_isLinked': false,
+            }, {
+              'tag': '600',
+              'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
+              'indicators': ['0', '0'],
+              'isProtected': false,
+              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+              '_isDeleted': false,
+              '_isLinked': false,
+            },
+          ],
+        };
+
+        const linkSuggestionsResponse = {
+          fields: [
+            {
+              'tag': '100',
+              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'linkDetails': {
+                errorCause: '101',
+                status: 'ERROR',
+              },
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkDetails': {
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'authorityNaturalId': 'nr2005025774',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+            },
+          ],
+        };
+
+        const linkSuggestionsResponseFromCentralTenant = {
+          fields: [
+            {
+              'tag': '100',
+              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'linkDetails': {
+                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
+                'authorityNaturalId': 'n2008001084',
+                'linkingRuleId': 1,
+                'status': 'NEW',
+              },
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkDetails': {
+                errorCause: '101',
+                status: 'ERROR',
+              },
+            },
+          ],
+        };
+
+        useLinkSuggestions.mockReturnValue({
+          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
+        });
+
+        useLinkSuggestions.mockReturnValue({
+          fetchLinkSuggestions: mockFetchLinkSuggestions
+            .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
+        });
+
+        const { result } = renderHook(() => useAuthorityLinking({ marcType: MARC_TYPES.BIB }), { wrapper });
+
+        const outcome = await result.current.autoLinkAuthority(formValues);
+
+        expect(useLinkSuggestions).toHaveBeenNthCalledWith(1, { tenantId: '' });
+        expect(useLinkSuggestions).toHaveBeenNthCalledWith(2, { tenantId: 'consortia' });
+        expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(2);
+
+        expect(outcome).toEqual(expect.objectContaining({
+          suggestedFields: [
+            {
+              'tag': '100',
+              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'linkDetails': {
+                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
+                'authorityNaturalId': 'n2008001084',
+                'linkingRuleId': 1,
+                'status': 'NEW',
+              },
+            },
+            {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkDetails': {
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'authorityNaturalId': 'nr2005025774',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+            },
+          ],
+        }));
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Make auto-linking for the consortium.
Consolidate common functionality of auto-linking and actualization of links.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
Create a `getSuggestedFields` function that fetches link suggestions from the member and/or central tenants. 
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Issue
[UIQM-559](https://issues.folio.org/browse/UIQM-559)

## Screencast
Ocasionally `/link/suggestions` doesn't return the suggested field when it should. This is a known issue and there is a BE ticket for this ([MODELINKS-118](https://issues.folio.org/browse/MODELINKS-118)).

https://github.com/folio-org/ui-quick-marc/assets/77053927/8be2163f-6b10-4428-872d-27814a0864d1



#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
