### PR TITLE
UIQM-632: Run timer on submit during backend validation, if it takes over 2s, show modal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [UIQM-669](https://issues.folio.org/browse/UIQM-669) Display validation error messages inline.
 * [UIQM-658](https://issues.folio.org/browse/UIQM-658) Check for duplicate LCCN (010 $a) bib or authority records.
 * [UIQM-631](https://issues.folio.org/browse/UIQM-631) Create/Edit/Derive a MARC bib/authority/holdings record > Display MARC record validation errors inline.
+* [UIQM-631](https://issues.folio.org/browse/UIQM-632) Run timer on submit during backend validation, if it takes over 2s, show modal.
 
 ## [8.0.1] (https://github.com/folio-org/ui-quick-marc/tree/v8.0.1) (2024-04-18)
 

--- a/src/QuickMarcEditor/QuickMarcEditor.css
+++ b/src/QuickMarcEditor/QuickMarcEditor.css
@@ -1,3 +1,10 @@
 .saveContinueBtn {
   margin-right: 0.8rem;
 }
+
+.validationModalContent {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -50,7 +50,10 @@ import {
   useAuthorityLinking,
   useValidation,
 } from '../hooks';
-import { QUICK_MARC_ACTIONS } from './constants';
+import {
+  QUICK_MARC_ACTIONS,
+  VALIDATION_MODAL_DELAY,
+} from './constants';
 import {
   ERROR_TYPES,
   MARC_TYPES,
@@ -212,7 +215,7 @@ const QuickMarcEditor = ({
     let timerId;
 
     if (isBackEndValidationMarcType(marcType)) {
-      timerId = setTimeout(() => setIsValidationModalOpen(true), 2000);
+      timerId = setTimeout(() => setIsValidationModalOpen(true), VALIDATION_MODAL_DELAY);
     }
 
     return () => {

--- a/src/QuickMarcEditor/constants.js
+++ b/src/QuickMarcEditor/constants.js
@@ -143,3 +143,5 @@ export const AUTOLINKING_ERROR_CODES = {
 export const UNCONTROLLED_ALPHA = 'uncontrolledAlpha';
 export const UNCONTROLLED_NUMBER = 'uncontrolledNumber';
 export const UNCONTROLLED_SUBFIELDS = [UNCONTROLLED_ALPHA, UNCONTROLLED_NUMBER];
+
+export const VALIDATION_MODAL_DELAY = 2000;

--- a/src/hooks/useLccnDuplicationCheck/useLccnDuplicationCheck.js
+++ b/src/hooks/useLccnDuplicationCheck/useLccnDuplicationCheck.js
@@ -45,6 +45,10 @@ const useLccnDuplicationCheck = ({ marcType, id, action }) => {
       [MARC_TYPES.AUTHORITY]: () => ky.get(`search/authorities?limit=1&query=((${lccnQuery})${idQuery})`),
     };
 
+    const buildError = (messageId) => ({
+      [field010.id]: [{ id: messageId }],
+    });
+
     try {
       setIsLoading(true);
 
@@ -52,14 +56,10 @@ const useLccnDuplicationCheck = ({ marcType, id, action }) => {
       const isLccnDuplicated = records?.authorities?.[0] || records?.instances?.[0];
 
       if (isLccnDuplicated) {
-        return {
-          [field010.id]: { id: 'ui-quick-marc.record.error.010.lccnDuplicated' },
-        };
+        return buildError('ui-quick-marc.record.error.010.lccnDuplicated');
       }
     } catch (e) {
-      return {
-        [field010.id]: { id: 'ui-quick-marc.record.save.error.generic' },
-      };
+      return buildError('ui-quick-marc.record.error.generic');
     } finally {
       setIsLoading(false);
     }

--- a/src/hooks/useLccnDuplicationCheck/useLccnDuplicationCheck.test.js
+++ b/src/hooks/useLccnDuplicationCheck/useLccnDuplicationCheck.test.js
@@ -252,4 +252,39 @@ describe('useLccnDuplicationCheck', () => {
       });
     });
   });
+
+  describe('when request is rejected', () => {
+    it('should display the generic error', async () => {
+      const fieldId = 'field-id';
+      const marcRecords = [{
+        id: fieldId,
+        tag: '010',
+        content: '$a 123 $a 456 $z 789',
+      }];
+      const mockGet = jest.fn(() => ({
+        json: jest.fn().mockRejectedValue({}),
+      }));
+
+      useLccnDuplicateConfig.mockReturnValue({ duplicateLccnCheckingEnabled: true });
+
+      useOkapiKy.mockReturnValue({
+        get: mockGet,
+      });
+
+      const { result } = renderHook(useLccnDuplicationCheck, {
+        initialProps: {
+          marcType: MARC_TYPES.AUTHORITY,
+          action: QUICK_MARC_ACTIONS.CREATE,
+        },
+      });
+
+      const error = await act(() => result.current.validateLccnDuplication(marcRecords));
+
+      expect(error).toEqual({
+        [fieldId]: [{
+          id: 'ui-quick-marc.record.error.generic',
+        }],
+      });
+    });
+  });
 });

--- a/src/hooks/useValidation/useValidation.js
+++ b/src/hooks/useValidation/useValidation.js
@@ -90,10 +90,12 @@ const useValidation = (context) => {
     return formatBEValidationResponse(response, marcRecords);
   }, [context, validateFetch]);
 
+  const isBackEndValidationMarcType = useCallback(marcType => BE_VALIDATION_MARC_TYPES.includes(marcType), []);
+
   const validate = useCallback(async (marcRecords) => {
     let errors = {};
 
-    if (BE_VALIDATION_MARC_TYPES.includes(context.marcType)) {
+    if (isBackEndValidationMarcType(context.marcType)) {
       errors = await runBackEndValidation(marcRecords);
     } else {
       errors = runFrontEndValidation(marcRecords);
@@ -106,7 +108,14 @@ const useValidation = (context) => {
     quickMarcContext.setValidationErrors(joinedErrors);
 
     return joinedErrors;
-  }, [quickMarcContext, context, runFrontEndValidation, runBackEndValidation, validateLccnDuplication]);
+  }, [
+    quickMarcContext,
+    context,
+    runFrontEndValidation,
+    runBackEndValidation,
+    validateLccnDuplication,
+    isBackEndValidationMarcType,
+  ]);
 
   const hasIssuesBySeverity = (severity) => {
     return Object.values(quickMarcContext.validationErrorsRef.current)
@@ -118,6 +127,7 @@ const useValidation = (context) => {
     validate,
     hasErrorIssues: hasIssuesBySeverity(SEVERITY.ERROR),
     hasWarnIssues: hasIssuesBySeverity(SEVERITY.WARN),
+    isBackEndValidationMarcType,
   };
 };
 

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -707,6 +707,7 @@
 
   "record.errorMessage.error": "<b>Fail: </b>",
   "record.errorMessage.warn": "<b>Warn: </b>",
+  "record.error.generic": "Communication problem with server. Please try again.",
   "record.error.leader.length": "Record cannot be saved. The Leader must contain 24 characters, including null spaces.",
   "record.error.leader.forbiddenBytes.holdings": "Record cannot be saved. Please check the Leader. Only positions 5, 6, 17, 18 can be edited in the Leader.",
   "record.error.leader.forbiddenBytes.bibliographic": "Record cannot be saved. Please check the Leader. Only positions 5, 6, 7, 8, 17, 18 and/or 19 can be edited in the Leader.",
@@ -906,5 +907,8 @@
   "records.autoLink.notLinkedFields.multiple": "Field <b>{fieldTags}</b>{count, plural, one {} =2 { and <b>{lastFieldTag}</b>} other {, and <b>{lastFieldTag}</b>}} must be set manually by selecting the link icon. There are multiple authority records that can be matched to this bibliographic field.",
   "autoLinkingButton": "Link headings",
   "records.error.autoLinking": "Unable to link record(s) due to system error. Please try again or contact support.",
-  "record.searchLink": "Search for records by 010 value(s)"
+  "record.searchLink": "Search for records by 010 value(s)",
+
+  "validation.modal.heading": "MARC validation rules check",
+  "validation.modal.message": "There might be a slight delay while the system is checking against the library's validation rules. You can continue to work with Inventory in a different browser tab if needed."
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Display a modal window if backend validation takes over 2s. Hide it once the validation is over.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Description
To manage that modal the `manageBackendValidationModal` function is created with `setTimeout`.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Issues
[UIQM-632](https://folio-org.atlassian.net/browse/UIQM-632)

## Screenshots

https://github.com/user-attachments/assets/e606d0a6-d4f2-4627-bf73-d7a72248c42c





#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
