### PR TITLE
UIQM-606 Fetch only selectable source files for source file lookup modal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [UIQM-576](https://issues.folio.org/browse/UIQM-576) Generate 001 per selected authority file configuration.
 * [UIQM-598](https://issues.folio.org/browse/UIQM-598) *BREAKING* Added onSave prop to handle saving records separately.
 * [UIQM-577](https://issues.folio.org/browse/UIQM-577) Validate the 010 record when creating an authority record.
+* [UIQM-606](https://issues.folio.org/browse/UIQM-606) Fetch only selectable source files for source file lookup modal.
 
 ## [7.0.5](https://github.com/folio-org/ui-quick-marc/tree/v7.0.5) (2023-12-11)
 

--- a/src/QuickMarcEditor/SourceFileLookup/SourceFileLookup.js
+++ b/src/QuickMarcEditor/SourceFileLookup/SourceFileLookup.js
@@ -6,7 +6,6 @@ import {
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { useStripes } from '@folio/stripes/core';
 import { Button } from '@folio/stripes/components';
 
 import { useAuthoritySourceFiles } from '../../queries';
@@ -21,12 +20,10 @@ const SourceFileLookup = ({
   disabled,
   onSourceFileSelect,
 }) => {
-  const stripes = useStripes();
   const intl = useIntl();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const tenantId = stripes.hasInterface('consortia') ? stripes.user.user?.consortium?.centralTenantId : null;
-  const { sourceFiles } = useAuthoritySourceFiles({ tenantId });
+  const { sourceFiles } = useAuthoritySourceFiles({ searchParams: { selectable: true } });
 
   const openModal = useCallback(() => setIsModalOpen(true), [setIsModalOpen]);
   const closeModal = useCallback(() => setIsModalOpen(false), [setIsModalOpen]);

--- a/src/QuickMarcEditor/SourceFileLookup/SourceFileLookup.test.js
+++ b/src/QuickMarcEditor/SourceFileLookup/SourceFileLookup.test.js
@@ -59,6 +59,14 @@ describe('Given SourceFileLookup', () => {
     await waitFor(() => expect(getByText('SourceFileLookupModal')).toBeDefined());
   });
 
+  it('should only fetch selectable source files', () => {
+    const { getByRole } = renderSourceFileLookup();
+
+    fireEvent.click(getByRole('button', { name: 'ui-quick-marc.sourceFileLookup' }));
+
+    expect(useAuthoritySourceFiles).toHaveBeenCalledWith({ searchParams: { selectable: true } });
+  });
+
   describe('when confirming source file selection in modal', () => {
     it('should call onSourceFileSelect callback with correct source file', async () => {
       const {

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -49,7 +49,7 @@ const useAuthorityLinking = ({ tenantId, marcType, action } = {}) => {
     && action === QUICK_MARC_ACTIONS.EDIT;
 
   // tenantId for linking functionality must be with the member tenant id when user derives shared record
-  const _tenantId = tenantId || (isCentralTenantInHeaders && centralTenantId) || '';
+  const _tenantId = tenantId || (isCentralTenantInHeaders && centralTenantId) || null;
 
   const { sourceFiles } = useAuthoritySourceFiles({ tenantId: _tenantId });
   const { linkingRules } = useAuthorityLinkingRules({ tenantId: _tenantId });

--- a/src/queries/useAuthoritySourceFiles/useAuthoritySourceFiles.js
+++ b/src/queries/useAuthoritySourceFiles/useAuthoritySourceFiles.js
@@ -2,18 +2,24 @@ import { useQuery } from 'react-query';
 
 import {
   useNamespace,
+  useOkapiKy,
 } from '@folio/stripes/core';
 
-import { useTenantKy } from '../../temp';
-
-const useAuthoritySourceFiles = ({ tenantId } = {}) => {
-  const ky = useTenantKy({ tenantId });
+const useAuthoritySourceFiles = ({ searchParams, tenantId } = {}) => {
+  const ky = useOkapiKy({ tenant: tenantId });
   const [namespace] = useNamespace({ key: 'authority-source-files' });
 
+  const queryString = new URLSearchParams(searchParams).toString();
+
+  const _searchParams = {
+    limit: 100,
+    query: queryString,
+  };
+
   const { isFetching, data } = useQuery(
-    [namespace, tenantId],
+    [namespace, tenantId, queryString],
     async () => {
-      return ky.get('authority-source-files?limit=100').json();
+      return ky.get('authority-source-files', { searchParams: _searchParams }).json();
     },
   );
 

--- a/src/queries/useAuthoritySourceFiles/useAuthoritySourceFiles.test.js
+++ b/src/queries/useAuthoritySourceFiles/useAuthoritySourceFiles.test.js
@@ -31,6 +31,7 @@ describe('Given useAuthoritySourceFiles', () => {
   }));
 
   beforeEach(() => {
+    jest.clearAllMocks();
     useOkapiKy.mockClear().mockReturnValue({
       get: mockGet,
     });
@@ -42,5 +43,17 @@ describe('Given useAuthoritySourceFiles', () => {
     await act(async () => !result.current.isLoading);
 
     expect(mockGet).toHaveBeenCalled();
+  });
+
+  describe('when passing search parameters', () => {
+    it('should include them in the url', async () => {
+      const searchParams = { selectable: true };
+
+      const { result } = renderHook(() => useAuthoritySourceFiles({ searchParams }), { wrapper });
+
+      await act(async () => !result.current.isLoading);
+
+      expect(mockGet).toHaveBeenCalledWith('authority-source-files', { searchParams: { limit: 100, query: 'selectable=true' } });
+    });
   });
 });


### PR DESCRIPTION
## Description
Pass `selectable` as a search parameter to source files call
Fetch source files for linking from current tenant because the data is now propagated from central to member tenants

## Screenshots


https://github.com/folio-org/ui-quick-marc/assets/19309423/bb0dc524-0f50-4fcf-a4c4-30aaeb30d2f2


## Issues
[UIQM-606](https://issues.folio.org/browse/UIQM-606)