### PR TITLE
UIQM-631 Fix infinite loop when need to run confirmations (follow-up)

### DIFF
--- a/src/QuickMarcEditor/QuickMarcEditorRows/BytesField/BytesField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/BytesField/BytesField.js
@@ -15,10 +15,10 @@ import {
   Select,
 } from '@folio/stripes/components';
 
+import { ErrorMessages } from '../ErrorMessages';
 import { FIXED_FIELD_MAX_LENGTH } from '../../../common/constants';
 
 import styles from './BytesField.css';
-import { ErrorMessages } from '../ErrorMessages';
 
 export const SUBFIELD_TYPES = {
   BYTE: 'Byte',

--- a/src/QuickMarcEditor/QuickMarcEditorRows/ContentField/ContentField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/ContentField/ContentField.js
@@ -9,10 +9,8 @@ import {
   HasCommand,
 } from '@folio/stripes/components';
 
-import { useSubfieldNavigation } from '../../../hooks';
-import {
-  getResizeStyles,
-} from './utils';
+import { useSubfieldNavigation } from '../../../hooks/useSubfieldNavigation';
+import { getResizeStyles } from './utils';
 
 export const ContentField = ({
   input,

--- a/src/QuickMarcEditor/QuickMarcEditorRows/SplitField/SplitField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/SplitField/SplitField.js
@@ -10,15 +10,15 @@ import {
   HasCommand,
 } from '@folio/stripes/components';
 
+import { ErrorMessages } from '../ErrorMessages';
 import { QuickMarcContext } from '../../../contexts';
-import { useSubfieldNavigation } from '../../../hooks';
+import { useSubfieldNavigation } from '../../../hooks/useSubfieldNavigation';
 import {
   UNCONTROLLED_ALPHA,
   UNCONTROLLED_NUMBER,
 } from '../../constants';
 
 import css from './SplitField.css';
-import { ErrorMessages } from '../ErrorMessages';
 
 const propTypes = {
   name: PropTypes.string.isRequired,

--- a/src/contexts/QuickMarcContext/QuickMarcContext.js
+++ b/src/contexts/QuickMarcContext/QuickMarcContext.js
@@ -21,7 +21,6 @@ const QuickMarcProvider = ({
 }) => {
   const [selectedSourceFile, setSelectedSourceFile] = useState(null);
   const validationErrors = useRef({});
-  const [modifiedSinceLastSubmit, setModifiedSinceLastSubmit] = useState(false);
 
   const setValidationErrors = useCallback((newValidationErrors) => {
     validationErrors.current = newValidationErrors;
@@ -32,15 +31,11 @@ const QuickMarcProvider = ({
     setSelectedSourceFile,
     validationErrorsRef: validationErrors,
     setValidationErrors,
-    modifiedSinceLastSubmit,
-    setModifiedSinceLastSubmit,
   }), [
     selectedSourceFile,
     setSelectedSourceFile,
     validationErrors,
     setValidationErrors,
-    modifiedSinceLastSubmit,
-    setModifiedSinceLastSubmit,
   ]);
 
   return (


### PR DESCRIPTION
## Description
Fix infinite loop when need to run confirmation checks
Instead of form's `modifiedSinceLastSubmit` now using a state value to be able to re-set it when use has validated a record.

## Screenshots

https://github.com/user-attachments/assets/8056bc15-0a39-4e1e-8138-1e6820a2baed


## Issues
[UIQM-631](https://folio-org.atlassian.net/browse/UIQM-631)