### PR TITLE
UIQM-740 Don't show warn/fail error toasts when there are no warns/fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIQM-716](https://issues.folio.org/browse/UIQM-716) *BREAKING* Consolidate routes based on MARC type for bib and authority records to avoid page refresh after redirecting from the create page to the edit one.
 * [UIQM-730](https://issues.folio.org/browse/UIQM-730) Create/Edit/Derive MARC record - Retain focus when MARC record validation rules error display. Show validation issues toasts.
+* [UIQM-740](https://issues.folio.org/browse/UIQM-740) Don't show warn/fail error toasts when there are no warns/fails.
 
 ## [9.0.1](https://github.com/folio-org/ui-quick-marc/tree/v9.0.1) (2024-11-22)
 

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -232,11 +232,16 @@ const QuickMarcEditor = ({
     const failCount = allIssuesArray.filter(issue => issue.severity === SEVERITY.ERROR).length;
     const warnCount = allIssuesArray.length - failCount;
 
+    if (!failCount && !warnCount) {
+      return;
+    }
+
     const values = {
       warnCount,
       failCount,
       breakingLine: <br />,
     };
+
     let messageId = null;
 
     if (failCount && warnCount) {

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -895,6 +895,30 @@ describe('Given QuickMarcEditor', () => {
     });
   });
 
+  describe('when saving form without validation warnings or errors', () => {
+    beforeEach(async () => {
+      mockValidate.mockClear().mockResolvedValue({});
+
+      const {
+        getByText,
+        getByTestId,
+      } = renderQuickMarcEditor();
+
+      const contentField = getByTestId('content-field-3');
+
+      fireEvent.change(contentField, { target: { value: '' } });
+      await fireEvent.click(getByText('stripes-acq-components.FormFooter.save'));
+    });
+
+    it('should show a toast notification about validation warning and error', async () => {
+      await waitFor(() => {
+        expect(mockShowCallout).not.toHaveBeenCalledWith(expect.objectContaining({
+          messageId: expect.stringContaining('ui-quick-marc.record.save.error'),
+        }));
+      });
+    });
+  });
+
   describe('when marc record is of type HOLDINGS', () => {
     describe('when action is create', () => {
       it('should not show "Save & keep editing" button', () => {

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -910,7 +910,7 @@ describe('Given QuickMarcEditor', () => {
       await fireEvent.click(getByText('stripes-acq-components.FormFooter.save'));
     });
 
-    it('should show a toast notification about validation warning and error', async () => {
+    it('should not show a toast notification about validation warning and error', async () => {
       await waitFor(() => {
         expect(mockShowCallout).not.toHaveBeenCalledWith(expect.objectContaining({
           messageId: expect.stringContaining('ui-quick-marc.record.save.error'),


### PR DESCRIPTION
## Description
Don't show warn/fail error toasts when there are no warns/fails.

## Screenshots

https://github.com/user-attachments/assets/7b50e81e-23ba-4b43-b3fd-e0d80819a114



## Issues
[UIQM-740](https://folio-org.atlassian.net/browse/UIQM-740)