### PR TITLE
UIQM-660 *BREAKING* Added `stripes-inventory-components` to peerDeps. Added inventory search link next to 010 fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change history for ui-quick-marc
 
-## [8.1.0] IN PROGRESS
+## [9.0.0] IN PROGRESS
 
 * [UIQM-647](https://issues.folio.org/browse/UIQM-647) Import `useUserTenantPermissions` from `@folio/stripes/core`.
 * [UIQM-563](https://issues.folio.org/browse/UIQM-563) Allow a user to move 00X fields.
 * [UIQM-563](https://issues.folio.org/browse/UIQM-655) Add a `required` property to `Select` type fields for screen readers.
 * [UIQM-648](https://issues.folio.org/browse/UIQM-648) Add `aria-label` to the location field.
+* [UIQM-660](https://issues.folio.org/browse/UIQM-660) *BREAKING* Added `stripes-inventory-components` to peerDeps. Added inventory search link next to 010 fields.
 
 ## [8.0.1] (https://github.com/folio-org/ui-quick-marc/tree/v8.0.1) (2024-04-18)
 

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "@folio/stripes-cli": "^3.0.0",
     "@folio/stripes-core": "^10.0.0",
     "@folio/stripes-marc-components": "^1.0.0",
+    "@folio/stripes-inventory-components": "^1.0.0",
     "@folio/stripes-testing": "^4.2.0",
     "@formatjs/cli": "^6.1.3",
     "core-js": "^3.6.1",
@@ -191,6 +192,7 @@
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",
     "@folio/stripes-marc-components": "^1.0.0",
+    "@folio/stripes-inventory-components": "^1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/quick-marc",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "Quick MARC editor",
   "main": "index.js",
   "repository": "",

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.test.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import { createMemoryHistory } from 'history';
+
 import {
   act,
   fireEvent,
   render,
 } from '@folio/jest-config-stripes/testing-library/react';
-
 import {
   checkIfUserInMemberTenant,
   checkIfUserInCentralTenant,
@@ -14,7 +15,6 @@ import {
 import { ADVANCED_SEARCH_MATCH_OPTIONS } from '@folio/stripes/components';
 import { runAxeTest } from '@folio/stripes-testing';
 
-import { createMemoryHistory } from 'history';
 import { LinkButton } from './LinkButton';
 import { QUICK_MARC_ACTIONS } from '../../constants';
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -36,6 +36,7 @@ import { DeletedRowPlaceholder } from './DeletedRowPlaceholder';
 import { LinkButton } from './LinkButton';
 import { SplitField } from './SplitField';
 import { ControlNumberField } from './ControlNumberField';
+import { SearchLink } from './SearchLink';
 import {
   hasIndicatorException,
   hasAddException,
@@ -305,6 +306,7 @@ const QuickMarcEditorRows = ({
             const canBeLinkedAuto = isRecordForAutoLinking(recordRow, autoLinkableBibFields);
 
             const canViewAuthorityRecord = stripes.hasPerm('ui-marc-authorities.authority-record.view') && recordRow._isLinked;
+            const canSearchInInventory = [MARC_TYPES.AUTHORITY, MARC_TYPES.BIB].includes(marcType) && recordRow.tag === '010';
 
             return (
               <div
@@ -536,6 +538,9 @@ const QuickMarcEditorRows = ({
                 </div>
 
                 <div className={styles.quickMarcEditorRightSide}>
+                  {canSearchInInventory && (
+                    <SearchLink field={recordRow} />
+                  )}
                   {isMARCFieldProtections && isProtectedField && (
                     <span data-testid="quick-marc-protected-field-popover">
                       <InfoPopover

--- a/src/QuickMarcEditor/QuickMarcEditorRows/SearchLink/SearchLink.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/SearchLink/SearchLink.js
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types';
+import flatten from 'lodash/flatten';
+
+import { IconButton } from '@folio/stripes/components';
+import { advancedSearchQueryBuilder } from '@folio/stripes-inventory-components';
+
+import { getContentSubfieldValue } from '../../utils';
+
+const propTypes = {
+  field: PropTypes.shape({
+    content: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+const SearchLink = ({ field }) => {
+  const content = getContentSubfieldValue(field.content);
+
+  const numberOfAdvancedSearchRows = 6;
+  // we search by field's $a and $z values
+  const valuesToSearchBy = flatten([content.$a, content.$z]).slice(0, numberOfAdvancedSearchRows);
+
+  const advancedSearchRows = valuesToSearchBy.filter(value => Boolean(value)).map(value => ({
+    bool: 'or',
+    query: value,
+    match: 'exactPhrase',
+    searchOption: 'lccn',
+  }));
+
+  const builtQuery = advancedSearchQueryBuilder(advancedSearchRows);
+
+  const searchParams = new URLSearchParams({
+    qindex: 'advancedSearch',
+    query: builtQuery,
+  });
+
+  const link = `/inventory?${searchParams.toString()}`;
+
+  return (
+    <IconButton
+      icon="search"
+      to={link}
+      target="_blank"
+    />
+  );
+};
+
+SearchLink.propTypes = propTypes;
+
+export { SearchLink };

--- a/src/QuickMarcEditor/QuickMarcEditorRows/SearchLink/SearchLink.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/SearchLink/SearchLink.js
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types';
 import flatten from 'lodash/flatten';
 
 import { IconButton } from '@folio/stripes/components';
-import { advancedSearchQueryBuilder } from '@folio/stripes-inventory-components';
+import {
+  ADVANCED_SEARCH_INDEX,
+  advancedSearchQueryBuilder,
+} from '@folio/stripes-inventory-components';
 
 import { getContentSubfieldValue } from '../../utils';
 
@@ -29,7 +32,7 @@ const SearchLink = ({ field }) => {
   const builtQuery = advancedSearchQueryBuilder(advancedSearchRows);
 
   const searchParams = new URLSearchParams({
-    qindex: 'advancedSearch',
+    qindex: ADVANCED_SEARCH_INDEX,
     query: builtQuery,
   });
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/SearchLink/SearchLink.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/SearchLink/SearchLink.test.js
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { render } from '@folio/jest-config-stripes/testing-library/react';
+
+import { runAxeTest } from '@folio/stripes-testing';
+import { advancedSearchQueryBuilder } from '@folio/stripes-inventory-components';
+
+import { SearchLink } from './SearchLink';
+
+import Harness from '../../../../test/jest/helpers/harness';
+
+const renderComponent = (props = {}) => render(
+  <Harness history={props.history}>
+    <SearchLink
+      field={{
+        content: '$a some value',
+      }}
+      {...props}
+    />
+  </Harness>,
+);
+
+describe('Given SearchLink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with no axe errors', async () => {
+    const { container } = renderComponent();
+
+    await runAxeTest({
+      rootNode: container,
+    });
+  });
+
+  describe('when there is just one $a', () => {
+    it('should render a correct link with one $a value', () => {
+      const { getByRole } = renderComponent();
+
+      expect(getByRole('link').href).toContain('/inventory?qindex=advancedSearch&query=lccn+exactPhrase+some+value');
+    });
+  });
+
+  describe('when there is $a and $z', () => {
+    it('should render a correct link with $a and $z values', () => {
+      const { getByRole } = renderComponent({
+        field: {
+          content: '$a value a $z value z',
+        },
+      });
+
+      expect(getByRole('link').href).toContain('/inventory?qindex=advancedSearch&query=lccn+exactPhrase+value+a+or+lccn+exactPhrase+value+z');
+    });
+  });
+
+  describe('when there there are more than 6 $a or $z', () => {
+    it('should render a correct link with maximum 5 values', () => {
+      const { getByRole } = renderComponent({
+        field: {
+          content: '$a v1 $a v2 $a v3 $a v4 $z v5 $z v6 $z v7',
+        },
+      });
+
+      expect(getByRole('link').href).toContain('/inventory?qindex=advancedSearch&query=lccn+exactPhrase+v1+or+lccn+exactPhrase+v2+or+lccn+exactPhrase+v3+or+lccn+exactPhrase+v4+or+lccn+exactPhrase+v5+or+lccn+exactPhrase+v6');
+    });
+  });
+});

--- a/src/QuickMarcEditor/QuickMarcEditorRows/SearchLink/SearchLink.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/SearchLink/SearchLink.test.js
@@ -1,9 +1,7 @@
 import React from 'react';
 
 import { render } from '@folio/jest-config-stripes/testing-library/react';
-
 import { runAxeTest } from '@folio/stripes-testing';
-import { advancedSearchQueryBuilder } from '@folio/stripes-inventory-components';
 
 import { SearchLink } from './SearchLink';
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/SearchLink/index.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/SearchLink/index.js
@@ -1,0 +1,1 @@
+export * from './SearchLink';

--- a/test/jest/__mock__/stripesInventoryComponents.mock.js
+++ b/test/jest/__mock__/stripesInventoryComponents.mock.js
@@ -1,0 +1,3 @@
+jest.mock('@folio/stripes-inventory-components', () => ({
+  ...jest.requireActual('@folio/stripes-inventory-components'),
+}));


### PR DESCRIPTION
## Description
Added `stripes-inventory-components` to peerDeps.
Added inventory search link next to 010 fields. The link will open Inventory app in a new tab with advanced search by lccn with `010 $a/$z` as values

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/ca339f63-6676-4a62-a3aa-98279423b95a


## Issues
[UIQM-660](https://folio-org.atlassian.net/browse/UIQM-660)

## Related PRs
https://github.com/folio-org/ui-inventory/pull/2484
https://github.com/folio-org/stripes-inventory-components/pull/37