### PR TITLE
UIQM-620 Added common validation rules for creating authority records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * [UIQM-576](https://issues.folio.org/browse/UIQM-576) Generate 001 per selected authority file configuration.
 * [UIQM-598](https://issues.folio.org/browse/UIQM-598) *BREAKING* Added onSave prop to handle saving records separately.
 * [UIQM-577](https://issues.folio.org/browse/UIQM-577) Validate the 010 record when creating an authority record.
-* [UIQM-620](https://issues.folio.org/browse/UIQM-620) Fix missing validation when creating Authority records.
+* [UIQM-620](https://issues.folio.org/browse/UIQM-620) Validate the creation of authority records with base authority record validation rules.
 
 ## [7.0.5](https://github.com/folio-org/ui-quick-marc/tree/v7.0.5) (2023-12-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [UIQM-576](https://issues.folio.org/browse/UIQM-576) Generate 001 per selected authority file configuration.
 * [UIQM-598](https://issues.folio.org/browse/UIQM-598) *BREAKING* Added onSave prop to handle saving records separately.
 * [UIQM-577](https://issues.folio.org/browse/UIQM-577) Validate the 010 record when creating an authority record.
+* [UIQM-620](https://issues.folio.org/browse/UIQM-620) Fix missing validation when creating Authority records.
 
 ## [7.0.5](https://github.com/folio-org/ui-quick-marc/tree/v7.0.5) (2023-12-11)
 

--- a/src/hooks/useValidation/rules.js
+++ b/src/hooks/useValidation/rules.js
@@ -246,6 +246,7 @@ const BASE_AUTHORITY_VALIDATORS = [
 ];
 
 const CREATE_AUTHORITY_VALIDATORS = [
+  ...BASE_AUTHORITY_VALIDATORS,
   {
     tag: '010',
     validator: RULES.EXISTS,


### PR DESCRIPTION
## Description
- Added common rules to create authority records ruleset
- Updated tests to also test Create and Derive actions.
  Many rules are the same for different quick marc action types (create/edit/derive), but initially tests only checked with edit.
  To test all actions I added functions like `testBaseBibValidation` that return `describe` statements. This allow us to test the same cases with the same data, but 1 different parameter - quick marc action

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/a6e78107-d3b2-41b4-8b6e-a363aa34f7d3



## Issues
[UIQM-620](https://issues.folio.org/browse/UIQM-620)