### PR TITLE
UIQM-625 Use `null` instead of empty string as an empty tenantId value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [UIQM-606](https://issues.folio.org/browse/UIQM-606) Fetch only selectable source files for source file lookup modal.
 * [UIQM-620](https://issues.folio.org/browse/UIQM-620) Validate the creation of authority records with base authority record validation rules.
 * [UIQM-607](https://issues.folio.org/browse/UIQM-607) Wait for a redirect in the onSubmit function after creating a record.
+* [UIQM-625](https://issues.folio.org/browse/UIQM-625) Use `null` instead of empty string as an empty tenantId value.
 
 ## [7.0.5](https://github.com/folio-org/ui-quick-marc/tree/v7.0.5) (2023-12-11)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
@@ -77,7 +77,7 @@ const LinkButton = ({
 
   let showSharedFilter = false;
   let showSharedRecordsOnly = false;
-  let pluginTenantId = '';
+  let pluginTenantId = null;
 
   if (checkIfUserInCentralTenant(stripes)) {
     if ([QUICK_MARC_ACTIONS.CREATE, QUICK_MARC_ACTIONS.EDIT, QUICK_MARC_ACTIONS.DERIVE].includes(action)) {

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.test.js
@@ -347,7 +347,7 @@ describe('Given LinkButton', () => {
       });
 
       expect(Pluggable).toHaveBeenLastCalledWith(expect.objectContaining({
-        tenantId: '',
+        tenantId: null,
         initialValues,
         excludedFilters,
       }), {});
@@ -385,7 +385,7 @@ describe('Given LinkButton', () => {
     });
 
     expect(Pluggable).toHaveBeenLastCalledWith(expect.objectContaining({
-      tenantId: '',
+      tenantId: null,
       initialValues,
       excludedFilters,
     }), {});
@@ -420,7 +420,7 @@ describe('Given LinkButton', () => {
     renderComponent({ action });
 
     expect(Pluggable).toHaveBeenLastCalledWith(expect.objectContaining({
-      tenantId: '',
+      tenantId: null,
       initialValues,
       excludedFilters,
     }), {});


### PR DESCRIPTION
## Description
`useOkapiKy` uses `??` operator instead of `||`, so an empty value needs to be null for default tenant id to be applied

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/a0cf8fcc-6cfd-4815-b480-903b4f8f1d9b



## Issues
[UIQM-625](https://folio-org.atlassian.net/browse/UIQM-625)