### PR TITLE
UIQM-639: Use the '$' sign instead of '{dollar}' for search input and search query during manual linking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [UIQM-471](https://issues.folio.org/browse/UIQM-471) Added Dropdowns for fixed field 008 bib records.
 * [UIQM-610](https://issues.folio.org/browse/UIQM-610) Split LDR by position & add dropdowns for create/edit/derive.
 * [UIQM-611](https://issues.folio.org/browse/UIQM-611) Add tooltips for LDR positions.
+* [UIQM-611](https://issues.folio.org/browse/UIQM-639) Use the `$` sign instead of `{dollar}` for search input and search query during manual linking.
 
 ## [7.0.5](https://github.com/folio-org/ui-quick-marc/tree/v7.0.5) (2023-12-11)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
@@ -165,7 +165,12 @@ const LinkButton = ({
       segment: initialSegment,
     };
 
-    const fieldContent = getContentSubfieldValue(content);
+    const fieldContent = Object.entries(getContentSubfieldValue(content))
+      .reduce((acc, [subfield, subfieldContent]) => {
+        acc[subfield] = subfieldContent.map(value => value.replaceAll('{dollar}', '$'));
+
+        return acc;
+      }, {});
 
     if (fieldContent.$0?.length) {
       const keywordValue = [fieldContent.$a, fieldContent.$d, fieldContent.$t].flat().filter(Boolean).join(' ');

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
@@ -165,6 +165,9 @@ const LinkButton = ({
       segment: initialSegment,
     };
 
+    // To get the desired search result, the search query must contain `$` instead of `{dollar}`.
+    // BE returns `{dollar}` because the field content already uses the `$` sign and there is no way
+    // to distinguish whether `$` is the start of the subfield or just some value in the subfield.
     const fieldContent = Object.entries(getContentSubfieldValue(content))
       .reduce((acc, [subfield, subfieldContent]) => {
         acc[subfield] = subfieldContent.map(value => value.replaceAll('{dollar}', '$'));

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.test.js
@@ -122,6 +122,36 @@ describe('Given LinkButton', () => {
       });
     });
 
+    describe('when linking Authority and field content contains "{dollar}"', () => {
+      it('should be replaced with $ sign for search input and search query', () => {
+        const { getAllByTestId } = renderComponent({
+          content: '$a {dollar}{dollar}{dollar} 50.00{dollar} $d currency ({dollar}) $0 n123456789 $t test{dollar}',
+        });
+
+        const searchInputValue = `keyword ${EXACT_PHRASE} $$$ 50.00$ currency ($) test$ or identifiers.value ${EXACT_PHRASE} n123456789`;
+
+        const initialValues = {
+          search: {
+            dropdownValue: 'advancedSearch',
+            searchIndex: 'advancedSearch',
+            searchInputValue,
+            searchQuery: searchInputValue,
+            filters: null,
+          },
+          browse: {
+            dropdownValue: 'personalNameTitle',
+            searchIndex: 'personalNameTitle',
+            filters: null,
+          },
+          segment: 'search',
+        };
+
+        fireEvent.click(getAllByTestId('link-authority-button-fakeId')[0]);
+
+        expect(Pluggable).toHaveBeenLastCalledWith(expect.objectContaining({ initialValues }), {});
+      });
+    });
+
     describe('when linking Authority to a field with $0', () => {
       it('should pass initial values to plugin', async () => {
         const { getAllByTestId } = renderComponent({


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Use the `$` sign instead of `{dollar}` for search input and search query during manual linking.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-639](https://folio-org.atlassian.net/browse/UIQM-639)

## Screencast



https://github.com/folio-org/ui-quick-marc/assets/77053927/c93d1692-d454-4353-8b89-0ed2ed6aa200




## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
