### PR TITLE
UIQM-765 Add `shared=true` parameter to url when a user saves and keeps editing a Bib/Authority record on a central tenant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIQM-762](https://issues.folio.org/browse/UIQM-762) Select a MARC authority record - Update auto-populate Advanced search and Browse queries with all controlled subfields.
 * [UIQM-744](https://issues.folio.org/browse/UIQM-744) Remove "Create a" text from the paneheader when creating new authority, bib, and holdings records.
+* [UIQM-744](https://issues.folio.org/browse/UIQM-765) Add `shared=true` parameter to url when a user saves and keeps editing a Bib/Authority record on a central tenant.
 
 ## [10.0.0] (https://github.com/folio-org/ui-quick-marc/tree/v10.0.0) (2025-03-13)
 

--- a/src/QuickMarcEditor/useSaveRecord/useSaveRecord.test.js
+++ b/src/QuickMarcEditor/useSaveRecord/useSaveRecord.test.js
@@ -35,11 +35,6 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn(() => ({})),
 }));
 
-jest.mock('@folio/stripes/core', () => ({
-  ...jest.requireActual('@folio/stripes/core'),
-  checkIfUserInCentralTenant: jest.fn().mockReturnValue(false),
-}));
-
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   useShowCallout: jest.fn(() => mockShowCallout),

--- a/src/QuickMarcEditor/useSaveRecord/useSaveRecord.test.js
+++ b/src/QuickMarcEditor/useSaveRecord/useSaveRecord.test.js
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import faker from 'faker';
 
+import { checkIfUserInCentralTenant } from '@folio/stripes/core';
 import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
 
 import { QUICK_MARC_ACTIONS } from '../constants';
@@ -32,6 +33,11 @@ const mockShowCallout = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: jest.fn(() => ({})),
+}));
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  checkIfUserInCentralTenant: jest.fn().mockReturnValue(false),
 }));
 
 jest.mock('@folio/stripes-acq-components', () => ({
@@ -693,6 +699,8 @@ describe('useSaveRecord', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    checkIfUserInCentralTenant.mockClear().mockReturnValue(false);
+
     useAuthorityLinking.mockReturnValue({
       linkableBibFields: [],
       actualizeLinks: mockActualizeLinks,
@@ -1105,6 +1113,37 @@ describe('useSaveRecord', () => {
 
         expect(history.location.pathname).toBe(`${basePath}/edit-bibliographic/externalId-1`);
         expect(history.location.search).toBe('?sort=title');
+      });
+    });
+
+    describe('when a user is in a central tenant', () => {
+      beforeEach(() => {
+        checkIfUserInCentralTenant.mockClear().mockReturnValue(true);
+      });
+
+      it('should add "shared=true" parameter to the url', async () => {
+        const action = QUICK_MARC_ACTIONS.CREATE;
+        const marcType = MARC_TYPES.BIB;
+        const history = createMemoryHistory({
+          initialEntries: [`${basePath}?sort=title`],
+        });
+
+        const { result } = renderHook(useSaveRecord, {
+          initialProps: getInitialProps(marcType),
+          wrapper: getWrapper({
+            quickMarcContext: {
+              action,
+              marcType,
+              continueAfterSave: { current: true },
+            },
+            history,
+          }),
+        });
+
+        await act(async () => result.current.onSubmit(getFormValues(action, marcType)));
+
+        expect(history.location.pathname).toBe(`${basePath}/edit-bibliographic/externalId-1`);
+        expect(history.location.search).toBe('?sort=title&shared=true');
       });
     });
 

--- a/src/QuickMarcEditor/useSaveRecord/useSubmitRecord/useSumbitRecord.js
+++ b/src/QuickMarcEditor/useSaveRecord/useSubmitRecord/useSumbitRecord.js
@@ -11,7 +11,10 @@ import {
 import noop from 'lodash/noop';
 import isNil from 'lodash/isNil';
 
-import { useStripes } from '@folio/stripes/core';
+import {
+  useStripes,
+  checkIfUserInCentralTenant,
+} from '@folio/stripes/core';
 import { useShowCallout } from '@folio/stripes-acq-components';
 import { getHeaders } from '@folio/stripes-marc-components';
 
@@ -79,6 +82,14 @@ const useSubmitRecord = ({
     const fieldIds = getFieldIds(formValues);
     const searchParams = new URLSearchParams(location.search);
 
+    const isInCentralTenant = checkIfUserInCentralTenant(stripes);
+
+    // when a user creates a new Bib or Authority in a central tenant - it becomes shared
+    // so we need to append this parameter to the URL to tell quickMARC it is now a shared record
+    if (isInCentralTenant && marcType !== MARC_TYPES.HOLDINGS) {
+      searchParams.append('shared', true);
+    }
+
     const routes = {
       [MARC_TYPES.BIB]: `${basePath}/edit-bibliographic/${externalId}`,
       [MARC_TYPES.AUTHORITY]: `${basePath}/edit-authority/${externalId}`,
@@ -91,7 +102,7 @@ const useSubmitRecord = ({
       pathname: routes[marcType],
       search: searchParams.toString(),
     });
-  }, [basePath, marcType, location, history, refreshPageData]);
+  }, [basePath, marcType, location, history, refreshPageData, stripes]);
 
   const onCreate = useCallback(async (formValues, _api) => {
     const formValuesToProcess = prepareForSubmit(formValues);


### PR DESCRIPTION
## Description
When a user creates a new record in a central tenant and clicks "Save and keep editing" the pane title should say "Edit shared...".
Add `shared=true` parameter to url when a user saves and keeps editing a Bib/Authority record on a central tenant. This parameter tells quickMARC that we're editing a shared record.

## Screenshots
Central tenant

https://github.com/user-attachments/assets/e607a943-adbc-4dda-abac-ec246df5a6c3


Member tenant

https://github.com/user-attachments/assets/518c6500-bb38-405c-9eea-26d3f7b5c158


## Issues
[UIQM-765](https://folio-org.atlassian.net/browse/UIQM-765)