### PR TITLE
UIQM-571 Wait for PUT request to finish after deriving before redirecting to Inventory

### DIFF
--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -155,7 +155,7 @@ export const saveLinksToNewRecord = async (mutator, externalId, marcRecord) => {
   // request derived MARC Bib record
   const marcPromise = mutator.quickMarcEditMarcRecord.GET({ params: { externalId } });
 
-  Promise.all([instancePromise, marcPromise]).then(([{ _version }, derivedRecord]) => {
+  return Promise.all([instancePromise, marcPromise]).then(([{ _version }, derivedRecord]) => {
     // copy linking data to new record
     derivedRecord.fields = derivedRecord.fields.map((field) => {
       // matching field from POST request


### PR DESCRIPTION
## Description
Wait for PUT request to finish after deriving before redirecting to Inventory

`onClose('id')` was added in https://github.com/folio-org/ui-quick-marc/pull/583, but now we're removing `shared` parameter in `onClose` in ui-inventory, so the issue is not reproduced

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/b66b225f-0301-414f-bcf7-a887b9ddc419

## Issues
[UIQM-571](https://issues.folio.org/browse/UIQM-571)