### PR TITLE
UIQM-695: Remove extra `$` from error messages when adding/removing $t from 1XX of linked MARC authority record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [UIQM-697](https://issues.folio.org/browse/UIQM-697) Field 008: Validate the length of subfields. Add backslashes if the length of a subfield of field 008 is shorter, if longer - cut off the extra characters.
 * [UIQM-699](https://issues.folio.org/browse/UIQM-699) ECS - send validation request with central tenant id for shared Bib and Authority records.
 * [UIQM-693](https://issues.folio.org/browse/UIQM-693) Hide permission - Edit, View: Enable duplicate LCCN (010 $a) checking of MARC bibliographic and authority records.
+* [UIQM-695](https://issues.folio.org/browse/UIQM-695) Remove extra `$` from error messages when adding/removing `$t` from 1XX of linked MARC authority record.
 
 ## [8.0.1] (https://github.com/folio-org/ui-quick-marc/tree/v8.0.1) (2024-04-18)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.test.js
@@ -300,7 +300,7 @@ describe('Given LinkButton', () => {
       });
 
       fireEvent.click(getAllByTestId('unlink-authority-button-fakeId')[0]);
-      fireEvent.click(getByText('ui-quick-marc.record.unlink.confirm.confirm'));
+      fireEvent.click(getByText('confirm'));
 
       expect(mockHandleUnlinkAuthority).toHaveBeenCalled();
     });

--- a/src/QuickMarcEditor/SourceFileLookup/SourceFileLookupModal.test.js
+++ b/src/QuickMarcEditor/SourceFileLookup/SourceFileLookupModal.test.js
@@ -49,7 +49,7 @@ describe('Given SourceFileLookupModal', () => {
     it('should disable Save & close button', () => {
       const { getByRole } = renderSourceFileLookupModal();
 
-      const button = getByRole('button', { name: 'stripes-components.saveAndClose', hidden: true });
+      const button = getByRole('button', { name: 'stripes-components.saveAndClose' });
 
       expect(button).toBeDisabled();
     });
@@ -58,15 +58,15 @@ describe('Given SourceFileLookupModal', () => {
   describe('when some source file value is selected', () => {
     it('should enable Save & close button', async () => {
       const {
+        getByRole,
         getByLabelText,
-        getByText,
       } = renderSourceFileLookupModal();
 
       const select = getByLabelText('ui-quick-marc.sourceFileLookupModal.fieldLabel');
 
       fireEvent.change(select, { target: { value: sourceFileOptions[0].value } });
 
-      const button = getByText('stripes-components.saveAndClose').closest('button');
+      const button = getByRole('button', { name: 'stripes-components.saveAndClose' });
 
       expect(button).toBeEnabled();
     });
@@ -75,15 +75,15 @@ describe('Given SourceFileLookupModal', () => {
   describe('when confirming Source File selection', () => {
     it('should call onConfirm with correct source file id', async () => {
       const {
+        getByRole,
         getByLabelText,
-        getByText,
       } = renderSourceFileLookupModal();
 
       const select = getByLabelText('ui-quick-marc.sourceFileLookupModal.fieldLabel');
 
       fireEvent.change(select, { target: { value: sourceFileOptions[0].value } });
 
-      const button = getByText('stripes-components.saveAndClose').closest('button');
+      const button = getByRole('button', { name: 'stripes-components.saveAndClose' });
 
       fireEvent.click(button);
 
@@ -93,9 +93,9 @@ describe('Given SourceFileLookupModal', () => {
 
   describe('when closing the modal', () => {
     it('should call onCancel', async () => {
-      const { getByText } = renderSourceFileLookupModal();
+      const { getByRole } = renderSourceFileLookupModal();
 
-      const button = getByText('stripes-components.cancel').closest('button');
+      const button = getByRole('button', { name: 'stripes-components.cancel' });
 
       fireEvent.click(button);
 

--- a/src/QuickMarcEditor/SourceFileLookup/SourceFileLookupModal.test.js
+++ b/src/QuickMarcEditor/SourceFileLookup/SourceFileLookupModal.test.js
@@ -49,7 +49,7 @@ describe('Given SourceFileLookupModal', () => {
     it('should disable Save & close button', () => {
       const { getByRole } = renderSourceFileLookupModal();
 
-      const button = getByRole('button', { name: 'stripes-components.saveAndClose' });
+      const button = getByRole('button', { name: 'stripes-components.saveAndClose', hidden: true });
 
       expect(button).toBeDisabled();
     });
@@ -58,15 +58,15 @@ describe('Given SourceFileLookupModal', () => {
   describe('when some source file value is selected', () => {
     it('should enable Save & close button', async () => {
       const {
-        getByRole,
         getByLabelText,
+        getByText,
       } = renderSourceFileLookupModal();
 
       const select = getByLabelText('ui-quick-marc.sourceFileLookupModal.fieldLabel');
 
       fireEvent.change(select, { target: { value: sourceFileOptions[0].value } });
 
-      const button = getByRole('button', { name: 'stripes-components.saveAndClose' });
+      const button = getByText('stripes-components.saveAndClose').closest('button');
 
       expect(button).toBeEnabled();
     });
@@ -75,15 +75,15 @@ describe('Given SourceFileLookupModal', () => {
   describe('when confirming Source File selection', () => {
     it('should call onConfirm with correct source file id', async () => {
       const {
-        getByRole,
         getByLabelText,
+        getByText,
       } = renderSourceFileLookupModal();
 
       const select = getByLabelText('ui-quick-marc.sourceFileLookupModal.fieldLabel');
 
       fireEvent.change(select, { target: { value: sourceFileOptions[0].value } });
 
-      const button = getByRole('button', { name: 'stripes-components.saveAndClose' });
+      const button = getByText('stripes-components.saveAndClose').closest('button');
 
       fireEvent.click(button);
 
@@ -93,9 +93,9 @@ describe('Given SourceFileLookupModal', () => {
 
   describe('when closing the modal', () => {
     it('should call onCancel', async () => {
-      const { getByRole } = renderSourceFileLookupModal();
+      const { getByText } = renderSourceFileLookupModal();
 
-      const button = getByRole('button', { name: 'stripes-components.cancel' });
+      const button = getByText('stripes-components.cancel').closest('button');
 
       fireEvent.click(button);
 

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -1,3 +1,4 @@
 import './stripesCore.mock';
 import './resizeObserver.mock';
 import './reactIntl.mock';
+import './stripesComponents.mock';

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,0 +1,29 @@
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
+  ConfirmationModal: jest.fn(({ heading, message, onConfirm, onCancel, onRemove }) => (
+    <div>
+      <span>ConfirmationModal</span>
+      {heading}
+      <div>{message}</div>
+      <div>
+        <button type="button" onClick={onConfirm}>confirm</button>
+        <button type="button" onClick={onCancel}>cancel</button>
+        <button type="button" onClick={onRemove}>remove</button>
+      </div>
+    </div>
+  )),
+  Loading: () => <div>Loading</div>,
+  LoadingPane: () => <div>LoadingPane</div>,
+  LoadingView: jest.fn(() => <div>LoadingView</div>),
+  Modal: jest.fn(({ children, open, label, footer, ...rest }) => {
+    return open && (
+      <div
+        {...rest}
+      >
+        <h1>{label}</h1>
+        {children}
+        {footer}
+      </div>
+    );
+  }),
+}), { virtual: true });

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -745,8 +745,8 @@
   "record.error.location.invalid": "852 $b contains an invalid Location code. Please try again.",
   "record.error.$9": "$9 is an invalid subfield for linkable bibliographic fields.",
   "record.error.1xx.change": "Cannot change the <b>saved MARC authority field {tag}</b> because it controls a bibliographic field(s). To change this 1XX, you must unlink all controlled bibliographic fields.",
-  "record.error.1xx.add$t": "Cannot add a <b>$t to the ${tag} field</b> because it controls a bibliographic field(s) that cannot control this subfield. To change this 1XX value, you must unlink all controlled bibliographic fields that cannot control $t.",
-  "record.error.1xx.remove$t": "Cannot remove <b>$t from the ${tag} field</b> because it controls a bibliographic field(s) that requires  this subfield. To change this 1XX value, you must unlink all controlled bibliographic fields that requires $t to be controlled.",
+  "record.error.1xx.add$t": "Cannot add a <b>$t to the {tag} field</b> because it controls a bibliographic field(s) that cannot control this subfield. To change this 1XX value, you must unlink all controlled bibliographic fields that cannot control $t.",
+  "record.error.1xx.remove$t": "Cannot remove <b>$t from the {tag} field</b> because it controls a bibliographic field(s) that requires  this subfield. To change this 1XX value, you must unlink all controlled bibliographic fields that requires $t to be controlled.",
   "record.error.fieldIsControlled": "A subfield(s) cannot be updated because it is controlled by an authority heading.",
   "record.error.field.onlyOneSubfield":"<b>{fieldTag}</b> can only have one <b>{subField}</b>.",
 


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Remove the extra `$` sign in error messages.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-695](https://folio-org.atlassian.net/browse/UIQM-695)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
