### PR TITLE
UIQM-708 Change 007 Microforms type to allow 4 characters in RRR/RR field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [UIQM-695](https://issues.folio.org/browse/UIQM-695) Remove extra `$` from error messages when adding/removing `$t` from 1XX of linked MARC authority record.
 * [UIQM-706](https://issues.folio.org/browse/UIQM-706) *BREAKING* Upgrade `marc-records-editor` to `6.0`.
 * [UIQM-698](https://issues.folio.org/browse/UIQM-698) Validate 006/007 field lengths.
+* [UIQM-708](https://issues.folio.org/browse/UIQM-708) Change 007 Microforms type to allow 4 characters in RRR/RR field.
 
 ## [8.0.1] (https://github.com/folio-org/ui-quick-marc/tree/v8.0.1) (2024-04-18)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/PhysDescriptionField/MicroformDescriptionFieldConfig.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/PhysDescriptionField/MicroformDescriptionFieldConfig.js
@@ -14,7 +14,7 @@ const MicroformDescriptionFieldConfig = [
   {
     name: 'Reduction ratio range/Reduction ratio',
     type: SUBFIELD_TYPES.STRING,
-    length: 3,
+    length: 4,
   },
   {
     name: 'Color',


### PR DESCRIPTION
## Description
Change 007 Microforms type to allow 4 characters in RRR/RR field.

## Screenshots

https://github.com/user-attachments/assets/c0104045-d6b6-49c8-ac81-c708d0c0c5b4



## Issues
[UIQM-708](https://folio-org.atlassian.net/browse/UIQM-708)