### PR TITLE
UIQM-688 Convert Leader from Object to string when fetching links autosuggestions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [UIQM-632](https://issues.folio.org/browse/UIQM-632) Run timer on submit during backend validation, if it takes over 2s, show modal.
 * [UIQM-681](https://issues.folio.org/browse/UIQM-681) Return some validation rules for Bib and Authority records.
 * [UIQM-685](https://issues.folio.org/browse/UIQM-685) “ELvl” box (17th LDR position) validation when Creating/Editing/Deriving MARC bib.
+* [UIQM-688](https://issues.folio.org/browse/UIQM-688) Convert Leader from Object to string when fetching links autosuggestions.
 
 ## [8.0.1] (https://github.com/folio-org/ui-quick-marc/tree/v8.0.1) (2024-04-18)
 

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -1190,9 +1190,9 @@ export const dehydrateMarcRecordResponse = (marcRecordResponse, marcType, fixedF
   )(marcRecordResponse)
 );
 
-export const hydrateForLinkSuggestions = (marcRecord, fields) => {
+export const hydrateForLinkSuggestions = (marcRecord, marcType, fields) => {
   return ({
-    leader: marcRecord.records.find(field => field.tag === LEADER_TAG)?.content,
+    leader: convertLeaderToString(marcType, marcRecord.records.find(isLeaderRow)),
     fields: fields.map(record => ({
       tag: record.tag,
       content: record.content,

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1726,7 +1726,7 @@ describe('QuickMarcEditor utils', () => {
         ],
       };
 
-      expect(utils.hydrateForLinkSuggestions(marcRecord, fields)).toEqual({
+      expect(utils.hydrateForLinkSuggestions(marcRecord, MARC_TYPES.BIB, fields)).toEqual({
         leader: bibLeaderString,
         marcFormat: MARC_TYPES.BIB.toUpperCase(),
         _actionType: 'view',

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -223,7 +223,7 @@ const useAuthorityLinking = ({ tenantId, marcType, action } = {}) => {
   }, [getSubfieldGroups]);
 
   const getSuggestedFields = useCallback(async (formValues, fieldsToHydrate, extraRequestArgs = {}) => {
-    const payload = hydrateForLinkSuggestions(formValues, fieldsToHydrate);
+    const payload = hydrateForLinkSuggestions(formValues, marcType, fieldsToHydrate);
 
     const requestArgs = {
       body: payload,
@@ -233,7 +233,7 @@ const useAuthorityLinking = ({ tenantId, marcType, action } = {}) => {
     const { fields: memberSuggestedFields } = await fetchLinkSuggestions(requestArgs);
 
     return memberSuggestedFields;
-  }, [fetchLinkSuggestions]);
+  }, [fetchLinkSuggestions, marcType]);
 
   const autoLinkAuthority = useCallback(async (formValues) => {
     const fieldsToLink = formValues.records.filter(record => isRecordForAutoLinking(record, autoLinkableBibFields));

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -1433,7 +1433,7 @@ describe('Given useAuthorityLinking', () => {
           fetchLinkSuggestions: mockFetchLinkSuggestions.mockResolvedValue(linkSuggestionsResponse),
         });
 
-        const { result } = renderHook(() => useAuthorityLinking(), { wrapper });
+        const { result } = renderHook(() => useAuthorityLinking({ marcType: MARC_TYPES.BIB }), { wrapper });
 
         const values = await result.current.actualizeLinks(formValues);
 


### PR DESCRIPTION
## Description
Fix an error when autolinking. Convert Leader from Object to string when fetching links autosuggestions.

## Screenshots

https://github.com/user-attachments/assets/a50dac0b-7683-4296-929d-c6aee75fe711



## Issues
[UIQM-688](https://folio-org.atlassian.net/browse/UIQM-688)