### PR TITLE
UIQM-699 use member tenant id for validation when deriving a bib record (follow-up)

### DIFF
--- a/src/QuickMarcEditor/QuickMarcDeriveWrapper.js
+++ b/src/QuickMarcEditor/QuickMarcDeriveWrapper.js
@@ -4,13 +4,11 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import flow from 'lodash/flow';
 import isEmpty from 'lodash/isEmpty';
 
 import { useShowCallout } from '@folio/stripes-acq-components';
-import { useStripes } from '@folio/stripes/core';
 
 import QuickMarcEditor from './QuickMarcEditor';
 import {
@@ -37,7 +35,6 @@ import {
   removeEnteredDate,
   autopopulatePhysDescriptionField,
   autopopulateMaterialCharsField,
-  applyCentralTenantInHeaders,
 } from './utils';
 
 const propTypes = {
@@ -59,16 +56,10 @@ const QuickMarcDeriveWrapper = ({
   marcType,
   fixedFieldSpec,
 }) => {
-  const stripes = useStripes();
-  const location = useLocation();
   const showCallout = useShowCallout();
   const { linkableBibFields, actualizeLinks, linkingRules } = useAuthorityLinking({ marcType, action });
   const [httpError, setHttpError] = useState(null);
   const { validationErrorsRef } = useContext(QuickMarcContext);
-
-  const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(location, stripes, marcType);
-  const centralTenantId = stripes.user.user.consortium?.centralTenantId;
-  const tenantId = isRequestToCentralTenantFromMember ? centralTenantId : '';
 
   const validationContext = useMemo(() => ({
     initialValues,
@@ -79,7 +70,7 @@ const QuickMarcDeriveWrapper = ({
     fixedFieldSpec,
     instanceId: instance.id,
   }), [initialValues, marcType, linkableBibFields, linkingRules, fixedFieldSpec, instance.id]);
-  const { validate } = useValidation(validationContext, tenantId);
+  const { validate } = useValidation(validationContext);
 
   const prepareForSubmit = useCallback((formValues) => {
     const formValuesForDerive = flow(


### PR DESCRIPTION
## Description
use member tenant id for validation when deriving a bib record

## Issues
[UIQM-699](https://folio-org.atlassian.net/browse/UIQM-699)