### PR TITLE
UIQM-591  Show permission `quickMARC: Create a new MARC authority record`. Don't load locations when MARC type is not Holdings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UIQM-543](https://issues.folio.org/browse/UIQM-543) Remove eslint deps that are already listed in eslint-config-stripes.
 * [UIQM-573](https://issues.folio.org/browse/UIQM-573) Edit MARC authority | Allow user to Add/Edit 010 $a when linking is based on 001.
 * [UIQM-574](https://issues.folio.org/browse/UIQM-574) Added authority source file selection button and modal to Authority Create view.
+* [UIQM-591](https://issues.folio.org/browse/UIQM-591) Show permission `quickMARC: Create a new MARC authority record`. Don't load locations when MARC type is not Holdings.
 
 ## [7.0.4](https://github.com/folio-org/ui-quick-marc/tree/v7.0.4) (2023-11-09)
 

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -140,7 +140,10 @@ const QuickMarcEditorContainer = ({
         ...headers,
       });
 
-    const locationsPromise = mutator.locations.GET(headers);
+    const locationsPromise = marcType === MARC_TYPES.HOLDINGS
+      ? mutator.locations.GET(headers)
+      : Promise.resolve();
+
     // must be with the central tenant id when user derives shared record
     const linkingRulesPromise = mutator.linkingRules.GET(headers);
 


### PR DESCRIPTION
## Description
Don't load locations when MARC type is not Holdings.

## Issues
[UIQM-591](https://issues.folio.org/browse/UIQM-591)