### PR TITLE
UIQM-766: useSaveRecord - do not use central tenant id when deriving a shared record from a member tenant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UIQM-762](https://issues.folio.org/browse/UIQM-762) Select a MARC authority record - Update auto-populate Advanced search and Browse queries with all controlled subfields.
 * [UIQM-744](https://issues.folio.org/browse/UIQM-744) Remove "Create a" text from the paneheader when creating new authority, bib, and holdings records.
 * [UIQM-744](https://issues.folio.org/browse/UIQM-765) Add `shared=true` parameter to url when a user saves and keeps editing a Bib/Authority record on a central tenant.
+* [UIQM-766](https://issues.folio.org/browse/UIQM-766) useSaveRecord - do not use central tenant id when deriving a shared record from a member tenant.
 
 ## [10.0.0] (https://github.com/folio-org/ui-quick-marc/tree/v10.0.0) (2025-03-13)
 

--- a/src/QuickMarcEditor/useSaveRecord/useSaveRecord.js
+++ b/src/QuickMarcEditor/useSaveRecord/useSaveRecord.js
@@ -77,7 +77,10 @@ const useSaveRecord = ({
     instance?.id,
   ]);
 
-  const { validate } = useValidation(validationContext, tenantId);
+  const validationTenantId = isRequestToCentralTenantFromMember && action !== QUICK_MARC_ACTIONS.DERIVE
+    ? centralTenantId
+    : null;
+  const { validate } = useValidation(validationContext, validationTenantId);
 
   const prepareForSubmit = useCallback((formValues) => {
     let handlers = [];


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Description
Currently, when a _member_ tenant _derives_ a _shared_ record the validation endpoint uses the central tenant id, which is incorrect since the record will become local, local records should use validation rules specified for the member tenant. 

After this PR is merged the validation will not use the central tenant id when deriving a shared record in a member tenant. 

The `isRequestToCentralTenantFromMember` checks if the record is shared and bib/authority and if the user is in the member tenant, it remains only to exclude the deriving action (`action !== QUICK_MARC_ACTIONS.DERIVE`).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Issues
[UIQM-766](https://folio-org.atlassian.net/browse/UIQM-766)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Sceencasts

https://github.com/user-attachments/assets/7bb422b8-5211-4b6b-a5b1-bd73fb411f90



## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
