### PR TITLE
UIQM-725 Fix wrong error message while saving MARC Bib record with invalid LDR position values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-quick-marc
 
+## [9.0.1] (IN PROGRESS)
+
+* [UIQM-725](https://issues.folio.org/browse/UIQM-725) Fix wrong error message while saving MARC Bib record with invalid LDR position values.
+
 ## [9.0.0](https://github.com/folio-org/ui-quick-marc/tree/v9.0.0) (2024-11-01)
 
 * [UIQM-647](https://issues.folio.org/browse/UIQM-647) Import `useUserTenantPermissions` from `@folio/stripes/core`.

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -1228,6 +1228,10 @@ export const isDiacritic = (char) => {
 };
 
 export const getVisibleNonSelectable008Subfields = (fixedFieldType) => {
+  if (!fixedFieldType) {
+    return [];
+  }
+
   return fixedFieldType.items
     .filter(field => !field.readOnly)
     .filter(field => !field.isArray);

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1865,21 +1865,19 @@ describe('QuickMarcEditor utils', () => {
   });
 
   describe('getFixedFieldStringPositions', () => {
-    beforeEach(() => {
-      jest.spyOn(FixedFieldFactory, 'getFixedFieldType').mockReturnValue({
-        items: [{
-          code: 'test1',
-          isArray: true,
-        }, {
-          code: 'test2',
-          isArray: false,
-          readOnly: false,
-        }],
-      });
-    });
-
     describe('when a field is an 008', () => {
       it('should return an 008 config', () => {
+        jest.spyOn(FixedFieldFactory, 'getFixedFieldType').mockReturnValueOnce({
+          items: [{
+            code: 'test1',
+            isArray: true,
+          }, {
+            code: 'test2',
+            isArray: false,
+            readOnly: false,
+          }],
+        });
+
         const field = { tag: '008' };
 
         expect(utils.getFixedFieldStringPositions('a', 'm', field, fixedFieldSpecBib)).toEqual([
@@ -1889,6 +1887,14 @@ describe('QuickMarcEditor utils', () => {
             readOnly: false,
           },
         ]);
+      });
+
+      describe('when type or subtype are invalid', () => {
+        it('should return an empty array', () => {
+          const field = { tag: '008' };
+
+          expect(utils.getFixedFieldStringPositions('|', '|', field, fixedFieldSpecBib)).toEqual([]);
+        });
       });
     });
 


### PR DESCRIPTION
## Description
Fix wrong error message while saving MARC Bib record with invalid LDR position values.

Handle case when invalid LDR/06 and LDR/07 will result in an empty fixed field type

## Screenshots

https://github.com/user-attachments/assets/80aec2d2-14d3-4a36-a7d0-b75562a55c0b

## Issues
[UIQM-725](https://folio-org.atlassian.net/browse/UIQM-725)