### PR TITLE
UIQM-728 Keep focus on last focused element when user cancels on confirmation modals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UIQM-716](https://issues.folio.org/browse/UIQM-716) *BREAKING* Consolidate routes based on MARC type for bib and authority records to avoid page refresh after redirecting from the create page to the edit one.
 * [UIQM-730](https://issues.folio.org/browse/UIQM-730) Create/Edit/Derive MARC record - Retain focus when MARC record validation rules error display. Show validation issues toasts.
 * [UIQM-740](https://issues.folio.org/browse/UIQM-740) Don't show warn/fail error toasts when there are no warns/fails.
+* [UIQM-728](https://issues.folio.org/browse/UIQM-728) Keep focus on last focused element when user cancels on confirmation modals.
 
 ## [9.0.2] (IN PROGRESS)
 

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -447,6 +447,9 @@ const QuickMarcEditor = ({
 
   const cancelUpdateLinks = () => {
     setIsUpdate0101xxfieldsAuthRecModalOpen(false);
+    setTimeout(() => {
+      focusLastFocusedInput();
+    });
   };
 
   const confirmUpdateLinks = async (e) => {
@@ -461,17 +464,23 @@ const QuickMarcEditor = ({
   };
 
   const cancelDeleteFields = () => {
-    setIsDeleteModalOpened(false);
-
     if (deletedRecords.length) {
       restoreDeletedRecords();
     } else {
       reset();
     }
+
+    setIsDeleteModalOpened(false);
+    setTimeout(() => {
+      focusLastFocusedInput();
+    });
   };
 
   const cancelRemoveLinking = () => {
     setIsUnlinkRecordsModalOpen(false);
+    setTimeout(() => {
+      focusLastFocusedInput();
+    });
   };
 
   const confirmRemoveLinking = () => {

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -478,9 +478,6 @@ const QuickMarcEditor = ({
 
   const cancelRemoveLinking = () => {
     setIsUnlinkRecordsModalOpen(false);
-    setTimeout(() => {
-      focusLastFocusedInput();
-    });
   };
 
   const confirmRemoveLinking = () => {

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -135,6 +135,12 @@ const initialValues = {
       indicators: ['2', '\\'],
       id: 'test-id-1',
     },
+    {
+      tag: '999',
+      content: '',
+      indicators: ['f', 'f'],
+      id: '999',
+    },
   ],
 };
 
@@ -764,7 +770,7 @@ describe('Given QuickMarcEditor', () => {
     });
 
     describe('when click Cancel', () => {
-      it('should hide ConfirmationModal and restore deleted fields', async () => {
+      beforeEach(async () => {
         const {
           getAllByRole,
           getByText,
@@ -780,10 +786,21 @@ describe('Given QuickMarcEditor', () => {
 
         await act(async () => fireEvent.click(getByText('stripes-acq-components.FormFooter.save')));
         await fireEvent.click(getByText('Cancel'));
+      });
+
+      it('should hide ConfirmationModal and restore deleted fields', async () => {
+        await waitFor(() => {
+          expect(screen.queryByText('Confirmation modal')).toBeNull();
+          expect(screen.getByText('$a Test title')).toBeDefined();
+        });
+      });
+
+      it('should keep focus on the last focused element', async () => {
+        const moveUpButtons = screen.getAllByRole('button', { name: 'ui-quick-marc.record.moveUpRow' });
 
         await waitFor(() => {
-          expect(queryByText('Confirmation modal')).toBeNull();
-          expect(getByText('$a Test title')).toBeDefined();
+          expect(screen.getByText('$a Test title')).toBeDefined();
+          expect(moveUpButtons[moveUpButtons.length - 1]).toHaveFocus();
         });
       });
     });


### PR DESCRIPTION
## Description
When a user chooses "Cancel" option on any of the confirmation modals they should have focus on the last focused element before the modal opened.

## Screenshots

https://github.com/user-attachments/assets/3cf9f4ca-9485-4e10-9bf2-681a97c68f6c

## Issues
[UIQM-728](https://folio-org.atlassian.net/browse/UIQM-728)