### PR TITLE
UIQM-534 Remove fields that have no MARC tag and no subfield value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [UIQM-591](https://issues.folio.org/browse/UIQM-591) Show permission `quickMARC: Create a new MARC authority record`. Don't load locations when MARC type is not Holdings.
 * [UIQM-594](https://issues.folio.org/browse/UIQM-594) *BREAKING* Add authority-source-files interface.
 * [UIQM-522](https://issues.folio.org/browse/UIQM-522) Create/Derive a new MARC bib record & Create a MARC holdings | Default state of Save & close button should be disabled.
+* [UIQM-534](https://issues.folio.org/browse/UIQM-534) Remove fields that have no MARC tag and no subfield value.  
 
 ## [7.0.4](https://github.com/folio-org/ui-quick-marc/tree/v7.0.4) (2023-11-09)
 

--- a/src/QuickMarcEditor/constants.js
+++ b/src/QuickMarcEditor/constants.js
@@ -2,6 +2,8 @@ import { MARC_TYPES } from '../common/constants';
 
 export const LEADER_TAG = 'LDR';
 
+export const TAG_LENGTH = 3;
+
 export const LEADER_EDITABLE_BYTES = {
   [MARC_TYPES.BIB]: [5, 6, 7, 8, 17, 18, 19],
   [MARC_TYPES.HOLDINGS]: [5, 6, 17, 18],

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -37,6 +37,7 @@ import {
   CREATE_AUTHORITY_RECORD_DEFAULT_FIELD_TAGS,
   UNCONTROLLED_ALPHA,
   UNCONTROLLED_NUMBER,
+  TAG_LENGTH,
 } from './constants';
 import { RECORD_STATUS_NEW } from './QuickMarcRecordInfo/constants';
 import { SUBFIELD_TYPES } from './QuickMarcEditorRows/BytesField';
@@ -590,13 +591,15 @@ const checkIsEmptyContent = (field) => {
 export const validateRecordTag = marcRecords => {
   const nonEmptyRecords = marcRecords.filter(field => !checkIsEmptyContent(field));
 
-  if (nonEmptyRecords.some(({ tag }) => !tag || tag.length !== 3)) {
+  if (nonEmptyRecords.some(({ tag }) => !tag || tag.length !== TAG_LENGTH)) {
     return <FormattedMessage id="ui-quick-marc.record.error.tag.length" />;
   }
 
   const marcRecordsWithoutLDR = marcRecords.filter(record => record.tag !== LEADER_TAG);
 
-  if (marcRecordsWithoutLDR.some(({ tag }) => !tag.match(/^\d{0,3}$/))) {
+  const tagDigitsRegex = new RegExp(`^\\d{0,${TAG_LENGTH}}$`);
+
+  if (marcRecordsWithoutLDR.some(({ tag }) => !tag.match(tagDigitsRegex))) {
     return <FormattedMessage id="ui-quick-marc.record.error.tag.nonDigits" />;
   }
 

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -579,14 +579,24 @@ export const validateLocationSubfield = (field, locations) => {
   return !!locations.find(location => location.code === locationValue);
 };
 
+const checkIsEmptyContent = (field) => {
+  if (typeof field.content === 'string') {
+    return compact(field.content.split(' ')).every(content => /^\$[a-z0-9]?$/.test(content));
+  }
+
+  return false;
+};
+
 export const validateRecordTag = marcRecords => {
-  if (marcRecords.some(({ tag }) => !tag || tag.length !== 3)) {
+  const nonEmptyRecords = marcRecords.filter(field => !checkIsEmptyContent(field));
+
+  if (nonEmptyRecords.some(({ tag }) => !tag || tag.length !== 3)) {
     return <FormattedMessage id="ui-quick-marc.record.error.tag.length" />;
   }
 
   const marcRecordsWithoutLDR = marcRecords.filter(record => record.tag !== LEADER_TAG);
 
-  if (marcRecordsWithoutLDR.some(({ tag }) => !tag.match(/\d{3}/))) {
+  if (marcRecordsWithoutLDR.some(({ tag }) => !tag.match(/^\d{0,3}$/))) {
     return <FormattedMessage id="ui-quick-marc.record.error.tag.nonDigits" />;
   }
 
@@ -1098,14 +1108,6 @@ export const removeFieldsForDerive = (formValues) => {
     ...omit(formValues, 'updateInfo'),
     records: filteredRecords,
   };
-};
-
-const checkIsEmptyContent = (field) => {
-  if (typeof field.content === 'string') {
-    return compact(field.content.split(' ')).every(content => /^\$[a-z0-9]?$/.test(content));
-  }
-
-  return false;
 };
 
 export const autopopulateIndicators = (formValues) => {

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1302,10 +1302,25 @@ describe('QuickMarcEditor utils', () => {
       expect(utils.validateRecordTag(records)).not.toBeDefined();
     });
 
+    it('should not return error message when tag is valid (invalid length) and field content is empty', () => {
+      const records = [
+        {
+          tag: '10',
+          content: '$a ',
+        },
+        {
+          tag: '245',
+        },
+      ];
+
+      expect(utils.validateRecordTag(records)).not.toBeDefined();
+    });
+
     it('should return error message when tag is not valid (invalid length)', () => {
       const records = [
         {
           tag: '10',
+          content: '$a test',
         },
         {
           tag: '245',


### PR DESCRIPTION
## Description
Remove fields that have no MARC tag and no subfield value.

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/f9aa130c-8bc5-4ba6-86b6-16e15cd89324

## Issues
[UIQM-534](https://issues.folio.org/browse/UIQM-534)