### PR TITLE
UIQM-658: Add existance check for 010 $a to prevent LCCN check with empty $a (follow-up).

### DIFF
--- a/src/hooks/useLccnDuplicationCheck/useLccnDuplicationCheck.js
+++ b/src/hooks/useLccnDuplicationCheck/useLccnDuplicationCheck.js
@@ -17,14 +17,14 @@ const useLccnDuplicationCheck = ({ marcType, id, action }) => {
 
   const validateLccnDuplication = useCallback(async (marcRecords) => {
     const field010 = marcRecords.find(field => field.tag === '010');
+    const { $a = [] } = getContentSubfieldValue(field010?.content);
 
     if (!duplicateLccnCheckingEnabled
       || !field010
+      || !$a.filter(lccn => lccn).length
       || ![MARC_TYPES.BIB, MARC_TYPES.AUTHORITY].includes(marcType)) {
       return undefined;
     }
-
-    const { $a = [] } = getContentSubfieldValue(field010?.content);
 
     const lccnQuery = $a
       .filter(lccn => lccn)
@@ -40,9 +40,14 @@ const useLccnDuplicationCheck = ({ marcType, id, action }) => {
       idQuery = '';
     }
 
+    const searchParams = {
+      limit: 1,
+      query: `(${lccnQuery})${idQuery}`,
+    };
+
     const requests = {
-      [MARC_TYPES.BIB]: () => ky.get(`search/instances?limit=1&query=((${lccnQuery})${idQuery})`),
-      [MARC_TYPES.AUTHORITY]: () => ky.get(`search/authorities?limit=1&query=((${lccnQuery})${idQuery})`),
+      [MARC_TYPES.BIB]: () => ky.get('search/instances', { searchParams }),
+      [MARC_TYPES.AUTHORITY]: () => ky.get('search/authorities', { searchParams }),
     };
 
     const buildError = (messageId) => ({

--- a/src/hooks/useLccnDuplicationCheck/useLccnDuplicationCheck.test.js
+++ b/src/hooks/useLccnDuplicationCheck/useLccnDuplicationCheck.test.js
@@ -19,6 +19,34 @@ describe('useLccnDuplicationCheck', () => {
     useLccnDuplicateConfig.mockReturnValue({ duplicateLccnCheckingEnabled: false });
   });
 
+  it('should not validate if 010 $a is empty', async () => {
+    const fieldId = 'field-id';
+    const marcRecords = [{
+      id: fieldId,
+      tag: '010',
+      content: '$a ',
+    }];
+    const mockGet = jest.fn();
+
+    useLccnDuplicateConfig.mockReturnValue({ duplicateLccnCheckingEnabled: true });
+
+    useOkapiKy.mockReturnValue({
+      get: mockGet,
+    });
+
+    const { result } = renderHook(useLccnDuplicationCheck, {
+      initialProps: {
+        marcType: MARC_TYPES.BIB,
+        action: QUICK_MARC_ACTIONS.EDIT,
+        id,
+      },
+    });
+
+    await act(() => result.current.validateLccnDuplication(marcRecords));
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
   describe('when marc type is bib', () => {
     describe('when duplicateLccnCheckingEnabled is enabled and LCCN is already used in another record', () => {
       it('should return error', async () => {

--- a/src/hooks/useLccnDuplicationCheck/useLccnDuplicationCheck.test.js
+++ b/src/hooks/useLccnDuplicationCheck/useLccnDuplicationCheck.test.js
@@ -50,7 +50,13 @@ describe('useLccnDuplicationCheck', () => {
         const error = await act(() => result.current.validateLccnDuplication(marcRecords));
 
         expect(mockGet).toHaveBeenCalledWith(
-          `search/instances?limit=1&query=((lccn=="123" or lccn=="456") not id=="${id}")`,
+          'search/instances',
+          {
+            searchParams: {
+              limit: 1,
+              query: '(lccn=="123" or lccn=="456") not id=="record-id"',
+            },
+          },
         );
         expect(error).toEqual({
           [fieldId]: [{ id: 'ui-quick-marc.record.error.010.lccnDuplicated' }],
@@ -87,7 +93,13 @@ describe('useLccnDuplicationCheck', () => {
         const error = await act(() => result.current.validateLccnDuplication(marcRecords));
 
         expect(mockGet).toHaveBeenCalledWith(
-          'search/instances?limit=1&query=((lccn=="123" or lccn=="456"))',
+          'search/instances',
+          {
+            searchParams: {
+              limit: 1,
+              query: '(lccn=="123" or lccn=="456")',
+            },
+          },
         );
         expect(error).toBeUndefined();
       });
@@ -179,7 +191,15 @@ describe('useLccnDuplicationCheck', () => {
 
         const error = await act(() => result.current.validateLccnDuplication(marcRecords));
 
-        expect(mockGet).toHaveBeenCalledWith('search/authorities?limit=1&query=((lccn=="123" or lccn=="456"))');
+        expect(mockGet).toHaveBeenCalledWith(
+          'search/authorities',
+          {
+            searchParams: {
+              limit: 1,
+              query: '(lccn=="123" or lccn=="456")',
+            },
+          },
+        );
         expect(error).toEqual({
           [fieldId]: [{ id: 'ui-quick-marc.record.error.010.lccnDuplicated' }],
         });
@@ -215,7 +235,13 @@ describe('useLccnDuplicationCheck', () => {
         const error = await act(() => result.current.validateLccnDuplication(marcRecords));
 
         expect(mockGet).toHaveBeenCalledWith(
-          `search/authorities?limit=1&query=((lccn=="123" or lccn=="456") not id=="${id}")`,
+          'search/authorities',
+          {
+            searchParams: {
+              limit: 1,
+              query: `(lccn=="123" or lccn=="456") not id=="${id}"`,
+            },
+          },
         );
         expect(error).toBeUndefined();
       });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Avoid showing an inline LCCN error message during the LCCN validation when 010 $a is empty.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
Add existance check for 010 $a value to prevent LCCN check with empty $a.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Issues
[UIQM-658](https://folio-org.atlassian.net/browse/UIQM-658)

## Screencast


https://github.com/user-attachments/assets/cf90e381-6a30-47b6-8c14-253fd121fcf5



#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
