### PR TITLE
UIQM-534 Delete saved fields that have empty tag and content (follow-up)

### DIFF
--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -660,8 +660,11 @@ export const isFieldLinked = (field) => Boolean(field.linkDetails?.linkingRuleId
 export const recordHasLinks = (fields) => fields.some(isFieldLinked);
 
 export const validateSubfield = (marcRecords) => {
-  const marcRecordsWithSubfields = marcRecords.filter(marcRecord => marcRecord.indicators);
-  const isEmptySubfield = marcRecordsWithSubfields.some(marcRecord => {
+  const recordsToValidate = marcRecords
+    .filter(marcRecord => Boolean(marcRecord.tag))
+    .filter(marcRecord => marcRecord.indicators);
+
+  const isEmptySubfield = recordsToValidate.some(marcRecord => {
     return !marcRecord.content && checkIsInitialRecord(marcRecord);
   });
 

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1467,13 +1467,32 @@ describe('QuickMarcEditor utils', () => {
       expect(utils.validateSubfield(records)).not.toBeDefined();
     });
 
+    it('should not return error message when tag is present and content is empty', () => {
+      const records = [
+        {
+          tag: '100',
+          content: '',
+          id: 'id1',
+        },
+        {
+          indicators: ['\\', '7'],
+          content: 'test',
+          id: 'id2',
+        },
+      ];
+
+      expect(utils.validateSubfield(records)).not.toBeDefined();
+    });
+
     it('should return error message when content is empty', () => {
       const records = [
         {
+          tag: '100',
           indicators: ['\\', '\\'],
           id: 'id1',
         },
         {
+          tag: '100',
           indicators: [undefined, undefined],
           id: 'id2',
         },


### PR DESCRIPTION
## Description
 Delete saved fields that have empty tag and content

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/4888e6ba-a46f-4270-89c8-07335abeea37

## Issues
[UIQM-534](https://issues.folio.org/browse/UIQM-534)