### PR TITLE
UIQM-596 Fix http error handling when Editing/Creating/Deriving MARC records.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [UIQM-597](https://issues.folio.org/browse/UIQM-597) Build initial values for the find-authority plugin using EXACT_PHRASE when there is '$0' value.
 * [UIQM-595](https://issues.folio.org/browse/UIQM-595) During linking, take the authority subfields first and then the bib subfields.
 * [UIQM-555](https://issues.folio.org/browse/UIQM-555) Not change the pane header of the authority record while editing the 1xx field.
+* [UIQM-596](https://issues.folio.org/browse/UIQM-596) Fix http error handling when Editing/Creating/Deriving MARC records.
 
 ## [7.0.5](https://github.com/folio-org/ui-quick-marc/tree/v7.0.5) (2023-12-11)
 

--- a/src/queries/useMarcRecordMutation/useMarcRecordMutation.js
+++ b/src/queries/useMarcRecordMutation/useMarcRecordMutation.js
@@ -9,6 +9,10 @@ const useMarcRecordMutation = ({ tenantId } = {}) => {
 
   const { mutateAsync: updateMarcRecord, isLoading: isUpdating } = useMutation(body => {
     return ky.put(`${MARC_RECORD_API}/${body.parsedRecordId}`, { json: body });
+  }, {
+    onError: (error) => {
+      throw error.response;
+    },
   });
 
   return {

--- a/src/queries/useMarcRecordMutation/useMarcRecordMutation.test.js
+++ b/src/queries/useMarcRecordMutation/useMarcRecordMutation.test.js
@@ -46,4 +46,19 @@ describe('Given useMarcRecordMutation', () => {
 
     expect(mockPut).toHaveBeenCalledWith(`${MARC_RECORD_API}/${body.parsedRecordId}`, { json: body });
   });
+
+  describe('when there is an error', () => {
+    it('should throw a http response', async () => {
+      const response = { json: jest.fn() };
+
+      ky.put.mockRejectedValueOnce({
+        code: 409,
+        response,
+      });
+
+      const { result } = renderHook(() => useMarcRecordMutation(), { wrapper });
+
+      expect(() => result.current.updateMarcRecord(body)).rejects.toEqual(response);
+    });
+  });
 });


### PR DESCRIPTION
## Description
By default, `useMutation` catches an error from `ky` which has format `{ response: { ... } }`. But quickMARC error parsing code needs the `response` object.
The fix is to override default error handling and throw `error.response` instead

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/e89c5671-9cb1-47a1-b4f8-575c307276f2

## Issues
[UIQM-596](https://issues.folio.org/browse/UIQM-596)