### PR TITLE
UIQM-595: During linking, take the authority subfields first and then the bib subfields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [UIQM-381](https://issues.folio.org/browse/UIQM-381) Create Orig Authority Record: Populate new record with default Leader values.
 * [UIQM-526](https://issues.folio.org/browse/UIQM-526) Refactor validation functionality.
 * [UIQM-597](https://issues.folio.org/browse/UIQM-597) Build initial values for the find-authority plugin using EXACT_PHRASE when there is '$0' value.
+* [UIQM-595](https://issues.folio.org/browse/UIQM-595) During linking, take the authority subfields first and then the bib subfields.
 
 ## [7.0.5](https://github.com/folio-org/ui-quick-marc/tree/v7.0.5) (2023-12-11)
 

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -126,7 +126,7 @@ describe('Given useAuthorityLinking', () => {
         };
 
         expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-          content: '$a authority value $b fakeB $0 some.url/n0001 $t field for modification $9 authority-id',
+          content: '$a authority value $b fakeB $t field for modification $0 some.url/n0001 $9 authority-id',
           linkDetails: {
             authorityId: 'authority-id',
             authorityNaturalId: 'n0001',
@@ -151,7 +151,7 @@ describe('Given useAuthorityLinking', () => {
         };
 
         expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-          content: '$a authority value $b fakeB $0 some.url/n0001 $9 authority-id $t field for modification',
+          content: '$a authority value $b fakeB $t field for modification $0 some.url/n0001 $9 authority-id',
           linkDetails: {
             authorityId: 'authority-id',
             authorityNaturalId: 'n0001',
@@ -176,7 +176,7 @@ describe('Given useAuthorityLinking', () => {
         };
 
         expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-          content: '$a authority value $b fakeB $0 some.url/n0001 $9 authority-id $t field for modification',
+          content: '$a authority value $b fakeB $t field for modification $0 some.url/n0001 $9 authority-id',
           linkDetails: {
             authorityId: 'authority-id',
             authorityNaturalId: 'n0001',
@@ -201,7 +201,7 @@ describe('Given useAuthorityLinking', () => {
         };
 
         expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-          content: '$a authority value $b fakeB $e author $e illustrator $0 some.url/n0001 $t field for modification $9 authority-id',
+          content: '$a authority value $b fakeB $t field for modification $e author $e illustrator $0 some.url/n0001 $9 authority-id',
           linkDetails: {
             authorityId: 'authority-id',
             authorityNaturalId: 'n0001',
@@ -244,13 +244,42 @@ describe('Given useAuthorityLinking', () => {
         };
 
         expect(result.current.linkAuthority(authority, authoritySource, field)).toMatchObject({
-          content: '$a authority value $b fakeB $e author $e illustrator $0 some.url/n0001 $c field for modification $9 authority-id',
+          content: '$a authority value $b fakeB $c field for modification $e author $e illustrator $0 some.url/n0001 $9 authority-id',
           linkDetails: {
             authorityId: 'authority-id',
             authorityNaturalId: 'n0001',
             linkingRuleId: 1,
           },
         });
+      });
+    });
+
+    it('should return authority subfields first and then bib subfields', () => {
+      const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+
+      const authority = {
+        id: 'authority-id',
+        sourceFileId: '1',
+        naturalId: 'n0001',
+      };
+      const field = {
+        tag: '600',
+        content: '$c (Fictitious character) $a Black Panther $2 fast $0 (OCoLC)fst02000849',
+      };
+      const _authoritySource = {
+        fields: [{
+          tag: '100',
+          content: '$a Black Panther $c (Fictitious character)',
+        }],
+      };
+
+      expect(result.current.linkAuthority(authority, _authoritySource, field)).toMatchObject({
+        content: '$a Black Panther $c (Fictitious character) $2 fast $0 some.url/n0001 $9 authority-id',
+        linkDetails: {
+          authorityId: 'authority-id',
+          authorityNaturalId: 'n0001',
+          linkingRuleId: 8,
+        },
       });
     });
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
During linking, take the authority subfields first and then the bib subfields.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-595](https://issues.folio.org/browse/UIQM-595)
## Screencast


https://github.com/folio-org/ui-quick-marc/assets/77053927/864286d7-60c8-4c78-863e-cb420f6e91f0



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
