### PR TITLE
UIQM-562 Optimistic locking error doesn't appear when edit "MARC authority" record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [UIQM-558](https://issues.folio.org/browse/UIQM-558) *BREAKING* bump `react-intl` to `v6.4.4`.
 * [UIQM-559](https://issues.folio.org/browse/UIQM-559) Make auto-linking for the consortium.
 * [UIQM-558](https://issues.folio.org/browse/UIQM-558) Allow a user to select a location code from the plugin.
+* [UIQM-562](https://issues.folio.org/browse/UIQM-562) Fix optimistic locking error doesn't appear when edit "MARC authority" record.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.js
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router';
 import PropTypes from 'prop-types';
 import flow from 'lodash/flow';
 import noop from 'lodash/noop';
+import isNil from 'lodash/isNil';
 
 import {
   useStripes,
@@ -184,7 +185,7 @@ const QuickMarcEditWrapper = ({
     const prevVersion = instance._version;
     const lastVersion = instanceResponse._version;
 
-    if (prevVersion && lastVersion && prevVersion !== lastVersion) {
+    if (!isNil(prevVersion) && !isNil(lastVersion) && prevVersion !== lastVersion) {
       setHttpError({
         errorType: ERROR_TYPES.OPTIMISTIC_LOCKING,
         message: 'ui-quick-marc.record.save.error.derive',

--- a/src/QuickMarcEditor/QuickMarcEditWrapper.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditWrapper.test.js
@@ -312,7 +312,7 @@ jest.mock('./constants', () => ({
 const getInstance = () => ({
   id: faker.random.uuid(),
   title: 'ui-quick-marc.record.edit.title',
-  _version: 1,
+  _version: 0,
 });
 
 const linkingRules = [{
@@ -494,13 +494,13 @@ describe('Given QuickMarcEditWrapper', () => {
         it('should show up a conflict detection banner and not make an update request', async () => {
           mutator.quickMarcEditInstance.GET = jest.fn(() => Promise.resolve({
             ...instance,
-            _version: '2',
+            _version: 1,
           }));
 
           const { getByText } = renderQuickMarcEditWrapper({
             instance: {
               ...instance,
-              _version: '1',
+              _version: 0,
             },
             mutator,
           });


### PR DESCRIPTION
## Description
Fix issue with handling `0` version of MARC records

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/462dd587-7351-454c-8dc6-b2d91472c6fa

## Issues
[UIQM-562](https://issues.folio.org/browse/UIQM-562)