### PR TITLE
UIQM-691 Show correct field and toast color when validation returns warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [UIQM-687](https://issues.folio.org/browse/UIQM-687) Create/Derive MARC Bib records - remove field 001 error related to missing field during validation.
 * [UIQM-686](https://issues.folio.org/browse/UIQM-686) Return removed UI validation in "quickmarc".
 * [UIQM-690](https://issues.folio.org/browse/UIQM-690) Match payload formatting for submit and validate when editing.
+* [UIQM-691](https://issues.folio.org/browse/UIQM-691) Show correct field and toast color when validation returns warnings.
 
 ## [8.0.1] (https://github.com/folio-org/ui-quick-marc/tree/v8.0.1) (2024-04-18)
 

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -47,6 +47,7 @@ import { AutoLinkingButton } from './AutoLinkingButton';
 import { QuickMarcContext } from '../contexts';
 import {
   MISSING_FIELD_ID,
+  SEVERITY,
   useAuthorityLinking,
   useValidation,
 } from '../hooks';
@@ -227,6 +228,17 @@ const QuickMarcEditor = ({
     };
   }, [setIsValidationModalOpen, isBackEndValidationMarcType, marcType]);
 
+  const showValidationIssuesCallouts = useCallback((issues) => {
+    issues.forEach((error) => {
+      showCallout({
+        message: error.message,
+        messageId: error.id,
+        values: error.values,
+        type: error.severity === SEVERITY.ERROR ? 'error' : 'warning',
+      });
+    });
+  }, [showCallout]);
+
   const confirmSubmit = useCallback(async (e, isKeepEditing = false) => {
     continueAfterSave.current = isKeepEditing;
     let skipValidation = false;
@@ -258,17 +270,9 @@ const QuickMarcEditor = ({
 
         return;
       }
-
       const validationErrorsWithoutFieldId = newValidationErrors[MISSING_FIELD_ID] || [];
 
-      validationErrorsWithoutFieldId.forEach((error) => {
-        showCallout({
-          message: error.message,
-          messageId: error.id,
-          values: error.values,
-          type: 'error',
-        });
-      });
+      showValidationIssuesCallouts(validationErrorsWithoutFieldId);
       setIsValidatedCurrentValues(true);
     } else {
       setValidationErrors({});
@@ -290,6 +294,7 @@ const QuickMarcEditor = ({
     getState,
     hasErrorIssues,
     setValidationErrors,
+    showValidationIssuesCallouts,
     showCallout,
     validate,
     runConfirmationChecks,

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -794,7 +794,7 @@ describe('Given QuickMarcEditor', () => {
 
   describe('when saving form with validation errors and deleted fields', () => {
     beforeEach(() => {
-      mockValidate.mockClear().mockResolvedValue({ [MISSING_FIELD_ID]: [{ id: 'some error', values: {} }] });
+      mockValidate.mockClear().mockResolvedValue({ [MISSING_FIELD_ID]: [{ id: 'some error', severity: 'error', values: {} }] });
     });
 
     it('should show errors and not show confirmation modal', async () => {

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -43,6 +43,7 @@ import {
   hasIndicatorException,
   hasAddException,
   hasMoveException,
+  separateValidationErrorsAndWarnings,
 } from './utils';
 import {
   isRecordForManualLinking,
@@ -290,7 +291,9 @@ const QuickMarcEditorRows = ({
 
             const isLeader = isLeaderRow(recordRow);
             const isDisabled = isReadOnly(recordRow, action, marcType);
-            const fieldValidationErrors = validationErrorsRef.current[recordRow.id];
+            const fieldValidationIssues = separateValidationErrorsAndWarnings(
+              validationErrorsRef.current[recordRow.id],
+            );
             const withIndicators = !hasIndicatorException(recordRow);
             const withAddRowAction = hasAddException(recordRow, marcType, action);
             const withDeleteRowAction = hasDeleteException(recordRow, marcType, instance, initialValues, linksCount);
@@ -500,7 +503,7 @@ const QuickMarcEditorRows = ({
                       marcType={marcType}
                       leaderField={recordRow}
                       action={action}
-                      error={fieldValidationErrors}
+                      error={fieldValidationIssues}
                     />
                   )}
                   {
@@ -518,7 +521,7 @@ const QuickMarcEditorRows = ({
                       FixedFieldFactory.getFixedField(
                         intl, `${name}.content`, fixedFieldSpec, type, subtype, fixedFieldInitialValues(),
                       )({
-                        error: fieldValidationErrors,
+                        error: fieldValidationIssues,
                         fieldId: recordRow.id,
                       })
                     )
@@ -553,7 +556,10 @@ const QuickMarcEditorRows = ({
                             id={`content-field-${idx}`}
                             component={ContentField}
                             data-testid={`content-field-${idx}`}
-                            error={fieldValidationErrors && <ErrorMessages errors={fieldValidationErrors} />}
+                            error={fieldValidationIssues.errors
+                              && <ErrorMessages errors={fieldValidationIssues.errors} />}
+                            warning={fieldValidationIssues.warnings
+                              && <ErrorMessages errors={fieldValidationIssues.warnings} />}
                           />
                         )
                     )

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -56,13 +56,13 @@ export const separateValidationErrorsAndWarnings = (validationErrors = []) => {
       }
 
       acc.errors = [...acc.errors, cur];
-    }
+    } else {
+      if (!acc.warnings) {
+        acc.warnings = [];
+      }
 
-    if (!acc.warnings) {
-      acc.warnings = [];
+      acc.warnings = [...acc.warnings, cur];
     }
-
-    acc.warnings = [...acc.warnings, cur];
 
     return acc;
   }, {

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.js
@@ -2,6 +2,7 @@ import {
   LEADER_TAG,
   QUICK_MARC_ACTIONS,
 } from '../constants';
+import { SEVERITY } from '../../hooks';
 import { MARC_TYPES } from '../../common/constants';
 import { fieldMatchesDescription } from '../utils';
 
@@ -45,4 +46,27 @@ export const hasMoveException = (recordRow, sibling, action = QUICK_MARC_ACTIONS
     || fieldMatchesDescription(recordRow, rows)
     || fieldMatchesDescription(sibling, rows)
   );
+};
+
+export const separateValidationErrorsAndWarnings = (validationErrors = []) => {
+  return validationErrors.reduce((acc, cur) => {
+    if (cur.severity === SEVERITY.ERROR) {
+      if (!acc.errors) {
+        acc.errors = [];
+      }
+
+      acc.errors = [...acc.errors, cur];
+    }
+
+    if (!acc.warnings) {
+      acc.warnings = [];
+    }
+
+    acc.warnings = [...acc.warnings, cur];
+
+    return acc;
+  }, {
+    errors: null,
+    warnings: null,
+  });
 };

--- a/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/utils.test.js
@@ -1,3 +1,4 @@
+import { SEVERITY } from '../../hooks';
 import {
   LEADER_TAG,
   QUICK_MARC_ACTIONS,
@@ -168,6 +169,25 @@ describe('QuickMarcEditorRows utils', () => {
 
           expect(utils.hasMoveException(field, _sibling, action)).toBeTruthy();
         });
+      });
+    });
+  });
+
+  describe('separateValidationErrorsAndWarnings', () => {
+    it('should separate warn and error issues into separate arrays', () => {
+      const error = {
+        severity: SEVERITY.ERROR,
+        message: 'error',
+      };
+      const warning = {
+        severity: SEVERITY.WARN,
+        message: 'warning',
+      };
+      const issues = [error, warning];
+
+      expect(utils.separateValidationErrorsAndWarnings(issues)).toEqual({
+        errors: [error],
+        warnings: [warning],
       });
     });
   });


### PR DESCRIPTION
## Description
Validation warnings should make fields have warning style

## Screenshots

https://github.com/user-attachments/assets/ebe8422c-8c0e-437f-bd8d-c1c108639881


## Issues
[UIQM-691](https://folio-org.atlassian.net/browse/UIQM-691)