### PR TITLE
UIQM-592 Fix input polish chars into fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [UIQM-691](https://issues.folio.org/browse/UIQM-691) Show correct field and toast color when validation returns warnings.
 * [UIQM-665](https://issues.folio.org/browse/UIQM-665) Fix to generate array content in 008 after changing document type of MARC bib.
 * [UIQM-694](https://issues.folio.org/browse/UIQM-694) Separate error messages triggered by controlled subfields of different linked fields.
+* [UIQM-592](https://issues.folio.org/browse/UIQM-592) Fix to input polish special chars into fields.
 
 ## [8.0.1] (https://github.com/folio-org/ui-quick-marc/tree/v8.0.1) (2024-04-18)
 

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -465,6 +465,10 @@ const QuickMarcEditor = ({
     name: 'save',
     shortcut: 'mod+s',
     handler: async (e) => {
+      if (['ctrl', 'alt'].every(x => e.pressedKeys.includes(x))) {
+        return;
+      }
+
       if (!saveFormDisabled) {
         e.preventDefault();
         confirmationChecks.current = { ...REQUIRED_CONFIRMATIONS };

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -75,6 +75,7 @@ import {
   updateRecordAtIndex,
   markLinkedRecords,
   getLeaderPositions,
+  isDiacritic,
 } from './utils';
 
 import css from './QuickMarcEditor.css';
@@ -465,10 +466,7 @@ const QuickMarcEditor = ({
     name: 'save',
     shortcut: 'mod+s',
     handler: async (e) => {
-      // Comments: ctrl+alt+s is combination for ś. Checking combination to prevent saving record.
-      if (['ctrl', 'alt'].every(x => e.pressedKeys.includes(x))) {
-        return;
-      }
+      if (isDiacritic(e.key)) return;
 
       if (!saveFormDisabled) {
         e.preventDefault();

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -465,6 +465,7 @@ const QuickMarcEditor = ({
     name: 'save',
     shortcut: 'mod+s',
     handler: async (e) => {
+      // Comments: ctrl+alt+s is combination for ś. Checking combination to prevent saving record.
       if (['ctrl', 'alt'].every(x => e.pressedKeys.includes(x))) {
         return;
       }

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -1220,3 +1220,11 @@ export const isFolioSourceFileNotSelected = ({ selectedSourceFile }) => {
 export const joinErrors = (errorsA, errorsB) => {
   return assignWith({}, errorsA, errorsB, (objValue = [], srcValue = []) => objValue.concat(srcValue));
 };
+
+export const isDiacritic = (char) => {
+  const specialDiactrics = 'łŁøß';
+
+  if (specialDiactrics.includes(char)) return true;
+
+  return char.normalize('NFD') !== char;
+};

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1793,4 +1793,22 @@ describe('QuickMarcEditor utils', () => {
       });
     });
   });
+
+  describe('isDiacritic', () => {
+    it('should all chars to be detected as diacritics', () => {
+      const diacriticArray = 'ąćęłńóśźżĄĆĘŁŃÓŚŹŻøãéžŽšŠşŞß';
+
+      [...diacriticArray].forEach(c => {
+        expect(utils.isDiacritic(c)).toBeTruthy();
+      });
+    });
+
+    it('should all chars to be detected as not diacritics', () => {
+      const diacriticArray = 'acelnoszACELNOSZ';
+
+      [...diacriticArray].forEach(c => {
+        expect(utils.isDiacritic(c)).toBeFalsy();
+      });
+    });
+  });
 });


### PR DESCRIPTION

## Purpose
Problem detected only on windows with polish programmer keyboard installed (default for polish).
No issue detected on Mac or Linux.
Prevent execute action for ex. "Save record" triggered from shortcut ctrl + s when inputing polish special chars ś or Ś. 

## Approach
Detects pressing the ctrl and alt keys  and interrupts shortcut actions.

## Issues
[UIQM-592](https://folio-org.atlassian.net/browse/UIQM-592)

## ScreenRecords

Before changes 


https://github.com/user-attachments/assets/1370c99f-a16f-4775-ab85-95634ba78c97

After changes 


https://github.com/user-attachments/assets/19583e64-9dc7-428d-85c7-6ba4da8b517a

