### PR TITLE
UIQM-661 Derive a new MARC bib record > Do not copy over 010 field values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UIQM-648](https://issues.folio.org/browse/UIQM-648) Add `aria-label` to the location field.
 * [UIQM-660](https://issues.folio.org/browse/UIQM-660) *BREAKING* Added `stripes-inventory-components` to peerDeps. Added inventory search link next to 010 fields.
 * [UIQM-671](https://issues.folio.org/browse/UIQM-671) Create/Derive a MARC bib/holdings/authority > Remove the add new field on the system generated 999 ff.
+* [UIQM-661](https://issues.folio.org/browse/UIQM-661) Derive a new MARC bib record > Do not copy over 010 field values.
 
 ## [8.0.1] (https://github.com/folio-org/ui-quick-marc/tree/v8.0.1) (2024-04-18)
 

--- a/src/QuickMarcEditor/constants.js
+++ b/src/QuickMarcEditor/constants.js
@@ -23,39 +23,65 @@ export const QUICK_MARC_ACTIONS = {
   DERIVE: 'derive',
 };
 
-export const FIELD_TAGS_TO_REMOVE = [
-  { tag: '001' },
-  { tag: '005' },
-  { tag: '019' },
-  { tag: '035' },
-  {
-    tag: '999',
-    indicators: ['f', 'f'],
-  },
-];
+export const FIELDS_TO_CLEAR_FOR_DERIVE = {
+  [MARC_TYPES.BIB]: [
+    { tag: '001' },
+    { tag: '005' },
+    { tag: '010' },
+    { tag: '019' },
+    { tag: '035' },
+    {
+      tag: '999',
+      indicators: ['f', 'f'],
+    },
+  ],
+  [MARC_TYPES.HOLDINGS]: [],
+  [MARC_TYPES.AUTHORITY]: [],
+};
 
 export const FIELDS_TAGS_WITHOUT_DEFAULT_SUBFIELDS = {
   [MARC_TYPES.BIB]: [
     { tag: LEADER_TAG },
-    ...FIELD_TAGS_TO_REMOVE,
+    { tag: '001' },
     { tag: '003' },
+    { tag: '005' },
     { tag: '006' },
     { tag: '007' },
     { tag: '008' },
+    { tag: '019' },
+    { tag: '035' },
+    {
+      tag: '999',
+      indicators: ['f', 'f'],
+    },
   ],
   [MARC_TYPES.HOLDINGS]: [
     { tag: LEADER_TAG },
-    ...FIELD_TAGS_TO_REMOVE,
+    { tag: '001' },
     { tag: '003' },
     { tag: '004' },
+    { tag: '005' },
     { tag: '006' },
     { tag: '007' },
     { tag: '008' },
+    { tag: '019' },
+    { tag: '035' },
+    {
+      tag: '999',
+      indicators: ['f', 'f'],
+    },
   ],
   [MARC_TYPES.AUTHORITY]: [
     { tag: LEADER_TAG },
-    ...FIELD_TAGS_TO_REMOVE,
+    { tag: '001' },
+    { tag: '005' },
     { tag: '008' },
+    { tag: '019' },
+    { tag: '035' },
+    {
+      tag: '999',
+      indicators: ['f', 'f'],
+    },
   ],
 };
 

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -16,7 +16,7 @@ import {
 
 import {
   LEADER_TAG,
-  FIELD_TAGS_TO_REMOVE,
+  FIELDS_TO_CLEAR_FOR_DERIVE,
   FIELDS_TAGS_WITHOUT_DEFAULT_SUBFIELDS,
   QUICK_MARC_ACTIONS,
   CREATE_HOLDINGS_RECORD_DEFAULT_FIELD_TAGS,
@@ -392,14 +392,6 @@ export const fieldMatchesDescription = (field, descriptionArray) => {
   return match;
 };
 
-const getEmptyContent = (field) => {
-  if (field.tag === '035' || field.tag === '019') {
-    return '$a';
-  }
-
-  return '';
-};
-
 export const removeDuplicateSystemGeneratedFields = (marcRecord) => {
   return {
     ...marcRecord,
@@ -413,10 +405,18 @@ export const removeDuplicateSystemGeneratedFields = (marcRecord) => {
   };
 };
 
-const removeMarcRecordFieldContentForDerive = marcRecord => {
+const getEmptyContent = (field) => {
+  if (['010', '019', '035'].includes(field.tag)) {
+    return '$a';
+  }
+
+  return '';
+};
+
+const removeMarcRecordFieldContentForDerive = (marcRecord, marcType) => {
   return {
     ...marcRecord,
-    records: marcRecord.records.map((field) => (fieldMatchesDescription(field, FIELD_TAGS_TO_REMOVE)
+    records: marcRecord.records.map((field) => (fieldMatchesDescription(field, FIELDS_TO_CLEAR_FOR_DERIVE[marcType])
       ? {
         ...field,
         content: getEmptyContent(field),
@@ -442,7 +442,7 @@ export const formatMarcRecordByQuickMarcAction = (marcRecord, action, marcType) 
   if (action === QUICK_MARC_ACTIONS.DERIVE) {
     return {
       ...flow(
-        removeMarcRecordFieldContentForDerive,
+        (formValues) => removeMarcRecordFieldContentForDerive(formValues, marcType),
         moveIdentifierFieldsAfterLeader,
       )(marcRecord),
       updateInfo: {

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -586,12 +586,16 @@ describe('QuickMarcEditor utils', () => {
           }],
         };
 
-        expect(utils.formatMarcRecordByQuickMarcAction(record, QUICK_MARC_ACTIONS.EDIT)).toEqual(record);
+        expect(utils.formatMarcRecordByQuickMarcAction(
+          record,
+          QUICK_MARC_ACTIONS.EDIT,
+          MARC_TYPES.BIB,
+        )).toEqual(record);
       });
     });
 
     describe('when action is "derive"', () => {
-      it('should return record without 001, 005 and 999ff fields content and no updateInfo', () => {
+      it('should return record without 001, 005, 010 and 999ff fields content and no updateInfo', () => {
         const record = {
           records: [{
             tag: LEADER_TAG,
@@ -601,6 +605,9 @@ describe('QuickMarcEditor utils', () => {
             content: 'some content',
           }, {
             tag: '005',
+            content: 'some content',
+          }, {
+            tag: '010',
             content: 'some content',
           }, {
             tag: '019',
@@ -633,6 +640,9 @@ describe('QuickMarcEditor utils', () => {
             tag: '005',
             content: '',
           }, {
+            tag: '010',
+            content: '$a',
+          }, {
             tag: '019',
             content: '$a',
           }, {
@@ -651,7 +661,11 @@ describe('QuickMarcEditor utils', () => {
           },
         };
 
-        expect(utils.formatMarcRecordByQuickMarcAction(record, QUICK_MARC_ACTIONS.DERIVE)).toEqual(expectedRecord);
+        expect(utils.formatMarcRecordByQuickMarcAction(
+          record,
+          QUICK_MARC_ACTIONS.DERIVE,
+          MARC_TYPES.BIB,
+        )).toEqual(expectedRecord);
       });
 
       it('should return record with Leader, 001 and 005 fields first', () => {
@@ -694,7 +708,11 @@ describe('QuickMarcEditor utils', () => {
           },
         };
 
-        expect(utils.formatMarcRecordByQuickMarcAction(record, QUICK_MARC_ACTIONS.DERIVE)).toEqual(expectedRecord);
+        expect(utils.formatMarcRecordByQuickMarcAction(
+          record,
+          QUICK_MARC_ACTIONS.DERIVE,
+          MARC_TYPES.BIB,
+        )).toEqual(expectedRecord);
       });
     });
 
@@ -738,8 +756,11 @@ describe('QuickMarcEditor utils', () => {
           },
         };
 
-        expect(utils.formatMarcRecordByQuickMarcAction(record, QUICK_MARC_ACTIONS.CREATE, MARC_TYPES.HOLDINGS))
-          .toEqual(expectedRecord);
+        expect(utils.formatMarcRecordByQuickMarcAction(
+          record,
+          QUICK_MARC_ACTIONS.CREATE,
+          MARC_TYPES.HOLDINGS,
+        )).toEqual(expectedRecord);
       });
     });
   });


### PR DESCRIPTION
## Description
When deriving a MARC Bib record 010 field content should be cleared

## Screenshots

https://github.com/folio-org/ui-quick-marc/assets/19309423/51569036-dd60-49b3-8acb-1e33542aeb9e



## Issues
[UIQM-661](https://folio-org.atlassian.net/browse/UIQM-661)