### PR TITLE
UIQM-736 Use a larger width of 7-16 leader positions field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * [UIQM-716](https://issues.folio.org/browse/UIQM-716) *BREAKING* Consolidate routes based on MARC type for bib and authority records to avoid page refresh after redirecting from the create page to the edit one.
 * [UIQM-730](https://issues.folio.org/browse/UIQM-730) Create/Edit/Derive MARC record - Retain focus when MARC record validation rules error display. Show validation issues toasts.
 
+## [9.0.2] (IN PROGRESS)
+
+* [UIQM-726](https://issues.folio.org/browse/UIQM-726) Use a larger width of 7-16 leader positions field.
+
 ## [9.0.1](https://github.com/folio-org/ui-quick-marc/tree/v9.0.1) (2024-11-22)
 
 * [UIQM-725](https://issues.folio.org/browse/UIQM-725) Fix wrong error message while saving MARC Bib record with invalid LDR position values.

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LeaderField/leaderConfig.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LeaderField/leaderConfig.js
@@ -356,7 +356,7 @@ export const leaderConfig = {
       type: SUBFIELD_TYPES.STRING,
       disabled: true,
       noLabel: true,
-      width72: true,
+      width82: true,
       defaultValue: '\\\\\\2200000',
     },
     {


### PR DESCRIPTION
## Description
Use a larger width of 7-16 leader positions field.

## Screenshots
![image](https://github.com/user-attachments/assets/16184ba2-1ae4-45cd-8d47-4f4373d2ab7b)

## Issues
[UIQM-736](https://folio-org.atlassian.net/browse/UIQM-736)