### PR TITLE
UIQM-649 Allow users to delete 010 fields when Authority record is not linked (follow-up)

### DIFF
--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -192,7 +192,7 @@ const QuickMarcEditor = ({
 
       if (
         is010$aUpdated(initialValues.records, records) &&
-        is010LinkedToBibRecord(initialValues.records, instance.naturalId)
+        is010LinkedToBibRecord(initialValues.records, instance.naturalId, linksCount)
       ) {
         setIsUpdate0101xxfieldsAuthRecModalOpen(true);
 

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -89,7 +89,11 @@ export const getContentSubfieldValue = (content = '') => {
     }, {});
 };
 
-export const is010LinkedToBibRecord = (initialRecords, naturalId) => {
+export const is010LinkedToBibRecord = (initialRecords, naturalId, linksCount) => {
+  if (!linksCount) {
+    return false;
+  }
+
   const initial010Field = initialRecords.find(record => record.tag === '010');
 
   if (!initial010Field) {
@@ -1089,7 +1093,7 @@ export const hasDeleteException = (recordRow, marcType = MARC_TYPES.BIB, authori
   if (marcType === MARC_TYPES.AUTHORITY) {
     if (
       is1XXField(recordRow.tag) ||
-      (recordRow.tag === '010' && linksCount && is010LinkedToBibRecord(initialValues.records, authority.naturalId))
+      (recordRow.tag === '010' && is010LinkedToBibRecord(initialValues.records, authority.naturalId, linksCount))
     ) {
       return true;
     }

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1618,4 +1618,58 @@ describe('QuickMarcEditor utils', () => {
       });
     });
   });
+
+  describe('is010LinkedToBibRecord', () => {
+    describe('when links count is 0', () => {
+      it('should return false', () => {
+        const initialRecords = [{
+          tag: '010',
+          content: '$a n 123456',
+        }];
+        const naturalId = 'n123456';
+        const linksCount = 0;
+
+        expect(utils.is010LinkedToBibRecord(initialRecords, naturalId, linksCount)).toEqual(false);
+      });
+    });
+
+    describe('when 010 field is missing', () => {
+      it('should return false', () => {
+        const initialRecords = [{
+          tag: '011',
+          content: '$a n 123456',
+        }];
+        const naturalId = 'n123456';
+        const linksCount = 1;
+
+        expect(utils.is010LinkedToBibRecord(initialRecords, naturalId, linksCount)).toEqual(false);
+      });
+    });
+
+    describe('when 010$a does not match naturalId', () => {
+      it('should return false', () => {
+        const initialRecords = [{
+          tag: '010',
+          content: '$a n 123456',
+        }];
+        const naturalId = 'n123456789';
+        const linksCount = 1;
+
+        expect(utils.is010LinkedToBibRecord(initialRecords, naturalId, linksCount)).toEqual(false);
+      });
+    });
+
+    describe('when 010$a matches naturalId', () => {
+      it('should return true', () => {
+        const initialRecords = [{
+          tag: '010',
+          content: '$a n 123456',
+        }];
+        const naturalId = 'n123456';
+        const linksCount = 1;
+
+        expect(utils.is010LinkedToBibRecord(initialRecords, naturalId, linksCount)).toEqual(true);
+      });
+    });
+  });
 });

--- a/src/hooks/useValidation/rules.js
+++ b/src/hooks/useValidation/rules.js
@@ -200,13 +200,17 @@ const BASE_AUTHORITY_VALIDATORS = [
   {
     tag: '010',
     subfield: '$a',
-    ignore: ({ initialValues, naturalId }) => !is010LinkedToBibRecord(initialValues.records, naturalId),
+    ignore: ({ linksCount, initialValues, naturalId }) => {
+      return !is010LinkedToBibRecord(initialValues.records, naturalId, linksCount);
+    },
     validator: RULES.SUBFIELD_VALUE_EXISTS,
     message: () => <FormattedMessage id="ui-quick-marc.record.error.010.$aRemoved" />,
   },
   {
     tag: '010',
-    ignore: ({ initialValues, naturalId }) => !is010LinkedToBibRecord(initialValues.records, naturalId),
+    ignore: ({ linksCount, initialValues, naturalId }) => {
+      return !is010LinkedToBibRecord(initialValues.records, naturalId, linksCount);
+    },
     validator: RULES.EXISTS,
     message: () => <FormattedMessage id="ui-quick-marc.record.error.010.removed" />,
   },

--- a/src/hooks/useValidation/useValidation.test.js
+++ b/src/hooks/useValidation/useValidation.test.js
@@ -1446,6 +1446,70 @@ describe('useValidation', () => {
           });
         });
       });
+
+      describe('when authority is not linked to bib record', () => {
+        describe('when 010 $a was removed', () => {
+          it('should not return an error message', () => {
+            const _initialValues = {
+              leader: initialValues.leader,
+              records: [
+                {
+                  id: 1,
+                  content: initialValues.leader,
+                  tag: 'LDR',
+                },
+                {
+                  id: 2,
+                  content: {},
+                  tag: '008',
+                },
+                {
+                  id: 3,
+                  tag: '110',
+                  content: '$a Record title',
+                },
+                {
+                  id: 4,
+                  tag: '010',
+                  content: '$a n123456',
+                },
+              ],
+            };
+            const { result } = renderHook(() => useValidation({
+              ...marcContext,
+              linksCount: 0,
+              initialValues: _initialValues,
+            }));
+
+            const record = {
+              ...initialValues,
+              records: [
+                {
+                  id: 'LDR',
+                  content: initialValues.leader,
+                  tag: 'LDR',
+                },
+                {
+                  id: 1,
+                  content: {},
+                  tag: '008',
+                },
+                {
+                  id: 2,
+                  content: '$a',
+                  tag: '010',
+                },
+                {
+                  id: 3,
+                  tag: '110',
+                },
+              ],
+            };
+
+            expect(result.current.validate(record.records)).not.toBeDefined();
+          });
+        });
+      });
     });
 
     describe('when action is CREATE', () => {


### PR DESCRIPTION
## Description
Allow users to delete 010 fields when Authority record is not linked

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/3f4b6f9c-7ab6-49ff-9975-9fa047bac7d0

## Issues
[UIQM-649](https://folio-org.atlassian.net/browse/UIQM-649)