### PR TITLE
UIQM-568 Remove second call to links-suggestion endpoint. Now only need to send one call to member tenant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [UIQM-562](https://issues.folio.org/browse/UIQM-562) Fix optimistic locking error doesn't appear when edit "MARC authority" record.
 * [UIQM-564](https://issues.folio.org/browse/UIQM-564) Hide permission `quickMARC: Create a new MARC authority record
 * [UIQM-431](https://issues.folio.org/browse/UIQM-431) Marc record fixed field 008 with proper order.
+* [UIQM-568](https://issues.folio.org/browse/UIQM-568) Remove second call to links-suggestion endpoint. Now only need to send one call to member tenant.
 
 ## [6.0.2](https://github.com/folio-org/ui-quick-marc/tree/v6.0.2) (2023-03-30)
 

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -7,10 +7,7 @@ import get from 'lodash/get';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
-import {
-  checkIfUserInMemberTenant,
-  useStripes,
-} from '@folio/stripes/core';
+import { useStripes } from '@folio/stripes/core';
 
 import {
   useAuthoritySourceFiles,
@@ -30,12 +27,10 @@ import {
 } from '../../QuickMarcEditor/utils';
 import {
   AUTOLINKING_STATUSES,
-  AUTOLINKING_ERROR_CODES,
   UNCONTROLLED_ALPHA,
   UNCONTROLLED_NUMBER,
   QUICK_MARC_ACTIONS,
 } from '../../QuickMarcEditor/constants';
-import { MARC_TYPES } from '../../common/constants';
 
 const joinSubfields = (subfields) => Object.keys(subfields).reduce((content, key) => {
   const subfield = subfields[key].join(` ${key} `);
@@ -48,10 +43,8 @@ const formatSubfieldCode = (code) => { return code.startsWith('$') ? code : `$${
 const useAuthorityLinking = ({ tenantId, marcType, action } = {}) => {
   const stripes = useStripes();
   const location = useLocation();
-  const { search } = location;
 
   const centralTenantId = stripes.user.user.consortium?.centralTenantId;
-  const isMemberTenant = checkIfUserInMemberTenant(stripes);
   const isCentralTenantInHeaders = applyCentralTenantInHeaders(location, stripes, marcType)
     && action === QUICK_MARC_ACTIONS.EDIT;
 
@@ -65,10 +58,6 @@ const useAuthorityLinking = ({ tenantId, marcType, action } = {}) => {
     fetchLinkSuggestions: fetchMemberLinkSuggestions,
     isLoading: isLoadingMemberLinkSuggestions,
   } = useLinkSuggestions({ tenantId: _tenantId });
-  const {
-    fetchLinkSuggestions: fetchCentralLinkSuggestions,
-    isLoading: isLoadingCentralLinkSuggestions,
-  } = useLinkSuggestions({ tenantId: centralTenantId });
 
   const linkableBibFields = useMemo(() => linkingRules.map(rule => rule.bibField), [linkingRules]);
   const autoLinkableBibFields = useMemo(() => {
@@ -221,8 +210,6 @@ const useAuthorityLinking = ({ tenantId, marcType, action } = {}) => {
   }, [getSubfieldGroups]);
 
   const getSuggestedFields = useCallback(async (formValues, fieldsToHydrate, extraRequestArgs = {}) => {
-    const searchParams = new URLSearchParams(search);
-    const isSharedRecord = searchParams.get('shared') === 'true';
     const payload = hydrateForLinkSuggestions(formValues, fieldsToHydrate);
 
     const requestArgs = {
@@ -230,52 +217,16 @@ const useAuthorityLinking = ({ tenantId, marcType, action } = {}) => {
       ...extraRequestArgs,
     };
 
-    const isRecordWithCentralAndMemberSuggestions = (
-      marcType === MARC_TYPES.BIB
-      && isMemberTenant
-      && (!isSharedRecord || (isSharedRecord && action === QUICK_MARC_ACTIONS.DERIVE))
-    );
+    const { fields: memberSuggestedFields } = await fetchMemberLinkSuggestions(requestArgs);
 
-    const memberLinkSuggestionsPromise = fetchMemberLinkSuggestions(requestArgs);
-    const centralLinkSuggestionsPromise = isRecordWithCentralAndMemberSuggestions
-      ? fetchCentralLinkSuggestions(requestArgs)
-      : Promise.resolve({ fields: [] });
-
-    const [
-      { fields: memberSuggestedFields },
-      { fields: suggestedFieldsFromCentralTenant },
-    ] = await Promise.all([
-      memberLinkSuggestionsPromise,
-      centralLinkSuggestionsPromise,
-    ]);
-
-    return memberSuggestedFields.map((suggestedField, index) => {
+    return memberSuggestedFields.map((suggestedField) => {
       if (suggestedField.linkDetails?.status !== AUTOLINKING_STATUSES.ERROR) {
         return suggestedField;
       }
 
-      const suggestedFieldFromCentralTenant = suggestedFieldsFromCentralTenant[index];
-
-      const shouldTakeSuggestedFieldFromCentralTenant = (
-        isRecordWithCentralAndMemberSuggestions
-        && suggestedField.linkDetails.errorCause === AUTOLINKING_ERROR_CODES.AUTHORITY_NOT_FOUND
-        && suggestedFieldFromCentralTenant?.linkDetails.status !== AUTOLINKING_STATUSES.ERROR
-      );
-
-      if (shouldTakeSuggestedFieldFromCentralTenant) {
-        return suggestedFieldFromCentralTenant;
-      }
-
       return suggestedField;
     });
-  }, [
-    fetchMemberLinkSuggestions,
-    fetchCentralLinkSuggestions,
-    search,
-    marcType,
-    isMemberTenant,
-    action,
-  ]);
+  }, [fetchMemberLinkSuggestions]);
 
   const autoLinkAuthority = useCallback(async (formValues) => {
     const fieldsToLink = formValues.records.filter(record => isRecordForAutoLinking(record, autoLinkableBibFields));
@@ -402,8 +353,7 @@ const useAuthorityLinking = ({ tenantId, marcType, action } = {}) => {
     actualizeLinks,
     linkingRules,
     fetchMemberLinkSuggestions,
-    fetchCentralLinkSuggestions,
-    isLoadingLinkSuggestions: isLoadingMemberLinkSuggestions || isLoadingCentralLinkSuggestions,
+    isLoadingLinkSuggestions: isLoadingMemberLinkSuggestions,
   };
 };
 

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -6,14 +6,13 @@ import {
 import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
 import { useLocation } from 'react-router-dom';
 
-import { checkIfUserInMemberTenant } from '@folio/stripes/core';
 import useAuthorityLinking from './useAuthorityLinking';
 import {
   useAuthorityLinkingRules,
   useLinkSuggestions,
 } from '../../queries';
 import { MARC_TYPES } from '../../common/constants';
-import { QUICK_MARC_ACTIONS } from '../../QuickMarcEditor/constants';
+import { linkingRules } from '../../../test/jest/fixtures/linkingRules';
 
 const mockFetchLinkSuggestions = jest.fn().mockResolvedValue({ fields: [] });
 
@@ -36,43 +35,6 @@ jest.mock('../../queries', () => ({
   useLinkSuggestions: jest.fn(),
 }));
 
-const linkingRules = {
-  linkingRules: [{
-    id: 1,
-    bibField: '100',
-    authorityField: '100',
-    authoritySubfields: ['a', 'b', 't', 'd'],
-    subfieldModifications: [],
-    validation: {},
-    autoLinkingEnabled: true,
-  }, {
-    id: 8,
-    bibField: '600',
-    authorityField: '100',
-    authoritySubfields: ['a', 'b', 'c', 'd', 'g', 'j', 'q', 'f', 'h', 'k', 'l', 'm', 'n', 'o', 'p', 'r', 's', 't'],
-    autoLinkingEnabled: true,
-  }, {
-    id: 12,
-    bibField: '650',
-    authorityField: '150',
-    authoritySubfields: ['a', 'b', 'g'],
-    autoLinkingEnabled: false,
-  }, {
-    id: 15,
-    bibField: '700',
-    authorityField: '100',
-    authoritySubfields: ['a', 'b', 'c', 'd', 'j', 'q', 'f', 'h', 'k', 'l', 'm', 'n', 'o', 'p', 'r', 's', 't', 'g'],
-    autoLinkingEnabled: true,
-  }, {
-    id: 17,
-    bibField: '711',
-    authorityField: '111',
-    authoritySubfields: ['a', 'c', 'e', 'q', 'f', 'h', 'k', 'l', 'p', 's', 't', 'd', 'g', 'n'],
-    autoLinkingEnabled: true,
-  }],
-  isLoading: false,
-};
-
 const queryClient = new QueryClient();
 
 const wrapper = ({ children }) => (
@@ -93,161 +55,271 @@ describe('Given useAuthorityLinking', () => {
     jest.clearAllMocks();
 
     useLocation.mockReturnValue({ search: '?shared=false' });
-    checkIfUserInMemberTenant.mockReturnValue(false);
     useAuthorityLinkingRules.mockReturnValue(linkingRules);
     useLinkSuggestions.mockReturnValue({
       fetchLinkSuggestions: mockFetchLinkSuggestions,
     });
   });
 
-  describe('when calling linkAuthority with not matched source file', () => {
-    it('should return field as it is', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+  describe('when using linkAuthority', () => {
+    describe('when calling linkAuthority with not matched source file', () => {
+      it('should return field as it is', () => {
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
 
-      const authority = {
-        sourceFileId: '4',
-      };
-      const field = {
-        tag: '100',
-        content: '$a some value $b some other value',
-      };
-
-      expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject(field);
-    });
-  });
-
-  describe('when calling linkAuthority and some subfields are in the linking rule but not in authority', () => {
-    it('should return field without invalid subfields', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const authSource = {
-        fields: [{
+        const authority = {
+          sourceFileId: '4',
+        };
+        const field = {
           tag: '100',
-          content: '$a Beethoven, Ludwig van',
-        }],
-      };
-      const authority = {
-        id: 'authority-id',
-        sourceFileId: '1',
-        naturalId: 'n0001',
-      };
-      const field = {
-        tag: '100',
-        content: '$a Beethoven, Ludwig van, $d 1770-1827, $e composer.',
-      };
+          content: '$a some value $b some other value',
+        };
 
-      expect(result.current.linkAuthority(authority, authSource, field)).toMatchObject({
-        content: '$a Beethoven, Ludwig van $e composer. $0 some.url/n0001 $9 authority-id',
-        linkDetails: {
-          authorityId: 'authority-id',
-          authorityNaturalId: 'n0001',
-          linkingRuleId: 1,
-        },
+        expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject(field);
+      });
+    });
+
+    describe('when some subfields are in the linking rule but not in authority', () => {
+      it('should return field without invalid subfields', () => {
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const authSource = {
+          fields: [{
+            tag: '100',
+            content: '$a Beethoven, Ludwig van',
+          }],
+        };
+        const authority = {
+          id: 'authority-id',
+          sourceFileId: '1',
+          naturalId: 'n0001',
+        };
+        const field = {
+          tag: '100',
+          content: '$a Beethoven, Ludwig van, $d 1770-1827, $e composer.',
+        };
+
+        expect(result.current.linkAuthority(authority, authSource, field)).toMatchObject({
+          content: '$a Beethoven, Ludwig van $e composer. $0 some.url/n0001 $9 authority-id',
+          linkDetails: {
+            authorityId: 'authority-id',
+            authorityNaturalId: 'n0001',
+            linkingRuleId: 1,
+          },
+        });
+      });
+    });
+
+    describe('when $0 subfield does not exist', () => {
+      it('should return field with new $0 and $9 subfields and authority subfields', () => {
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const authority = {
+          id: 'authority-id',
+          sourceFileId: '1',
+          naturalId: 'n0001',
+        };
+        const field = {
+          tag: '100',
+          content: '$a some value $b some other value',
+        };
+
+        expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
+          content: '$a authority value $b fakeB $0 some.url/n0001 $t field for modification $9 authority-id',
+          linkDetails: {
+            authorityId: 'authority-id',
+            authorityNaturalId: 'n0001',
+            linkingRuleId: 1,
+          },
+        });
+      });
+    });
+
+    describe('when $0 subfield and authority.naturalId do not match', () => {
+      it('should return field with new $0 and $9 subfields and authority subfields', () => {
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const authority = {
+          id: 'authority-id',
+          sourceFileId: '1',
+          naturalId: 'n0001',
+        };
+        const field = {
+          tag: '100',
+          content: '$a some value $b some other value $0 some.url/n0002 $9 authority-other-id',
+        };
+
+        expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
+          content: '$a authority value $b fakeB $0 some.url/n0001 $9 authority-id $t field for modification',
+          linkDetails: {
+            authorityId: 'authority-id',
+            authorityNaturalId: 'n0001',
+            linkingRuleId: 1,
+          },
+        });
+      });
+    });
+
+    describe('when $0 subfield and authority.naturalId match', () => {
+      it('should return field with new $0 and $9 subfields and authority subfields', () => {
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const authority = {
+          id: 'authority-id',
+          sourceFileId: '1',
+          naturalId: 'n0001',
+        };
+        const field = {
+          tag: '100',
+          content: '$a some value $b some other value $0 n0001 $9 authority-other-id',
+        };
+
+        expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
+          content: '$a authority value $b fakeB $0 some.url/n0001 $9 authority-id $t field for modification',
+          linkDetails: {
+            authorityId: 'authority-id',
+            authorityNaturalId: 'n0001',
+            linkingRuleId: 1,
+          },
+        });
+      });
+    });
+
+    describe('when there are repeated subfields', () => {
+      it('should return field with correctly formatted subfields', () => {
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const authority = {
+          id: 'authority-id',
+          sourceFileId: '1',
+          naturalId: 'n0001',
+        };
+        const field = {
+          tag: '100',
+          content: '$a some value $b some other value $e author $e illustrator',
+        };
+
+        expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
+          content: '$a authority value $b fakeB $e author $e illustrator $0 some.url/n0001 $t field for modification $9 authority-id',
+          linkDetails: {
+            authorityId: 'authority-id',
+            authorityNaturalId: 'n0001',
+            linkingRuleId: 1,
+          },
+        });
+      });
+    });
+
+    describe('when linking requires subfield modification', () => {
+      it('should return field with correctly formatted subfields', () => {
+        useAuthorityLinkingRules.mockReturnValue({
+          linkingRules: [{
+            id: 1,
+            bibField: '100',
+            authorityField: '100',
+            authoritySubfields: ['a', 'b', 't'],
+            subfieldModifications: [{
+              source: 't',
+              target: 'c',
+            }],
+            validation: {
+              existence: [{
+                t: true,
+              }],
+            },
+          }],
+        });
+
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const authority = {
+          id: 'authority-id',
+          sourceFileId: '1',
+          naturalId: 'n0001',
+        };
+        const field = {
+          tag: '100',
+          content: '$a some value $b some other value $e author $e illustrator',
+        };
+
+        expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
+          content: '$a authority value $b fakeB $e author $e illustrator $0 some.url/n0001 $c field for modification $9 authority-id',
+          linkDetails: {
+            authorityId: 'authority-id',
+            authorityNaturalId: 'n0001',
+            linkingRuleId: 1,
+          },
+        });
+      });
+    });
+
+    describe('when authority record doesnt pass required subfields validation', () => {
+      it('should throw validation error', () => {
+        useAuthorityLinkingRules.mockReturnValue({
+          linkingRules: [{
+            id: 1,
+            bibField: '100',
+            authorityField: '100',
+            authoritySubfields: ['a', 'b', 't'],
+            subfieldModifications: [{
+              source: 't',
+              target: 'c',
+            }],
+            validation: {
+              existence: [{
+                t: true,
+              }],
+            },
+          }],
+        });
+
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+        const field = {
+          tag: '100',
+          content: '$a Crumb, George. test',
+        };
+        const authority = {
+          id: 'authority-id',
+          sourceFileId: '1',
+          naturalId: 'n0001',
+        };
+        const authoritySourceWithoutMatchingField = {
+          fields: [{
+            tag: '100',
+            content: '$a authority value',
+          }],
+        };
+
+        expect(() => result.current.linkAuthority(authority, authoritySourceWithoutMatchingField, field))
+          .toThrow('ui-quick-marc.record.link.validation.invalidHeading');
+      });
+    });
+
+    describe('when records dont have fields that can be linked', () => {
+      it('should return field without changes', () => {
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+        const field = {
+          tag: '100',
+          content: '$a Crumb, George. test',
+        };
+        const authority = {
+          id: 'authority-id',
+          sourceFileId: '1',
+          naturalId: 'n0001',
+        };
+        const authoritySourceWithoutMatchingField = {
+          fields: [{
+            tag: '110',
+            content: '$a authority value',
+          }],
+        };
+
+        expect(() => result.current.linkAuthority(authority, authoritySourceWithoutMatchingField, field))
+          .toThrow('ui-quick-marc.record.link.validation.invalidHeading');
       });
     });
   });
 
-  describe('when calling linkAuthority with not existing $0 subfield', () => {
-    it('should return field with new $0 and $9 subfields and authority subfields', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const authority = {
-        id: 'authority-id',
-        sourceFileId: '1',
-        naturalId: 'n0001',
-      };
-      const field = {
-        tag: '100',
-        content: '$a some value $b some other value',
-      };
-
-      expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b fakeB $0 some.url/n0001 $t field for modification $9 authority-id',
-        linkDetails: {
-          authorityId: 'authority-id',
-          authorityNaturalId: 'n0001',
-          linkingRuleId: 1,
-        },
-      });
-    });
-  });
-
-  describe('when calling linkAuthority with not matched $0 subfield and authority.naturalId', () => {
-    it('should return field with new $0 and $9 subfields and authority subfields', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const authority = {
-        id: 'authority-id',
-        sourceFileId: '1',
-        naturalId: 'n0001',
-      };
-      const field = {
-        tag: '100',
-        content: '$a some value $b some other value $0 some.url/n0002 $9 authority-other-id',
-      };
-
-      expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b fakeB $0 some.url/n0001 $9 authority-id $t field for modification',
-        linkDetails: {
-          authorityId: 'authority-id',
-          authorityNaturalId: 'n0001',
-          linkingRuleId: 1,
-        },
-      });
-    });
-  });
-
-  describe('when calling linkAuthority with matched $0 subfield and authority.naturalId', () => {
-    it('should return field with new $0 and $9 subfields and authority subfields', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const authority = {
-        id: 'authority-id',
-        sourceFileId: '1',
-        naturalId: 'n0001',
-      };
-      const field = {
-        tag: '100',
-        content: '$a some value $b some other value $0 n0001 $9 authority-other-id',
-      };
-
-      expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b fakeB $0 some.url/n0001 $9 authority-id $t field for modification',
-        linkDetails: {
-          authorityId: 'authority-id',
-          authorityNaturalId: 'n0001',
-          linkingRuleId: 1,
-        },
-      });
-    });
-  });
-
-  describe('when calling linkAuthority with repeated subfields', () => {
-    it('should return field with correctly formatted subfields', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const authority = {
-        id: 'authority-id',
-        sourceFileId: '1',
-        naturalId: 'n0001',
-      };
-      const field = {
-        tag: '100',
-        content: '$a some value $b some other value $e author $e illustrator',
-      };
-
-      expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b fakeB $e author $e illustrator $0 some.url/n0001 $t field for modification $9 authority-id',
-        linkDetails: {
-          authorityId: 'authority-id',
-          authorityNaturalId: 'n0001',
-          linkingRuleId: 1,
-        },
-      });
-    });
-  });
-
-  describe('when calling autoLinkAuthority', () => {
+  describe('when using autoLinkAuthority', () => {
     it('should link fields', async () => {
       const formValues = {
         records: [
@@ -352,9 +424,7 @@ describe('Given useAuthorityLinking', () => {
         suggestedFields: linkSuggestionsResponse.fields,
       });
     });
-  });
 
-  describe('when calling autoLinkAuthority', () => {
     it('should not link fields without $0', async () => {
       const formValues = {
         records: [
@@ -433,9 +503,7 @@ describe('Given useAuthorityLinking', () => {
         ],
       }));
     });
-  });
 
-  describe('when calling autoLinkAuthority', () => {
     it('should link in the correct order', async () => {
       const formValues = {
         records: [
@@ -539,26 +607,48 @@ describe('Given useAuthorityLinking', () => {
         ],
       }));
     });
-  });
 
-  describe('when calling autoLinkAuthority and returning an error for a field with the same tag', () => {
-    it('should link in the correct order', async () => {
+    it('should return non-linkable fields too', async () => {
+      const formValues = {
+        records: [{
+          'tag': 'LDR',
+          'content': '05274cam\\a2201021\\i\\4500',
+          'id': 'LDR',
+          '_isDeleted': false,
+          '_isLinked': false,
+        }],
+      };
+
+      const linkSuggestionsResponse = {
+        fields: [],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const outcome = await result.current.autoLinkAuthority(formValues);
+
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: [{
+          'tag': 'LDR',
+          'content': '05274cam\\a2201021\\i\\4500',
+          'id': 'LDR',
+          '_isDeleted': false,
+          '_isLinked': false,
+        }],
+      }));
+    });
+
+    it('should take uncontrolled subfields from the current field, not from suggested one', async () => {
       const formValues = {
         records: [
           {
-            'tag': '600',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-            'indicators': ['0', '7'],
+            'tag': '711',
+            'content': '$j something $0 n2008001084 $2 fast $f test',
+            'indicators': ['\\', '\\'],
             'isProtected': false,
             'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-            '_isDeleted': false,
-            '_isLinked': false,
-          }, {
-            'tag': '600',
-            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-            'indicators': ['0', '0'],
-            'isProtected': false,
-            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
             '_isDeleted': false,
             '_isLinked': false,
           },
@@ -568,238 +658,311 @@ describe('Given useAuthorityLinking', () => {
       const linkSuggestionsResponse = {
         fields: [
           {
+            'tag': '711',
+            'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Roma Council $c Basilica $d 1962-1965 : $n (2nd : $9 5d80ecfa-7370-460e-9e27-3883a7656fe1 $j test',
+            'linkDetails': {
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'authorityNaturalId': 'n2008001084',
+              'linkingRuleId': 17,
+              'status': 'NEW',
+            },
+          },
+        ],
+      };
+
+      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const outcome = await result.current.autoLinkAuthority(formValues);
+
+      expect(outcome).toEqual(expect.objectContaining({
+        fields: [
+          {
+            'tag': '711',
+            'content': '$a Roma Council $c Basilica $d 1962-1965 : $n (2nd : $j something $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1 $2 fast',
+            'indicators': ['\\', '\\'],
+            'prevContent': '$j something $0 n2008001084 $2 fast $f test',
+            'isProtected': false,
+            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            '_isDeleted': false,
+            '_isLinked': false,
+            'linkDetails': {
+              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'authorityNaturalId': 'n2008001084',
+              'linkingRuleId': 17,
+              'status': 'NEW',
+            },
+            'subfieldGroups': {
+              'controlled': '$a Roma Council $c Basilica $d 1962-1965 : $n (2nd :',
+              'uncontrolledAlpha': '$j something',
+              'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
+              'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
+              'uncontrolledNumber': '$2 fast',
+            },
+          },
+        ],
+      }));
+    });
+
+    describe('when link suggestions returns an error for a field with the same tag', () => {
+      it('should link in the correct order', async () => {
+        const formValues = {
+          records: [
+            {
+              'tag': '600',
+              'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+              'indicators': ['0', '7'],
+              'isProtected': false,
+              'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+              '_isDeleted': false,
+              '_isLinked': false,
+            }, {
+              'tag': '600',
+              'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+              'indicators': ['0', '0'],
+              'isProtected': false,
+              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+              '_isDeleted': false,
+              '_isLinked': false,
+            },
+          ],
+        };
+
+        const linkSuggestionsResponse = {
+          fields: [
+            {
+              'tag': '600',
+              'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+              'linkDetails': {
+                'status': 'ERROR',
+              },
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkDetails': {
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'authorityNaturalId': 'nr2005025774',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+            },
+          ],
+        };
+
+        mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const outcome = await result.current.autoLinkAuthority(formValues);
+
+        expect(outcome).toEqual(expect.objectContaining({
+          fields: [
+            {
+              'tag': '600',
+              'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+              'indicators': ['0', '7'],
+              'isProtected': false,
+              'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+              '_isDeleted': false,
+              '_isLinked': false,
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+              'indicators': ['0', '0'],
+              'isProtected': false,
+              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+              '_isDeleted': false,
+              '_isLinked': false,
+              'linkDetails': {
+                'authorityNaturalId': 'nr2005025774',
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+              'subfieldGroups': {
+                'controlled': '$a Brown, Benjamin, $d 1966-',
+                'uncontrolledAlpha': '$v Comic books, strips, etc.',
+                'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
+                'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'uncontrolledNumber': '',
+              },
+            },
+          ],
+        }));
+      });
+    });
+
+    describe('when there is no suggestion for a field with the same tag', () => {
+      it('should link in the correct order', async () => {
+        const formValues = {
+          records: [
+            {
+              'tag': '600',
+              'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+              'indicators': ['0', '7'],
+              'isProtected': false,
+              'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+              '_isDeleted': false,
+              '_isLinked': false,
+            }, {
+              'tag': '600',
+              'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+              'indicators': ['0', '0'],
+              'isProtected': false,
+              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+              '_isDeleted': false,
+              '_isLinked': false,
+            },
+          ],
+        };
+
+        const linkSuggestionsResponse = {
+          fields: [
+            {
+              'tag': '600',
+              'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'linkDetails': {
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'authorityNaturalId': 'nr2005025774',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+            },
+          ],
+        };
+
+        mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const outcome = await result.current.autoLinkAuthority(formValues);
+
+        expect(outcome).toEqual(expect.objectContaining({
+          fields: [
+            {
+              'tag': '600',
+              'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+              'indicators': ['0', '7'],
+              'isProtected': false,
+              'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+              '_isDeleted': false,
+              '_isLinked': false,
+            }, {
+              'tag': '600',
+              'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+              'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+              'indicators': ['0', '0'],
+              'isProtected': false,
+              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+              '_isDeleted': false,
+              '_isLinked': false,
+              'linkDetails': {
+                'authorityNaturalId': 'nr2005025774',
+                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'linkingRuleId': 8,
+                'status': 'NEW',
+              },
+              'subfieldGroups': {
+                'controlled': '$a Brown, Benjamin, $d 1966-',
+                'uncontrolledAlpha': '$v Comic books, strips, etc.',
+                'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
+                'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+                'uncontrolledNumber': '',
+              },
+            },
+          ],
+        }));
+      });
+    });
+
+    describe('when there is a field with ERROR status and there is no $9', () => {
+      it('should be left as is', async () => {
+        const formValues = {
+          records: [{
             'tag': '600',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+            'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
+            'indicators': ['\\', '0'],
+            'isProtected': false,
+            'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }],
+        };
+
+        const linkSuggestionsResponse = {
+          fields: [{
+            'tag': '600',
+            'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
             'linkDetails': {
               'status': 'ERROR',
+              'errorCause': '101',
             },
-          }, {
-            'tag': '600',
-            'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'linkDetails': {
-              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'authorityNaturalId': 'nr2005025774',
-              'linkingRuleId': 8,
-              'status': 'NEW',
-            },
-          },
-        ],
-      };
+          }],
+        };
 
-      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+        mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
 
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
 
-      const outcome = await result.current.autoLinkAuthority(formValues);
+        const outcome = await result.current.autoLinkAuthority(formValues);
 
-      expect(outcome).toEqual(expect.objectContaining({
-        fields: [
-          {
-            'tag': '600',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-            'indicators': ['0', '7'],
-            'isProtected': false,
-            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-            '_isDeleted': false,
-            '_isLinked': false,
-          }, {
-            'tag': '600',
-            'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-            'indicators': ['0', '0'],
-            'isProtected': false,
-            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-            '_isDeleted': false,
-            '_isLinked': false,
-            'linkDetails': {
-              'authorityNaturalId': 'nr2005025774',
-              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'linkingRuleId': 8,
-              'status': 'NEW',
-            },
-            'subfieldGroups': {
-              'controlled': '$a Brown, Benjamin, $d 1966-',
-              'uncontrolledAlpha': '$v Comic books, strips, etc.',
-              'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
-              'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'uncontrolledNumber': '',
-            },
-          },
-        ],
-      }));
+        expect(outcome).toEqual(expect.objectContaining({
+          fields: formValues.records,
+        }));
+      });
     });
-  });
 
-  describe('when calling autoLinkAuthority and there is no suggestion for a field with the same tag', () => {
-    it('should link in the correct order', async () => {
-      const formValues = {
-        records: [
-          {
+    describe('when there is a field with ERROR status and there is $9', () => {
+      it('should get rid of the $9', async () => {
+        const formValues = {
+          records: [{
             'tag': '600',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-            'indicators': ['0', '7'],
+            'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135 $9 UUID',
+            'indicators': ['\\', '0'],
             'isProtected': false,
-            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
             '_isDeleted': false,
             '_isLinked': false,
-          }, {
-            'tag': '600',
-            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-            'indicators': ['0', '0'],
-            'isProtected': false,
-            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-            '_isDeleted': false,
-            '_isLinked': false,
-          },
-        ],
-      };
+          }],
+        };
 
-      const linkSuggestionsResponse = {
-        fields: [
-          {
+        const linkSuggestionsResponse = {
+          fields: [{
             'tag': '600',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-          }, {
-            'tag': '600',
-            'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
+            'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135 $9 UUID',
             'linkDetails': {
-              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'authorityNaturalId': 'nr2005025774',
-              'linkingRuleId': 8,
-              'status': 'NEW',
+              'status': 'ERROR',
+              'errorCause': '101',
             },
-          },
-        ],
-      };
+          }],
+        };
 
-      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
+        mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
 
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
 
-      const outcome = await result.current.autoLinkAuthority(formValues);
+        const outcome = await result.current.autoLinkAuthority(formValues);
 
-      expect(outcome).toEqual(expect.objectContaining({
-        fields: [
-          {
+        expect(outcome).toEqual(expect.objectContaining({
+          fields: [{
             'tag': '600',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-            'indicators': ['0', '7'],
+            'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
+            'indicators': ['\\', '0'],
             'isProtected': false,
-            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
             '_isDeleted': false,
             '_isLinked': false,
-          }, {
-            'tag': '600',
-            'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-            'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-            'indicators': ['0', '0'],
-            'isProtected': false,
-            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-            '_isDeleted': false,
-            '_isLinked': false,
-            'linkDetails': {
-              'authorityNaturalId': 'nr2005025774',
-              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'linkingRuleId': 8,
-              'status': 'NEW',
-            },
-            'subfieldGroups': {
-              'controlled': '$a Brown, Benjamin, $d 1966-',
-              'uncontrolledAlpha': '$v Comic books, strips, etc.',
-              'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
-              'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'uncontrolledNumber': '',
-            },
-          },
-        ],
-      }));
+          }],
+        }));
+      });
     });
-  });
 
-  describe('when calling autoLinkAuthority and there is a field with ERROR status and there is no $9', () => {
-    it('should be left as is', async () => {
-      const formValues = {
-        records: [{
-          'tag': '600',
-          'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
-          'indicators': ['\\', '0'],
-          'isProtected': false,
-          'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }],
-      };
-
-      const linkSuggestionsResponse = {
-        fields: [{
-          'tag': '600',
-          'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
-          'linkDetails': {
-            'status': 'ERROR',
-            'errorCause': '101',
-          },
-        }],
-      };
-
-      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
-
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const outcome = await result.current.autoLinkAuthority(formValues);
-
-      expect(outcome).toEqual(expect.objectContaining({
-        fields: formValues.records,
-      }));
-    });
-  });
-
-  describe('when calling autoLinkAuthority and there is a field with ERROR status and there is $9', () => {
-    it('should get rid of the $9', async () => {
-      const formValues = {
-        records: [{
-          'tag': '600',
-          'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135 $9 UUID',
-          'indicators': ['\\', '0'],
-          'isProtected': false,
-          'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }],
-      };
-
-      const linkSuggestionsResponse = {
-        fields: [{
-          'tag': '600',
-          'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135 $9 UUID',
-          'linkDetails': {
-            'status': 'ERROR',
-            'errorCause': '101',
-          },
-        }],
-      };
-
-      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
-
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const outcome = await result.current.autoLinkAuthority(formValues);
-
-      expect(outcome).toEqual(expect.objectContaining({
-        fields: [{
-          'tag': '600',
-          'content': '$a Medycyna. $v Comic books, strips, etc. $0 vtls000869135',
-          'indicators': ['\\', '0'],
-          'isProtected': false,
-          'id': '103073ce-b2c8-4f92-ba2f-a65f733b3f02',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }],
-      }));
-    });
-  });
-
-  describe('when there is already a linked field', () => {
-    describe('and the user enters $9 into the split uncontrolledNumber or uncontrolledAlpha field and calls autoLinkAuthority', () => {
+    describe('when user enters $9 into the split uncontrolledNumber or uncontrolledAlpha field of a linked field', () => {
       it('should get rid of the $9', async () => {
         const formValues = {
           records: [
@@ -911,228 +1074,50 @@ describe('Given useAuthorityLinking', () => {
         }));
       });
     });
-  });
 
-  describe('when calling autoLinkAuthority and there is a field that cannot be linked', () => {
-    it('should be left as is', async () => {
-      const formValues = {
-        records: [{
-          'tag': '600',
-          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }],
-      };
-
-      const linkSuggestionsResponse = {
-        fields: [{
-          'tag': '600',
-          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-        }],
-      };
-
-      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
-
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const outcome = await result.current.autoLinkAuthority(formValues);
-
-      expect(outcome).toEqual(expect.objectContaining({
-        fields: [{
-          'tag': '600',
-          'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
-          'indicators': ['0', '0'],
-          'isProtected': false,
-          'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }],
-      }));
-    });
-  });
-
-  describe('when calling autoLinkAuthority', () => {
-    it('should take uncontrolled subfields from the current field, not from suggested one', async () => {
-      const formValues = {
-        records: [
-          {
-            'tag': '711',
-            'content': '$j something $0 n2008001084 $2 fast $f test',
-            'indicators': ['\\', '\\'],
+    describe('when there is a field that cannot be linked', () => {
+      it('should be left as is', async () => {
+        const formValues = {
+          records: [{
+            'tag': '600',
+            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+            'indicators': ['0', '0'],
             'isProtected': false,
-            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
             '_isDeleted': false,
             '_isLinked': false,
-          },
-        ],
-      };
-
-      const linkSuggestionsResponse = {
-        fields: [
-          {
-            'tag': '711',
-            'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Roma Council $c Basilica $d 1962-1965 : $n (2nd : $9 5d80ecfa-7370-460e-9e27-3883a7656fe1 $j test',
-            'linkDetails': {
-              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 17,
-              'status': 'NEW',
-            },
-          },
-        ],
-      };
-
-      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
-
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const outcome = await result.current.autoLinkAuthority(formValues);
-
-      expect(outcome).toEqual(expect.objectContaining({
-        fields: [
-          {
-            'tag': '711',
-            'content': '$a Roma Council $c Basilica $d 1962-1965 : $n (2nd : $j something $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1 $2 fast',
-            'indicators': ['\\', '\\'],
-            'prevContent': '$j something $0 n2008001084 $2 fast $f test',
-            'isProtected': false,
-            'id': '01f3e2b6-ccea-4fa8-9d20-0ef89bb5b39f',
-            '_isDeleted': false,
-            '_isLinked': false,
-            'linkDetails': {
-              'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 17,
-              'status': 'NEW',
-            },
-            'subfieldGroups': {
-              'controlled': '$a Roma Council $c Basilica $d 1962-1965 : $n (2nd :',
-              'uncontrolledAlpha': '$j something',
-              'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
-              'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-              'uncontrolledNumber': '$2 fast',
-            },
-          },
-        ],
-      }));
-    });
-  });
-
-  describe('when calling autoLinkAuthority', () => {
-    it('should return non-linkable fields too', async () => {
-      const formValues = {
-        records: [{
-          'tag': 'LDR',
-          'content': '05274cam\\a2201021\\i\\4500',
-          'id': 'LDR',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }],
-      };
-
-      const linkSuggestionsResponse = {
-        fields: [],
-      };
-
-      mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
-
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const outcome = await result.current.autoLinkAuthority(formValues);
-
-      expect(outcome).toEqual(expect.objectContaining({
-        fields: [{
-          'tag': 'LDR',
-          'content': '05274cam\\a2201021\\i\\4500',
-          'id': 'LDR',
-          '_isDeleted': false,
-          '_isLinked': false,
-        }],
-      }));
-    });
-  });
-
-  describe('when linking requires subfield modification', () => {
-    it('should return field with correctly formatted subfields', () => {
-      useAuthorityLinkingRules.mockReturnValue({
-        linkingRules: [{
-          id: 1,
-          bibField: '100',
-          authorityField: '100',
-          authoritySubfields: ['a', 'b', 't'],
-          subfieldModifications: [{
-            source: 't',
-            target: 'c',
           }],
-          validation: {
-            existence: [{
-              t: true,
-            }],
-          },
-        }],
-      });
+        };
 
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+        const linkSuggestionsResponse = {
+          fields: [{
+            'tag': '600',
+            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+          }],
+        };
 
-      const authority = {
-        id: 'authority-id',
-        sourceFileId: '1',
-        naturalId: 'n0001',
-      };
-      const field = {
-        tag: '100',
-        content: '$a some value $b some other value $e author $e illustrator',
-      };
+        mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse);
 
-      expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-        content: '$a authority value $b fakeB $e author $e illustrator $0 some.url/n0001 $c field for modification $9 authority-id',
-        linkDetails: {
-          authorityId: 'authority-id',
-          authorityNaturalId: 'n0001',
-          linkingRuleId: 1,
-        },
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const outcome = await result.current.autoLinkAuthority(formValues);
+
+        expect(outcome).toEqual(expect.objectContaining({
+          fields: [{
+            'tag': '600',
+            'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 nr2005025774',
+            'indicators': ['0', '0'],
+            'isProtected': false,
+            'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
+            '_isDeleted': false,
+            '_isLinked': false,
+          }],
+        }));
       });
     });
   });
 
-  describe('when calling linkAuthority without saving changes, and then unlinkAuthority', () => {
-    const authority = {
-      id: 'authority-id',
-      sourceFileId: '1',
-      naturalId: 'n0001',
-    };
-
-    it('should return previous field content', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-      const field = {
-        tag: '100',
-        content: '$a Crumb, George. test',
-      };
-
-      const linkedField = result.current.linkAuthority(authority, authoritySource, field);
-      const unlinkedField = result.current.unlinkAuthority(linkedField);
-
-      expect(unlinkedField.content).toBe('$a Crumb, George. test');
-    });
-
-    it('should return previous field content even if it is empty', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-      const field = {
-        tag: '100',
-        content: '',
-      };
-
-      const linkedField = result.current.linkAuthority(authority, authoritySource, field);
-      const unlinkedField = result.current.unlinkAuthority(linkedField);
-
-      expect(unlinkedField.content).toBe('');
-    });
-  });
-
-  describe('when calling unlinkAuthority', () => {
+  describe('when using unlinkAuthority', () => {
     it('should return field with correct data', () => {
       const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
 
@@ -1152,463 +1137,55 @@ describe('Given useAuthorityLinking', () => {
         content: '$a authority value $b some other value $e author $e illustrator $0 http://some.url/n0001',
       });
     });
-  });
 
-  describe('when authority record doesnt pass required subfields validation', () => {
-    it('should throw validation error', () => {
-      useAuthorityLinkingRules.mockReturnValue({
-        linkingRules: [{
-          id: 1,
-          bibField: '100',
-          authorityField: '100',
-          authoritySubfields: ['a', 'b', 't'],
-          subfieldModifications: [{
-            source: 't',
-            target: 'c',
-          }],
-          validation: {
-            existence: [{
-              t: true,
-            }],
-          },
-        }],
-      });
-
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-      const field = {
-        tag: '100',
-        content: '$a Crumb, George. test',
-      };
+    describe('when calling linkAuthority without saving changes, and then unlinkAuthority', () => {
       const authority = {
         id: 'authority-id',
         sourceFileId: '1',
         naturalId: 'n0001',
       };
-      const authoritySourceWithoutMatchingField = {
-        fields: [{
+
+      it('should return previous field content', () => {
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+        const field = {
           tag: '100',
-          content: '$a authority value',
-        }],
-      };
+          content: '$a Crumb, George. test',
+        };
 
-      expect(() => result.current.linkAuthority(authority, authoritySourceWithoutMatchingField, field))
-        .toThrow('ui-quick-marc.record.link.validation.invalidHeading');
-    });
-  });
+        const linkedField = result.current.linkAuthority(authority, authoritySource, field);
+        const unlinkedField = result.current.unlinkAuthority(linkedField);
 
-  describe('when records dont have fields that can be linked', () => {
-    it('should return field without changes', () => {
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-      const field = {
-        tag: '100',
-        content: '$a Crumb, George. test',
-      };
-      const authority = {
-        id: 'authority-id',
-        sourceFileId: '1',
-        naturalId: 'n0001',
-      };
-      const authoritySourceWithoutMatchingField = {
-        fields: [{
-          tag: '110',
-          content: '$a authority value',
-        }],
-      };
-
-      expect(() => result.current.linkAuthority(authority, authoritySourceWithoutMatchingField, field))
-        .toThrow('ui-quick-marc.record.link.validation.invalidHeading');
-    });
-  });
-
-  describe('when calling actualizeLinks and there is no linked field', () => {
-    it('should return the same form values', async () => {
-      const formValues = { records: [] };
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-      const values = await result.current.actualizeLinks(formValues);
-
-      expect(values).toEqual(formValues);
-    });
-  });
-
-  describe('when calling actualizeLinks and there are linked fields', () => {
-    it('should actualize all links in the correct order', async () => {
-      const formValues = {
-        externalHrid: 'in00000000001',
-        externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-        leader: 'test',
-        marcFormat: MARC_TYPES.BIB,
-        _actionType: 'view',
-        records: [
-          {
-            tag: 'LDR',
-            content: '05341cam\\a2201021\\i\\4500',
-          },
-          {
-            'tag': '700',
-            'content': '$a Wang, Shifu, $d 1260-1316 $0 id.loc.gov/authorities/names/n81003794 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-            'indicators': ['\\', '\\'],
-            'linkDetails': {
-              'authorityId': '3929e600-5efb-4427-abf6-a963b01c9c37',
-              'authorityNaturalId': 'n81003794',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '100',
-            'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-            'indicators': ['1', '\\'],
-            'linkDetails': {
-              'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 1,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '700',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
-            'indicators': ['\\', '\\'],
-            'linkDetails': {
-              'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
-              'authorityNaturalId': 'n93100664',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '700',
-            'content': '$a Zhang, Xuejing $0 id.loc.gov/authorities/names/no2005093867 $9 68927bf9-e78f-48b9-a45a-947408caff6e',
-            'indicators': ['\\', '\\'],
-            'linkDetails': {
-              'authorityId': '68927bf9-e78f-48b9-a45a-947408caff6e',
-              'authorityNaturalId': 'no2005093867',
-              'linkingRuleId': 15,
-              'status': 'ACTUAL',
-            },
-          },
-        ],
-      };
-
-      const linkSuggestionsRequestBody = {
-        'leader': formValues.records[0].content,
-        'fields': [
-          {
-            'tag': '700',
-            'content': '$a Wang, Shifu, $d 1260-1316 $0 id.loc.gov/authorities/names/n81003794 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-          },
-          {
-            'tag': '100',
-            'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-          },
-          {
-            'tag': '700',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
-          },
-          {
-            'tag': '700',
-            'content': '$a Zhang, Xuejing $0 id.loc.gov/authorities/names/no2005093867 $9 68927bf9-e78f-48b9-a45a-947408caff6e',
-          },
-        ],
-        'marcFormat': MARC_TYPES.BIB,
-        '_actionType': 'view',
-      };
-
-      const linkSuggestionsResponse = {
-        '_actionType': 'view',
-        'leader': formValues.records[0].content,
-        'fields': [
-          {
-            'tag': '700',
-            'content': '$a Wang, Shifu, test $d 1260-1316 $0 id.loc.gov/authorities/names/n12345678 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-            'linkDetails': {
-              'authorityId': '3929e600-5efb-4427-abf6-a963b01c9c37',
-              'authorityNaturalId': 'n12345678',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '100',
-            'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-            'linkDetails': {
-              'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 1,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '700',
-            'content': '$a Yuan, Bing test $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
-            'linkDetails': {
-              'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
-              'authorityNaturalId': 'n93100664',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '700',
-            'content': '$a Zhang, Xuejing test $0 id.loc.gov/authorities/names/no2005093867 $9 68927bf9-e78f-48b9-a45a-947408caff6e',
-            'linkDetails': {
-              'authorityId': '68927bf9-e78f-48b9-a45a-947408caff6e',
-              'authorityNaturalId': 'no2005093867',
-              'linkingRuleId': 15,
-              'status': 'ACTUAL',
-            },
-          },
-        ],
-        'suppressDiscovery': false,
-      };
-
-      useLinkSuggestions.mockReturnValue({
-        fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse),
+        expect(unlinkedField.content).toBe('$a Crumb, George. test');
       });
 
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+      it('should return previous field content even if it is empty', () => {
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+        const field = {
+          tag: '100',
+          content: '',
+        };
 
-      const values = await result.current.actualizeLinks(formValues);
+        const linkedField = result.current.linkAuthority(authority, authoritySource, field);
+        const unlinkedField = result.current.unlinkAuthority(linkedField);
 
-      expect(mockFetchLinkSuggestions).toHaveBeenCalledWith({
-        body: linkSuggestionsRequestBody,
-        isSearchByAuthorityId: true,
-        ignoreAutoLinkingEnabled: true,
-      });
-      expect(values).toEqual({
-        externalHrid: 'in00000000001',
-        externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-        leader: 'test',
-        marcFormat: MARC_TYPES.BIB,
-        _actionType: 'view',
-        records: [
-          {
-            tag: 'LDR',
-            content: formValues.records[0].content,
-          },
-          {
-            'tag': '700',
-            'content': '$a Wang, Shifu, test $d 1260-1316 $0 id.loc.gov/authorities/names/n12345678 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-            'indicators': ['\\', '\\'],
-            'linkDetails': {
-              'authorityId': '3929e600-5efb-4427-abf6-a963b01c9c37',
-              'authorityNaturalId': 'n12345678',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '100',
-            'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-            'indicators': ['1', '\\'],
-            'linkDetails': {
-              'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 1,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '700',
-            'content': '$a Yuan, Bing test $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
-            'indicators': ['\\', '\\'],
-            'linkDetails': {
-              'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
-              'authorityNaturalId': 'n93100664',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '700',
-            'content': '$a Zhang, Xuejing test $0 id.loc.gov/authorities/names/no2005093867 $9 68927bf9-e78f-48b9-a45a-947408caff6e',
-            'indicators': ['\\', '\\'],
-            'linkDetails': {
-              'authorityId': '68927bf9-e78f-48b9-a45a-947408caff6e',
-              'authorityNaturalId': 'no2005093867',
-              'linkingRuleId': 15,
-              'status': 'ACTUAL',
-            },
-          },
-        ],
+        expect(unlinkedField.content).toBe('');
       });
     });
   });
 
-  describe('when calling actualizeLinks and there are linked fields', () => {
-    it('should unlink links for which there are no suggestions', async () => {
-      const formValues = {
-        externalHrid: 'in00000000001',
-        externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-        leader: '05341cam\\a2201021\\i\\4500',
-        marcFormat: MARC_TYPES.BIB,
-        _actionType: 'view',
-        records: [
-          {
-            'tag': '100',
-            'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-            'indicators': ['1', '\\'],
-            'linkDetails': {
-              'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 1,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '700',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
-            'indicators': ['\\', '\\'],
-            'linkDetails': {
-              'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
-              'authorityNaturalId': 'n93100664',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-        ],
-      };
+  describe('when using actualizeLinks', () => {
+    describe('when there is no linked field', () => {
+      it('should return the same form values', async () => {
+        const formValues = { records: [] };
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+        const values = await result.current.actualizeLinks(formValues);
 
-      const linkSuggestionsResponse = {
-        '_actionType': 'view',
-        'leader': '05274cam\\a2201021\\i\\4500',
-        'fields': [
-          {
-            'tag': '100',
-            'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-            'linkDetails': {
-              'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 1,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '700',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
-            'linkDetails': {
-              'status': 'ERROR',
-              'errorCause': '101',
-            },
-          },
-        ],
-        'suppressDiscovery': false,
-      };
-
-      useLinkSuggestions.mockReturnValue({
-        fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse),
-      });
-
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const values = await result.current.actualizeLinks(formValues);
-
-      expect(values).toEqual({
-        externalHrid: 'in00000000001',
-        externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-        leader: '05341cam\\a2201021\\i\\4500',
-        marcFormat: MARC_TYPES.BIB,
-        _actionType: 'view',
-        records: [
-          {
-            'tag': '100',
-            'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-            'indicators': ['1', '\\'],
-            'linkDetails': {
-              'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 1,
-              'status': 'NEW',
-            },
-          },
-          {
-            'tag': '700',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
-            'indicators': ['\\', '\\'],
-          },
-        ],
+        expect(values).toEqual(formValues);
       });
     });
-  });
 
-  describe('when calling actualizeLinks and there are linked fields', () => {
-    it('should take controlled subfields from the suggested field and uncontrolled ones from the current field', async () => {
-      const formValues = {
-        externalHrid: 'in00000000001',
-        externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-        leader: '05341cam\\a2201021\\i\\4500',
-        marcFormat: MARC_TYPES.BIB,
-        _actionType: 'view',
-        records: [
-          {
-            'tag': '700',
-            'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b $2 test1 $i test2',
-            'indicators': ['\\', '\\'],
-            'linkDetails': {
-              'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
-              'authorityNaturalId': 'n93100664',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-        ],
-      };
-
-      const linkSuggestionsResponse = {
-        '_actionType': 'view',
-        'leader': '05274cam\\a2201021\\i\\4500',
-        'fields': [
-          {
-            'tag': '700',
-            'content': '$a Yuan, Bing test $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
-            'linkDetails': {
-              'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
-              'authorityNaturalId': 'n93100664',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-        ],
-        'suppressDiscovery': false,
-      };
-
-      useLinkSuggestions.mockReturnValue({
-        fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse),
-      });
-
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      const values = await result.current.actualizeLinks(formValues);
-
-      expect(values).toEqual({
-        externalHrid: 'in00000000001',
-        externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-        leader: '05341cam\\a2201021\\i\\4500',
-        marcFormat: MARC_TYPES.BIB,
-        _actionType: 'view',
-        records: [
-          {
-            'tag': '700',
-            'content': '$a Yuan, Bing test $i test2 $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b $2 test1',
-            'indicators': ['\\', '\\'],
-            'linkDetails': {
-              'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
-              'authorityNaturalId': 'n93100664',
-              'linkingRuleId': 15,
-              'status': 'NEW',
-            },
-          },
-        ],
-      });
-    });
-  });
-
-  describe('when a member tenant calls actualizeLinks and bib record is local', () => {
-    describe('and some of the fields linked with shared authority records', () => {
-      it('should take suggested fields from central tenant for the fields linked with shared authority records', async () => {
-        checkIfUserInMemberTenant.mockReturnValue(true);
-        useLocation.mockReturnValue({ search: '?shared=false' });
-
+    describe('when there are linked fields', () => {
+      it('should actualize all links in the correct order', async () => {
         const formValues = {
           externalHrid: 'in00000000001',
           externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
@@ -1617,6 +1194,10 @@ describe('Given useAuthorityLinking', () => {
           _actionType: 'view',
           records: [
             {
+              tag: 'LDR',
+              content: '05341cam\\a2201021\\i\\4500',
+            },
+            {
               'tag': '700',
               'content': '$a Wang, Shifu, $d 1260-1316 $0 id.loc.gov/authorities/names/n81003794 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
               'indicators': ['\\', '\\'],
@@ -1624,7 +1205,7 @@ describe('Given useAuthorityLinking', () => {
                 'authorityId': '3929e600-5efb-4427-abf6-a963b01c9c37',
                 'authorityNaturalId': 'n81003794',
                 'linkingRuleId': 15,
-                'status': 'ACTUAL',
+                'status': 'NEW',
               },
             },
             {
@@ -1663,49 +1244,31 @@ describe('Given useAuthorityLinking', () => {
           ],
         };
 
-        const linkSuggestionsResponse = {
-          '_actionType': 'view',
+        const linkSuggestionsRequestBody = {
           'leader': formValues.records[0].content,
           'fields': [
             {
               'tag': '700',
-              'content': '$a Wang, Shifu, test $d 1260-1316 $0 id.loc.gov/authorities/names/n12345678 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
+              'content': '$a Wang, Shifu, $d 1260-1316 $0 id.loc.gov/authorities/names/n81003794 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
             },
             {
               'tag': '100',
-              'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-              'linkDetails': {
-                'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-                'authorityNaturalId': 'n2008001084',
-                'linkingRuleId': 1,
-                'status': 'NEW',
-              },
+              'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
             },
             {
               'tag': '700',
-              'content': '$a Yuan, Bing test $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
+              'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
             },
             {
               'tag': '700',
-              'content': '$a Zhang, Xuejing test $0 id.loc.gov/authorities/names/no2005093867 $9 68927bf9-e78f-48b9-a45a-947408caff6e',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
+              'content': '$a Zhang, Xuejing $0 id.loc.gov/authorities/names/no2005093867 $9 68927bf9-e78f-48b9-a45a-947408caff6e',
             },
           ],
-          'suppressDiscovery': false,
+          'marcFormat': MARC_TYPES.BIB,
+          '_actionType': 'view',
         };
 
-        const linkSuggestionsResponseFromCentralTenant = {
+        const linkSuggestionsResponse = {
           '_actionType': 'view',
           'leader': formValues.records[0].content,
           'fields': [
@@ -1716,15 +1279,17 @@ describe('Given useAuthorityLinking', () => {
                 'authorityId': '3929e600-5efb-4427-abf6-a963b01c9c37',
                 'authorityNaturalId': 'n12345678',
                 'linkingRuleId': 15,
-                'status': 'ACTUAL',
+                'status': 'NEW',
               },
             },
             {
               'tag': '100',
               'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
               'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
+                'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
+                'authorityNaturalId': 'n2008001084',
+                'linkingRuleId': 1,
+                'status': 'NEW',
               },
             },
             {
@@ -1752,22 +1317,18 @@ describe('Given useAuthorityLinking', () => {
         };
 
         useLinkSuggestions.mockReturnValue({
-          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
+          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse),
         });
 
-        useLinkSuggestions.mockReturnValue({
-          fetchLinkSuggestions: mockFetchLinkSuggestions
-            .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
-        });
-
-        const { result } = renderHook(() => useAuthorityLinking({ marcType: MARC_TYPES.BIB }), { wrapper });
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
 
         const values = await result.current.actualizeLinks(formValues);
 
-        expect(useLinkSuggestions).toHaveBeenNthCalledWith(1, { tenantId: '' });
-        expect(useLinkSuggestions).toHaveBeenNthCalledWith(2, { tenantId: 'consortia' });
-        expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(2);
-
+        expect(mockFetchLinkSuggestions).toHaveBeenCalledWith({
+          body: linkSuggestionsRequestBody,
+          isSearchByAuthorityId: true,
+          ignoreAutoLinkingEnabled: true,
+        });
         expect(values).toEqual({
           externalHrid: 'in00000000001',
           externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
@@ -1776,6 +1337,10 @@ describe('Given useAuthorityLinking', () => {
           _actionType: 'view',
           records: [
             {
+              tag: 'LDR',
+              content: formValues.records[0].content,
+            },
+            {
               'tag': '700',
               'content': '$a Wang, Shifu, test $d 1260-1316 $0 id.loc.gov/authorities/names/n12345678 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
               'indicators': ['\\', '\\'],
@@ -1783,7 +1348,7 @@ describe('Given useAuthorityLinking', () => {
                 'authorityId': '3929e600-5efb-4427-abf6-a963b01c9c37',
                 'authorityNaturalId': 'n12345678',
                 'linkingRuleId': 15,
-                'status': 'ACTUAL',
+                'status': 'NEW',
               },
             },
             {
@@ -1822,33 +1387,15 @@ describe('Given useAuthorityLinking', () => {
           ],
         });
       });
-    });
-  });
 
-  describe('when a member tenant calls actualizeLinks and bib record is derived shared', () => {
-    describe('and some of the fields linked with shared authority records', () => {
-      it('should take suggested fields from central tenant for the fields linked with shared authority records', async () => {
-        checkIfUserInMemberTenant.mockReturnValue(true);
-        useLocation.mockReturnValue({ search: '?shared=true' });
-
+      it('should unlink links for which there are no suggestions', async () => {
         const formValues = {
           externalHrid: 'in00000000001',
           externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-          leader: 'test',
+          leader: '05341cam\\a2201021\\i\\4500',
           marcFormat: MARC_TYPES.BIB,
           _actionType: 'view',
           records: [
-            {
-              'tag': '700',
-              'content': '$a Wang, Shifu, $d 1260-1316 $0 id.loc.gov/authorities/names/n81003794 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-              'indicators': ['\\', '\\'],
-              'linkDetails': {
-                'authorityId': '3929e600-5efb-4427-abf6-a963b01c9c37',
-                'authorityNaturalId': 'n81003794',
-                'linkingRuleId': 15,
-                'status': 'ACTUAL',
-              },
-            },
             {
               'tag': '100',
               'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
@@ -1871,35 +1418,16 @@ describe('Given useAuthorityLinking', () => {
                 'status': 'NEW',
               },
             },
-            {
-              'tag': '700',
-              'content': '$a Zhang, Xuejing $0 id.loc.gov/authorities/names/no2005093867 $9 68927bf9-e78f-48b9-a45a-947408caff6e',
-              'indicators': ['\\', '\\'],
-              'linkDetails': {
-                'authorityId': '68927bf9-e78f-48b9-a45a-947408caff6e',
-                'authorityNaturalId': 'no2005093867',
-                'linkingRuleId': 15,
-                'status': 'ACTUAL',
-              },
-            },
           ],
         };
 
         const linkSuggestionsResponse = {
           '_actionType': 'view',
-          'leader': formValues.records[0].content,
+          'leader': '05274cam\\a2201021\\i\\4500',
           'fields': [
             {
-              'tag': '700',
-              'content': '$a Wang, Shifu, test $d 1260-1316 $0 id.loc.gov/authorities/names/n12345678 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
-            },
-            {
               'tag': '100',
-              'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
+              'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
               'linkDetails': {
                 'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
                 'authorityNaturalId': 'n2008001084',
@@ -1909,122 +1437,62 @@ describe('Given useAuthorityLinking', () => {
             },
             {
               'tag': '700',
-              'content': '$a Yuan, Bing test $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
+              'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
               'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
-            },
-            {
-              'tag': '700',
-              'content': '$a Zhang, Xuejing test $0 id.loc.gov/authorities/names/no2005093867 $9 68927bf9-e78f-48b9-a45a-947408caff6e',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
+                'status': 'ERROR',
+                'errorCause': '101',
               },
             },
           ],
           'suppressDiscovery': false,
         };
 
-        const linkSuggestionsResponseFromCentralTenant = {
-          '_actionType': 'view',
-          'leader': formValues.records[0].content,
-          'fields': [
-            {
-              'tag': '700',
-              'content': '$a Wang, Shifu, test $d 1260-1316 $0 id.loc.gov/authorities/names/n12345678 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-              'linkDetails': {
-                'authorityId': '3929e600-5efb-4427-abf6-a963b01c9c37',
-                'authorityNaturalId': 'n12345678',
-                'linkingRuleId': 15,
-                'status': 'ACTUAL',
-              },
-            },
+        useLinkSuggestions.mockReturnValue({
+          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse),
+        });
+
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const values = await result.current.actualizeLinks(formValues);
+
+        expect(values).toEqual({
+          externalHrid: 'in00000000001',
+          externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
+          leader: '05341cam\\a2201021\\i\\4500',
+          marcFormat: MARC_TYPES.BIB,
+          _actionType: 'view',
+          records: [
             {
               'tag': '100',
-              'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
+              'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
+              'indicators': ['1', '\\'],
               'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
-            },
-            {
-              'tag': '700',
-              'content': '$a Yuan, Bing test $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
-              'linkDetails': {
-                'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
-                'authorityNaturalId': 'n93100664',
-                'linkingRuleId': 15,
+                'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
+                'authorityNaturalId': 'n2008001084',
+                'linkingRuleId': 1,
                 'status': 'NEW',
               },
             },
             {
               'tag': '700',
-              'content': '$a Zhang, Xuejing test $0 id.loc.gov/authorities/names/no2005093867 $9 68927bf9-e78f-48b9-a45a-947408caff6e',
-              'linkDetails': {
-                'authorityId': '68927bf9-e78f-48b9-a45a-947408caff6e',
-                'authorityNaturalId': 'no2005093867',
-                'linkingRuleId': 15,
-                'status': 'ACTUAL',
-              },
+              'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664',
+              'indicators': ['\\', '\\'],
             },
           ],
-          'suppressDiscovery': false,
-        };
-
-        useLinkSuggestions.mockReturnValue({
-          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
         });
+      });
 
-        useLinkSuggestions.mockReturnValue({
-          fetchLinkSuggestions: mockFetchLinkSuggestions
-            .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
-        });
-
-        const { result } = renderHook(() => useAuthorityLinking({
-          marcType: MARC_TYPES.BIB,
-          action: QUICK_MARC_ACTIONS.DERIVE,
-        }), { wrapper });
-
-        const values = await result.current.actualizeLinks(formValues);
-
-        expect(useLinkSuggestions).toHaveBeenNthCalledWith(1, { tenantId: '' });
-        expect(useLinkSuggestions).toHaveBeenNthCalledWith(2, { tenantId: 'consortia' });
-        expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(2);
-
-        expect(values).toEqual({
+      it('should take controlled subfields from the suggested field and uncontrolled ones from the current field', async () => {
+        const formValues = {
           externalHrid: 'in00000000001',
           externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-          leader: 'test',
+          leader: '05341cam\\a2201021\\i\\4500',
           marcFormat: MARC_TYPES.BIB,
           _actionType: 'view',
           records: [
             {
               'tag': '700',
-              'content': '$a Wang, Shifu, test $d 1260-1316 $0 id.loc.gov/authorities/names/n12345678 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-              'indicators': ['\\', '\\'],
-              'linkDetails': {
-                'authorityId': '3929e600-5efb-4427-abf6-a963b01c9c37',
-                'authorityNaturalId': 'n12345678',
-                'linkingRuleId': 15,
-                'status': 'ACTUAL',
-              },
-            },
-            {
-              'tag': '100',
-              'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-              'indicators': ['1', '\\'],
-              'linkDetails': {
-                'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-                'authorityNaturalId': 'n2008001084',
-                'linkingRuleId': 1,
-                'status': 'NEW',
-              },
-            },
-            {
-              'tag': '700',
-              'content': '$a Yuan, Bing test $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
+              'content': '$a Yuan, Bing $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b $2 test1 $i test2',
               'indicators': ['\\', '\\'],
               'linkDetails': {
                 'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
@@ -2033,669 +1501,55 @@ describe('Given useAuthorityLinking', () => {
                 'status': 'NEW',
               },
             },
+          ],
+        };
+
+        const linkSuggestionsResponse = {
+          '_actionType': 'view',
+          'leader': '05274cam\\a2201021\\i\\4500',
+          'fields': [
             {
               'tag': '700',
-              'content': '$a Zhang, Xuejing test $0 id.loc.gov/authorities/names/no2005093867 $9 68927bf9-e78f-48b9-a45a-947408caff6e',
+              'content': '$a Yuan, Bing test $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b',
+              'linkDetails': {
+                'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
+                'authorityNaturalId': 'n93100664',
+                'linkingRuleId': 15,
+                'status': 'NEW',
+              },
+            },
+          ],
+          'suppressDiscovery': false,
+        };
+
+        useLinkSuggestions.mockReturnValue({
+          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse),
+        });
+
+        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+        const values = await result.current.actualizeLinks(formValues);
+
+        expect(values).toEqual({
+          externalHrid: 'in00000000001',
+          externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
+          leader: '05341cam\\a2201021\\i\\4500',
+          marcFormat: MARC_TYPES.BIB,
+          _actionType: 'view',
+          records: [
+            {
+              'tag': '700',
+              'content': '$a Yuan, Bing test $i test2 $0 id.loc.gov/authorities/names/n93100664 $9 a2803a7b-d479-46cd-b744-1305d2a7a29b $2 test1',
               'indicators': ['\\', '\\'],
               'linkDetails': {
-                'authorityId': '68927bf9-e78f-48b9-a45a-947408caff6e',
-                'authorityNaturalId': 'no2005093867',
+                'authorityId': 'a2803a7b-d479-46cd-b744-1305d2a7a29b',
+                'authorityNaturalId': 'n93100664',
                 'linkingRuleId': 15,
-                'status': 'ACTUAL',
+                'status': 'NEW',
               },
             },
           ],
         });
-      });
-    });
-  });
-
-  describe('when a member tenant calls actualizeLinks and bib record is local', () => {
-    describe('and some of the fields linked with shared authority records', () => {
-      describe('and the suggested field has an error status in both central and member tenants', () => {
-        it('should unlink this field', async () => {
-          checkIfUserInMemberTenant.mockReturnValue(true);
-          useLocation.mockReturnValue({ search: '?shared=false' });
-
-          const formValues = {
-            externalHrid: 'in00000000001',
-            externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-            leader: 'test',
-            marcFormat: MARC_TYPES.BIB,
-            _actionType: 'view',
-            records: [
-              {
-                'tag': '700',
-                'content': '$a Wang, Shifu, $d 1260-1316 $0 id.loc.gov/authorities/names/n81003794 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-                'indicators': ['\\', '\\'],
-                'linkDetails': {
-                  'authorityId': '3929e600-5efb-4427-abf6-a963b01c9c37',
-                  'authorityNaturalId': 'n81003794',
-                  'linkingRuleId': 15,
-                  'status': 'ACTUAL',
-                },
-              },
-              {
-                'tag': '100',
-                'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-                'indicators': ['1', '\\'],
-                'linkDetails': {
-                  'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-                  'authorityNaturalId': 'n2008001084',
-                  'linkingRuleId': 1,
-                  'status': 'NEW',
-                },
-              },
-            ],
-          };
-
-          const linkSuggestionsResponse = {
-            '_actionType': 'view',
-            'leader': formValues.records[0].content,
-            'fields': [
-              {
-                'tag': '700',
-                'content': '$a Wang, Shifu, test $d 1260-1316 $0 id.loc.gov/authorities/names/n12345678 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-                'linkDetails': {
-                  errorCause: '101',
-                  status: 'ERROR',
-                },
-              },
-              {
-                'tag': '100',
-                'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-                'linkDetails': {
-                  'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-                  'authorityNaturalId': 'n2008001084',
-                  'linkingRuleId': 1,
-                  'status': 'NEW',
-                },
-              },
-            ],
-            'suppressDiscovery': false,
-          };
-
-          const linkSuggestionsResponseFromCentralTenant = {
-            '_actionType': 'view',
-            'leader': formValues.records[0].content,
-            'fields': [
-              {
-                'tag': '700',
-                'content': '$a Wang, Shifu, test $d 1260-1316 $0 id.loc.gov/authorities/names/n12345678 $9 3929e600-5efb-4427-abf6-a963b01c9c37',
-                'linkDetails': {
-                  errorCause: '101',
-                  status: 'ERROR',
-                },
-              },
-              {
-                'tag': '100',
-                'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-                'linkDetails': {
-                  errorCause: '101',
-                  status: 'ERROR',
-                },
-              },
-            ],
-            'suppressDiscovery': false,
-          };
-
-          useLinkSuggestions.mockReturnValue({
-            fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
-          });
-
-          useLinkSuggestions.mockReturnValue({
-            fetchLinkSuggestions: mockFetchLinkSuggestions
-              .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
-          });
-
-          const { result } = renderHook(() => useAuthorityLinking({ marcType: MARC_TYPES.BIB }), { wrapper });
-
-          const values = await result.current.actualizeLinks(formValues);
-
-          expect(values).toEqual({
-            externalHrid: 'in00000000001',
-            externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-            leader: 'test',
-            marcFormat: MARC_TYPES.BIB,
-            _actionType: 'view',
-            records: [
-              {
-                'tag': '700',
-                'content': '$a Wang, Shifu, $d 1260-1316 $0 id.loc.gov/authorities/names/n81003794',
-                'indicators': ['\\', '\\'],
-              },
-              {
-                'tag': '100',
-                'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-                'indicators': ['1', '\\'],
-                'linkDetails': {
-                  'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-                  'authorityNaturalId': 'n2008001084',
-                  'linkingRuleId': 1,
-                  'status': 'NEW',
-                },
-              },
-            ],
-          });
-        });
-      });
-    });
-  });
-
-  describe('when not a member tenant calls actualizeLinks', () => {
-    it('should call fetchLinkSuggestions once', async () => {
-      const formValues = {
-        externalHrid: 'in00000000001',
-        externalId: '4c95c27d-51fc-4ae1-892d-11347377bdd4',
-        leader: 'test',
-        marcFormat: MARC_TYPES.BIB,
-        _actionType: 'view',
-        records: [
-          {
-            'tag': '100',
-            'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-            'indicators': ['1', '\\'],
-            'linkDetails': {
-              'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 1,
-              'status': 'NEW',
-            },
-          },
-        ],
-      };
-
-      const linkSuggestionsResponse = {
-        '_actionType': 'view',
-        'leader': formValues.records[0].content,
-        'fields': [
-          {
-            'tag': '100',
-            'content': '$a Coates, Ta-Nehisi test $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 541539bf-7e1f-468e-a817-a551c6b63d7d',
-            'linkDetails': {
-              'authorityId': '541539bf-7e1f-468e-a817-a551c6b63d7d',
-              'authorityNaturalId': 'n2008001084',
-              'linkingRuleId': 1,
-              'status': 'NEW',
-            },
-          },
-        ],
-        'suppressDiscovery': false,
-      };
-
-      useLinkSuggestions.mockReturnValue({
-        fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse),
-      });
-
-      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
-
-      await result.current.actualizeLinks(formValues);
-
-      expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(1);
-      expect(mockFetchLinkSuggestions).toHaveBeenCalledWith(expect.not.objectContaining({
-        tenantId: expect.anything(),
-      }));
-    });
-  });
-
-  describe('when a member tenant calls autoLinkAuthority and bib record is local', () => {
-    describe('and some of the fields can be linked with shared authority records', () => {
-      it('should take suggested fields from central tenant for those fields', async () => {
-        checkIfUserInMemberTenant.mockReturnValue(true);
-
-        const formValues = {
-          records: [
-            {
-              'tag': '100',
-              'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-              'indicators': ['1', '\\'],
-              'isProtected': false,
-              'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
-              '_isDeleted': false,
-              '_isLinked': false,
-            }, {
-              'tag': '600',
-              'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
-              'indicators': ['0', '0'],
-              'isProtected': false,
-              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-              '_isDeleted': false,
-              '_isLinked': false,
-            },
-          ],
-        };
-
-        const linkSuggestionsResponse = {
-          fields: [
-            {
-              'tag': '100',
-              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
-            }, {
-              'tag': '600',
-              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'linkDetails': {
-                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-                'authorityNaturalId': 'nr2005025774',
-                'linkingRuleId': 8,
-                'status': 'NEW',
-              },
-            },
-          ],
-        };
-
-        const linkSuggestionsResponseFromCentralTenant = {
-          fields: [
-            {
-              'tag': '100',
-              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-              'linkDetails': {
-                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
-                'authorityNaturalId': 'n2008001084',
-                'linkingRuleId': 1,
-                'status': 'NEW',
-              },
-            }, {
-              'tag': '600',
-              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
-            },
-          ],
-        };
-
-        useLinkSuggestions.mockReturnValue({
-          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
-        });
-
-        useLinkSuggestions.mockReturnValue({
-          fetchLinkSuggestions: mockFetchLinkSuggestions
-            .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
-        });
-
-        const { result } = renderHook(() => useAuthorityLinking({ marcType: MARC_TYPES.BIB }), { wrapper });
-
-        const outcome = await result.current.autoLinkAuthority(formValues);
-
-        expect(useLinkSuggestions).toHaveBeenNthCalledWith(1, { tenantId: '' });
-        expect(useLinkSuggestions).toHaveBeenNthCalledWith(2, { tenantId: 'consortia' });
-        expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(2);
-
-        expect(outcome).toEqual(expect.objectContaining({
-          fields: [
-            {
-              'tag': '100',
-              'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-              'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-              'indicators': ['1', '\\'],
-              'isProtected': false,
-              'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
-              '_isDeleted': false,
-              '_isLinked': false,
-              'linkDetails': {
-                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
-                'authorityNaturalId': 'n2008001084',
-                'linkingRuleId': 1,
-                'status': 'NEW',
-              },
-              'subfieldGroups': {
-                'controlled': '$a Coates, Ta-Nehisi',
-                'uncontrolledAlpha': '$e author.',
-                'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
-                'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-                'uncontrolledNumber': '',
-              },
-            }, {
-              'tag': '600',
-              'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
-              'indicators': ['0', '0'],
-              'isProtected': false,
-              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-              '_isDeleted': false,
-              '_isLinked': false,
-              'linkDetails': {
-                'authorityNaturalId': 'nr2005025774',
-                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-                'linkingRuleId': 8,
-                'status': 'NEW',
-              },
-              'subfieldGroups': {
-                'controlled': '$a Brown, Benjamin, $d 1966-',
-                'uncontrolledAlpha': '$v Comic books, strips, etc.',
-                'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
-                'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-                'uncontrolledNumber': '',
-              },
-            },
-          ],
-        }));
-      });
-    });
-  });
-
-  describe('when a member tenant calls autoLinkAuthority and bib record is derived shared', () => {
-    describe('and some of the fields can be linked with shared authority records', () => {
-      it('should take suggested fields from central tenant for the fields linked with shared authority records', async () => {
-        checkIfUserInMemberTenant.mockReturnValue(true);
-        useLocation.mockReturnValue({ search: '?shared=true' });
-
-        const formValues = {
-          records: [
-            {
-              'tag': '100',
-              'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-              'indicators': ['1', '\\'],
-              'isProtected': false,
-              'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
-              '_isDeleted': false,
-              '_isLinked': false,
-            }, {
-              'tag': '600',
-              'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
-              'indicators': ['0', '0'],
-              'isProtected': false,
-              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-              '_isDeleted': false,
-              '_isLinked': false,
-            },
-          ],
-        };
-
-        const linkSuggestionsResponse = {
-          fields: [
-            {
-              'tag': '100',
-              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
-            }, {
-              'tag': '600',
-              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'linkDetails': {
-                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-                'authorityNaturalId': 'nr2005025774',
-                'linkingRuleId': 8,
-                'status': 'NEW',
-              },
-            },
-          ],
-        };
-
-        const linkSuggestionsResponseFromCentralTenant = {
-          fields: [
-            {
-              'tag': '100',
-              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-              'linkDetails': {
-                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
-                'authorityNaturalId': 'n2008001084',
-                'linkingRuleId': 1,
-                'status': 'NEW',
-              },
-            }, {
-              'tag': '600',
-              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
-            },
-          ],
-        };
-
-        useLinkSuggestions.mockReturnValue({
-          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
-        });
-
-        useLinkSuggestions.mockReturnValue({
-          fetchLinkSuggestions: mockFetchLinkSuggestions
-            .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
-        });
-
-        const { result } = renderHook(() => useAuthorityLinking({
-          marcType: MARC_TYPES.BIB,
-          action: QUICK_MARC_ACTIONS.DERIVE,
-        }), { wrapper });
-
-        const outcome = await result.current.autoLinkAuthority(formValues);
-
-        expect(useLinkSuggestions).toHaveBeenNthCalledWith(1, { tenantId: '' });
-        expect(useLinkSuggestions).toHaveBeenNthCalledWith(2, { tenantId: 'consortia' });
-        expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(2);
-
-        expect(outcome).toEqual(expect.objectContaining({
-          fields: [
-            {
-              'tag': '100',
-              'content': '$a Coates, Ta-Nehisi $e author. $0 id.loc.gov/authorities/names/n2008001084 $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-              'prevContent': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-              'indicators': ['1', '\\'],
-              'isProtected': false,
-              'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
-              '_isDeleted': false,
-              '_isLinked': false,
-              'linkDetails': {
-                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
-                'authorityNaturalId': 'n2008001084',
-                'linkingRuleId': 1,
-                'status': 'NEW',
-              },
-              'subfieldGroups': {
-                'controlled': '$a Coates, Ta-Nehisi',
-                'uncontrolledAlpha': '$e author.',
-                'zeroSubfield': '$0 id.loc.gov/authorities/names/n2008001084',
-                'nineSubfield': '$9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-                'uncontrolledNumber': '',
-              },
-            }, {
-              'tag': '600',
-              'content': '$a Brown, Benjamin, $d 1966- $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'prevContent': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
-              'indicators': ['0', '0'],
-              'isProtected': false,
-              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-              '_isDeleted': false,
-              '_isLinked': false,
-              'linkDetails': {
-                'authorityNaturalId': 'nr2005025774',
-                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-                'linkingRuleId': 8,
-                'status': 'NEW',
-              },
-              'subfieldGroups': {
-                'controlled': '$a Brown, Benjamin, $d 1966-',
-                'uncontrolledAlpha': '$v Comic books, strips, etc.',
-                'zeroSubfield': '$0 id.loc.gov/authorities/names/nr2005025774',
-                'nineSubfield': '$9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-                'uncontrolledNumber': '',
-              },
-            },
-          ],
-        }));
-      });
-    });
-  });
-
-  describe('when a member tenant calls autoLinkAuthority and bib record is local', () => {
-    describe('and some of the fields can be linked with shared authority records', () => {
-      describe('and the suggested field has an error status in both central and member tenants', () => {
-        it('should return the same field', async () => {
-          checkIfUserInMemberTenant.mockReturnValue(true);
-
-          const formValues = {
-            records: [
-              {
-                'tag': '100',
-                'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-                'indicators': ['1', '\\'],
-                'isProtected': false,
-                'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
-                '_isDeleted': false,
-                '_isLinked': false,
-              },
-            ],
-          };
-
-          const linkSuggestionsResponse = {
-            fields: [
-              {
-                'tag': '100',
-                'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-                'linkDetails': {
-                  errorCause: '101',
-                  status: 'ERROR',
-                },
-              },
-            ],
-          };
-
-          const linkSuggestionsResponseFromCentralTenant = linkSuggestionsResponse;
-
-          useLinkSuggestions.mockReturnValue({
-            fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
-          });
-
-          useLinkSuggestions.mockReturnValue({
-            fetchLinkSuggestions: mockFetchLinkSuggestions
-              .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
-          });
-
-          const { result } = renderHook(() => useAuthorityLinking({ marcType: MARC_TYPES.BIB }), { wrapper });
-
-          const outcome = await result.current.autoLinkAuthority(formValues);
-
-          expect(useLinkSuggestions).toHaveBeenNthCalledWith(1, { tenantId: '' });
-          expect(useLinkSuggestions).toHaveBeenNthCalledWith(2, { tenantId: 'consortia' });
-          expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(2);
-
-          expect(outcome).toEqual(expect.objectContaining({
-            fields: formValues.records,
-          }));
-        });
-      });
-    });
-  });
-
-  describe('when a member tenant calls autoLinkAuthority and bib record is derived shared', () => {
-    describe('and some of the fields can be linked with shared authority records', () => {
-      it('should return the suggestedFields with those with error replaced', async () => {
-        checkIfUserInMemberTenant.mockReturnValue(true);
-
-        const formValues = {
-          records: [
-            {
-              'tag': '100',
-              'content': '$a Coates, Ta-Nehisi, $e author. $0 n2008001084',
-              'indicators': ['1', '\\'],
-              'isProtected': false,
-              'id': '301323a7-258c-46d0-a88a-c3ec604bf37a',
-              '_isDeleted': false,
-              '_isLinked': false,
-            }, {
-              'tag': '600',
-              'content': '$a Black Panther $c (Fictitious character) $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774',
-              'indicators': ['0', '0'],
-              'isProtected': false,
-              'id': 'bc44d91c-6915-4609-9fd1-bbe470f4740b',
-              '_isDeleted': false,
-              '_isLinked': false,
-            },
-          ],
-        };
-
-        const linkSuggestionsResponse = {
-          fields: [
-            {
-              'tag': '100',
-              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
-            }, {
-              'tag': '600',
-              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'linkDetails': {
-                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-                'authorityNaturalId': 'nr2005025774',
-                'linkingRuleId': 8,
-                'status': 'NEW',
-              },
-            },
-          ],
-        };
-
-        const linkSuggestionsResponseFromCentralTenant = {
-          fields: [
-            {
-              'tag': '100',
-              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-              'linkDetails': {
-                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
-                'authorityNaturalId': 'n2008001084',
-                'linkingRuleId': 1,
-                'status': 'NEW',
-              },
-            }, {
-              'tag': '600',
-              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'linkDetails': {
-                errorCause: '101',
-                status: 'ERROR',
-              },
-            },
-          ],
-        };
-
-        useLinkSuggestions.mockReturnValue({
-          fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValueOnce(linkSuggestionsResponse),
-        });
-
-        useLinkSuggestions.mockReturnValue({
-          fetchLinkSuggestions: mockFetchLinkSuggestions
-            .mockResolvedValueOnce(linkSuggestionsResponseFromCentralTenant),
-        });
-
-        const { result } = renderHook(() => useAuthorityLinking({ marcType: MARC_TYPES.BIB }), { wrapper });
-
-        const outcome = await result.current.autoLinkAuthority(formValues);
-
-        expect(useLinkSuggestions).toHaveBeenNthCalledWith(1, { tenantId: '' });
-        expect(useLinkSuggestions).toHaveBeenNthCalledWith(2, { tenantId: 'consortia' });
-        expect(mockFetchLinkSuggestions).toHaveBeenCalledTimes(2);
-
-        expect(outcome).toEqual(expect.objectContaining({
-          suggestedFields: [
-            {
-              'tag': '100',
-              'content': '$0 id.loc.gov/authorities/names/n2008001084 $a Coates, Ta-Nehisi $e author. $9 5d80ecfa-7370-460e-9e27-3883a7656fe1',
-              'linkDetails': {
-                'authorityId': '5d80ecfa-7370-460e-9e27-3883a7656fe1',
-                'authorityNaturalId': 'n2008001084',
-                'linkingRuleId': 1,
-                'status': 'NEW',
-              },
-            },
-            {
-              'tag': '600',
-              'content': '$a Brown, Benjamin, $v Comic books, strips, etc. $0 id.loc.gov/authorities/names/nr2005025774 $d 1966- $9 46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-              'linkDetails': {
-                'authorityId': '46b1a960-9ca2-43c1-b2b7-a7eafbc6c9d2',
-                'authorityNaturalId': 'nr2005025774',
-                'linkingRuleId': 8,
-                'status': 'NEW',
-              },
-            },
-          ],
-        }));
       });
     });
   });

--- a/test/jest/fixtures/linkingRules.js
+++ b/test/jest/fixtures/linkingRules.js
@@ -1,0 +1,36 @@
+export const linkingRules = {
+  linkingRules: [{
+    id: 1,
+    bibField: '100',
+    authorityField: '100',
+    authoritySubfields: ['a', 'b', 't', 'd'],
+    subfieldModifications: [],
+    validation: {},
+    autoLinkingEnabled: true,
+  }, {
+    id: 8,
+    bibField: '600',
+    authorityField: '100',
+    authoritySubfields: ['a', 'b', 'c', 'd', 'g', 'j', 'q', 'f', 'h', 'k', 'l', 'm', 'n', 'o', 'p', 'r', 's', 't'],
+    autoLinkingEnabled: true,
+  }, {
+    id: 12,
+    bibField: '650',
+    authorityField: '150',
+    authoritySubfields: ['a', 'b', 'g'],
+    autoLinkingEnabled: false,
+  }, {
+    id: 15,
+    bibField: '700',
+    authorityField: '100',
+    authoritySubfields: ['a', 'b', 'c', 'd', 'j', 'q', 'f', 'h', 'k', 'l', 'm', 'n', 'o', 'p', 'r', 's', 't', 'g'],
+    autoLinkingEnabled: true,
+  }, {
+    id: 17,
+    bibField: '711',
+    authorityField: '111',
+    authoritySubfields: ['a', 'c', 'e', 'q', 'f', 'h', 'k', 'l', 'p', 's', 't', 'd', 'g', 'n'],
+    autoLinkingEnabled: true,
+  }],
+  isLoading: false,
+};


### PR DESCRIPTION
## Description
Remove second call to links-suggestion endpoint.
`/link-suggestions` endpoint for member tenant now includes suggestions from central tenant as well, so wow only need to send one call
Cleaned up tests:
- grouped together tests by `useAuthorityLinking` functions
- removed tests for cases when linking bibs in member tenant that checks that central linking suggestions are included. This is no longer needed because that is now handle on back-end side it the hook doesn't care from which tenant the link is coming from

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/361e0b3b-c1c0-466c-abf0-a83a075595ea


## Issues
[UIQM-568](https://issues.folio.org/browse/UIQM-568)