### PR TITLE
UIQM-681 Added 001 validation rule for Create Authority (follow-up)

### DIFF
--- a/src/hooks/useValidation/rules.js
+++ b/src/hooks/useValidation/rules.js
@@ -264,6 +264,11 @@ const CREATE_AUTHORITY_VALIDATORS = [
     validator: RULES.SUBFIELD_VALUE_MATCH,
     message: () => ({ id: 'ui-quick-marc.record.error.010.prefix.invalid' }),
   },
+  {
+    tag: '001',
+    validator: RULES.CONTENT_EXISTS,
+    message: () => ({ id: 'ui-quick-marc.record.error.controlField.content.empty' }),
+  },
 ];
 
 export const validators = {

--- a/src/hooks/useValidation/validators.js
+++ b/src/hooks/useValidation/validators.js
@@ -93,6 +93,10 @@ export const validateSubfieldValueExists = (context, rule) => {
 export const validateContentExistence = (context, rule) => {
   const { marcRecords } = context;
 
+  if (!marcRecords.find(record => record.tag.match(rule.tag))) {
+    return { [MISSING_FIELD_ID]: rule.message() };
+  }
+
   const failingFields = marcRecords
     .filter(record => record.tag.match(rule.tag))
     .filter(record => !record.content);


### PR DESCRIPTION
## Description
Added 001 validation rule for Create Authority. Will show an error message when an Authority Source file is not selected

## Screenshots

https://github.com/user-attachments/assets/ea9bf169-6bc0-41a8-b590-c82ae60b5ffb


## Issues
[UIQM-681](https://folio-org.atlassian.net/browse/UIQM-681)