### PR TITLE
Revert " [UIQM-763] Enable settings menu by default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 * [UIQM-752](https://issues.folio.org/browse/UIQM-752) *BREAKING* migrate react-intl to v7.
 * [UIQM-659](https://issues.folio.org/browse/UIQM-659) React v19: refactor away from default props for functional components.
 * [UIQM-761](https://issues.folio.org/browse/UIQM-761) Add `audit.config.groups.settings.collection.get` permission for `quickMARC: View MARC bibliographic record`.
-* [UIQM-763](https://folio-org.atlassian.net/browse/UIQM-763) Enable settings menu if `ui-quick-marc.settings.lccn-duplicate-check.edit` is enabled (possible in Eureka which allows invisible permission sets).
 
 ## [9.0.2] (IN PROGRESS)
 

--- a/package.json
+++ b/package.json
@@ -24,14 +24,6 @@
     ],
     "permissionSets": [
       {
-        "permissionName": "settings.quick-marc.enabled",
-        "displayName": "Settings (quickMARC): Can view and edit settings",
-        "subPermissions": [
-          "settings.enabled"
-        ],
-        "visible": false
-      },
-      {
         "permissionName": "ui-quick-marc.quick-marc-editor.view",
         "displayName": "quickMARC: View MARC bibliographic record",
         "subPermissions": [
@@ -173,7 +165,6 @@
         "permissionName": "ui-quick-marc.settings.lccn-duplicate-check.edit",
         "displayName": "Edit, View: Enable duplicate LCCN (010 $a) checking of MARC bibliographic and authority records",
         "subPermissions": [
-          "settings.quick-marc.enabled",
           "mod-settings.entries.collection.get",
           "mod-settings.global.read.ui-quick-marc.lccn-duplicate-check.manage",
           "mod-settings.entries.item.post",


### PR DESCRIPTION
Reverts folio-org/ui-quick-marc#785

We no longer support invisible permissions in Eureka, so the previous PR is no longer valid and should be reverted. 