### PR TITLE
UIQM-658 Fix format of parameters for getting /settings/entries (follow-up)

### DIFF
--- a/src/queries/useLccnDuplicateConfig/useLccnDuplicateConfig.js
+++ b/src/queries/useLccnDuplicateConfig/useLccnDuplicateConfig.js
@@ -17,8 +17,7 @@ const useLccnDuplicateConfig = ({ marcType }) => {
     [namespace],
     () => ky.get('settings/entries', {
       searchParams: {
-        key: KEY,
-        scope: SCOPE,
+        query: `(key==${KEY} and scope==${SCOPE})`,
       },
     }).json(),
     {


### PR DESCRIPTION
## Description
`/settings/entries` accepts a `query` paremeter with `scope` and `key` values, but we send `scope` and `key` directly
https://s3.amazonaws.com/foliodocs/api/mod-settings/settings.html#operation/getSettings

## Issues
[UIQM-658](https://folio-org.atlassian.net/browse/UIQM-658)