### PR TITLE
UIQM-571  Added `marc-records-editor.item.put` to Create Bib permission to fix issue with broken links after creating a record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-quick-marc
 
+## [7.1.0] (IN PROGRESS)
+
+* [UIQM-571](https://issues.folio.org/browse/UIQM-571) Added `marc-records-editor.item.put` to Derive Bib permission to fix issue with broken links after deriving a record.
+
 ## [7.0.1](https://github.com/folio-org/ui-quick-marc/tree/v7.0.1) (2023-10-13)
 
 * Use correct version of `ui-plugin-find-authority`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [7.1.0] (IN PROGRESS)
 
-* [UIQM-571](https://issues.folio.org/browse/UIQM-571) Added `marc-records-editor.item.put` to Derive Bib permission to fix issue with broken links after deriving a record.
+* [UIQM-571](https://issues.folio.org/browse/UIQM-571) Added `marc-records-editor.item.put` to Derive and Create Bib permissions to fix issue with broken links after deriving or creating a record.
 
 ## [7.0.1](https://github.com/folio-org/ui-quick-marc/tree/v7.0.1) (2023-10-13)
 

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
         "subPermissions": [
           "ui-quick-marc.quick-marc-editor.view",
           "marc-records-editor.status.item.get",
+          "marc-records-editor.item.put",
           "marc-records-editor.item.post",
           "marc-records-editor.links.suggestion.post",
           "instance-authority-links.instances.collection.put",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "displayName": "quickMARC: Create a new MARC bibliographic record",
         "subPermissions": [
           "ui-quick-marc.quick-marc-editor.view",
+          "marc-records-editor.item.put",
           "marc-records-editor.item.post",
           "marc-records-editor.links.suggestion.post",
           "instance-authority-links.instances.collection.post",


### PR DESCRIPTION
## Description
Added `marc-records-editor.item.put` to Create Bib permission to fix issue with broken links after creating a record.

## Issues
[UIQM-571](https://issues.folio.org/browse/UIQM-571)