### PR TITLE
UIQM-670: Allow saving local control fields without subfield.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [UIQM-661](https://issues.folio.org/browse/UIQM-661) Derive a new MARC bib record > Do not copy over 010 field values.
 * [UIQM-666](https://issues.folio.org/browse/UIQM-666) Make leader positions `Type` and `BLvl` required when creating a bib record.
 * [UIQM-672](https://issues.folio.org/browse/UIQM-672) Add a tooltip for the search link.
+* [UIQM-670](https://issues.folio.org/browse/UIQM-670) Allow saving local control fields without subfield.
 
 ## [8.0.1] (https://github.com/folio-org/ui-quick-marc/tree/v8.0.1) (2024-04-18)
 

--- a/src/QuickMarcEditor/constants.js
+++ b/src/QuickMarcEditor/constants.js
@@ -43,11 +43,14 @@ export const FIELDS_TAGS_WITHOUT_DEFAULT_SUBFIELDS = {
   [MARC_TYPES.BIB]: [
     { tag: LEADER_TAG },
     { tag: '001' },
+    { tag: '002' },
     { tag: '003' },
+    { tag: '004' },
     { tag: '005' },
     { tag: '006' },
     { tag: '007' },
     { tag: '008' },
+    { tag: '009' },
     { tag: '019' },
     { tag: '035' },
     {
@@ -58,12 +61,14 @@ export const FIELDS_TAGS_WITHOUT_DEFAULT_SUBFIELDS = {
   [MARC_TYPES.HOLDINGS]: [
     { tag: LEADER_TAG },
     { tag: '001' },
+    { tag: '002' },
     { tag: '003' },
     { tag: '004' },
     { tag: '005' },
     { tag: '006' },
     { tag: '007' },
     { tag: '008' },
+    { tag: '009' },
     { tag: '019' },
     { tag: '035' },
     {
@@ -74,8 +79,11 @@ export const FIELDS_TAGS_WITHOUT_DEFAULT_SUBFIELDS = {
   [MARC_TYPES.AUTHORITY]: [
     { tag: LEADER_TAG },
     { tag: '001' },
+    { tag: '002' },
+    { tag: '004' },
     { tag: '005' },
     { tag: '008' },
+    { tag: '009' },
     { tag: '019' },
     { tag: '035' },
     {

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1150,6 +1150,106 @@ describe('QuickMarcEditor utils', () => {
 
       expect(utils.autopopulateSubfieldSection(record)).toEqual(expectedRecord);
     });
+
+    it('should allow saving local control fields of bib record without subfield', () => {
+      const record = {
+        records: [{
+          tag: '002',
+          content: 'some content',
+          id: 'id002',
+        }, {
+          tag: '004',
+          content: 'some content',
+          id: 'id004',
+        }, {
+          tag: '009',
+          content: 'some content',
+          id: 'id009',
+        }],
+      };
+
+      const expectedRecord = {
+        records: [{
+          tag: '002',
+          content: 'some content',
+          id: 'id002',
+        }, {
+          tag: '004',
+          content: 'some content',
+          id: 'id004',
+        }, {
+          tag: '009',
+          content: 'some content',
+          id: 'id009',
+        }],
+      };
+
+      expect(utils.autopopulateSubfieldSection(record, MARC_TYPES.BIB)).toEqual(expectedRecord);
+    });
+
+    it('should allow saving local control fields of authority record without subfield', () => {
+      const record = {
+        records: [{
+          tag: '002',
+          content: 'some content',
+          id: 'id002',
+        }, {
+          tag: '004',
+          content: 'some content',
+          id: 'id004',
+        }, {
+          tag: '009',
+          content: 'some content',
+          id: 'id009',
+        }],
+      };
+
+      const expectedRecord = {
+        records: [{
+          tag: '002',
+          content: 'some content',
+          id: 'id002',
+        }, {
+          tag: '004',
+          content: 'some content',
+          id: 'id004',
+        }, {
+          tag: '009',
+          content: 'some content',
+          id: 'id009',
+        }],
+      };
+
+      expect(utils.autopopulateSubfieldSection(record, MARC_TYPES.AUTHORITY)).toEqual(expectedRecord);
+    });
+
+    it('should allow saving local control fields of holdings record without subfield', () => {
+      const record = {
+        records: [{
+          tag: '002',
+          content: 'some content',
+          id: 'id002',
+        }, {
+          tag: '009',
+          content: 'some content',
+          id: 'id009',
+        }],
+      };
+
+      const expectedRecord = {
+        records: [{
+          tag: '002',
+          content: 'some content',
+          id: 'id002',
+        }, {
+          tag: '009',
+          content: 'some content',
+          id: 'id009',
+        }],
+      };
+
+      expect(utils.autopopulateSubfieldSection(record, MARC_TYPES.HOLDINGS)).toEqual(expectedRecord);
+    });
   });
 
   describe('cleanBytesFields', () => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Description
Fields 002, 004, 009 of the bib/authority record and fields 002, 009 of the holdings record are allowed to be saved without subfields.

## Issues
[UIQM-670](https://folio-org.atlassian.net/browse/UIQM-670)

## Screencast


https://github.com/user-attachments/assets/4a3ae397-74ec-440d-9c56-9af7af119868


## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
