### PR TITLE
UIQM-768 Switch to local record when deriving a shared MARC Bib record in a member tenant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UIQM-744](https://issues.folio.org/browse/UIQM-744) Remove "Create a" text from the paneheader when creating new authority, bib, and holdings records.
 * [UIQM-744](https://issues.folio.org/browse/UIQM-765) Add `shared=true` parameter to url when a user saves and keeps editing a Bib/Authority record on a central tenant.
 * [UIQM-766](https://issues.folio.org/browse/UIQM-766) useSaveRecord - do not use central tenant id when deriving a shared record from a member tenant.
+* [UIQM-768](https://issues.folio.org/browse/UIQM-768) Switch to local record when deriving a shared MARC Bib record in a member tenant.
 
 ## [10.0.0] (https://github.com/folio-org/ui-quick-marc/tree/v10.0.0) (2025-03-13)
 

--- a/src/MarcRoute/MarcRoute.js
+++ b/src/MarcRoute/MarcRoute.js
@@ -33,7 +33,14 @@ const MarcRoute = ({
     action,
   } = routeProps;
   const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
-  const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(location, stripes, marcType)
+
+  const searchParams = new URLSearchParams(location.search);
+
+  // in the rest of the code we get `isShared` from context, but this components is where we first
+  // use the QuickMarcProvider, so we can't access it yet. just get the value from the url
+  const isSharedRecord = searchParams.get('shared') === 'true';
+
+  const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(isSharedRecord, stripes, marcType)
     && action !== QUICK_MARC_ACTIONS.CREATE;
 
   const {

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -131,12 +131,11 @@ const QuickMarcEditor = ({
     setValidationErrors,
     continueAfterSave,
     validationErrorsRef,
+    isSharedRef,
   } = useContext(QuickMarcContext);
   const { hasErrorIssues, isBackEndValidationMarcType } = useValidation();
 
   const isConsortiaEnv = stripes.hasInterface('consortia');
-  const searchParameters = new URLSearchParams(location.search);
-  const isShared = searchParameters.get('shared') === 'true';
 
   const saveLastFocusedInput = useCallback((e) => {
     lastFocusedInput.current = e.target;
@@ -411,7 +410,7 @@ const QuickMarcEditor = ({
   const getPaneTitle = () => {
     let formattedMessageValues = {
       title: instance.title,
-      shared: isConsortiaEnv ? isShared : null,
+      shared: isConsortiaEnv ? isSharedRef.current : null,
     };
 
     if (marcType === MARC_TYPES.HOLDINGS && action !== QUICK_MARC_ACTIONS.CREATE) {
@@ -427,7 +426,7 @@ const QuickMarcEditor = ({
 
       const headingContent = initialHeading?.content;
       const shared = isConsortiaEnv
-        ? checkIfUserInCentralTenant(stripes) || isShared
+        ? checkIfUserInCentralTenant(stripes) || isSharedRef.current
         : null;
 
       formattedMessageValues = {

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -118,12 +118,11 @@ const QuickMarcEditorContainer = ({
     return `${externalRecordPath}/${externalId}`;
   }, [externalRecordPath, marcType, externalId, instanceId, action]);
 
-  const loadData = useCallback(async (fieldIds, nextAction, nextExternalId, nextIsShared) => {
+  const loadData = useCallback(async (fieldIds, nextAction, nextExternalId) => {
     const _action = nextAction || action;
     const _externalId = nextExternalId || externalId;
-    const _isShared = nextIsShared || isSharedRef.current;
 
-    const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(_isShared, stripes, marcType)
+    const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(isSharedRef.current, stripes, marcType)
       && _action !== QUICK_MARC_ACTIONS.CREATE;
 
     const path = _action === QUICK_MARC_ACTIONS.CREATE && marcType === MARC_TYPES.HOLDINGS

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -66,7 +66,6 @@ const QuickMarcEditorContainer = ({
   onClose,
   onSave,
   history,
-  location,
   externalRecordPath,
   stripes,
   onCheckCentralTenantPerm = noop,
@@ -84,6 +83,7 @@ const QuickMarcEditorContainer = ({
     setInstance,
     setMarcRecord,
     setRelatedRecordVersion,
+    isSharedRef,
   } = useContext(QuickMarcContext);
   const [locations, setLocations] = useState();
   const [isLoading, setIsLoading] = useState(true);
@@ -93,9 +93,6 @@ const QuickMarcEditorContainer = ({
 
   const { token, locale } = stripes.okapi;
   const centralTenantId = stripes.user.user.consortium?.centralTenantId;
-
-  const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(location, stripes, marcType)
-    && action !== QUICK_MARC_ACTIONS.CREATE;
 
   const getCloseEditorParams = useCallback((id) => {
     if (marcType === MARC_TYPES.HOLDINGS && action !== QUICK_MARC_ACTIONS.CREATE) {
@@ -121,9 +118,13 @@ const QuickMarcEditorContainer = ({
     return `${externalRecordPath}/${externalId}`;
   }, [externalRecordPath, marcType, externalId, instanceId, action]);
 
-  const loadData = useCallback(async (fieldIds, nextAction, nextExternalId) => {
+  const loadData = useCallback(async (fieldIds, nextAction, nextExternalId, nextIsShared) => {
     const _action = nextAction || action;
     const _externalId = nextExternalId || externalId;
+    const _isShared = nextIsShared || isSharedRef.current;
+
+    const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(_isShared, stripes, marcType)
+      && _action !== QUICK_MARC_ACTIONS.CREATE;
 
     const path = _action === QUICK_MARC_ACTIONS.CREATE && marcType === MARC_TYPES.HOLDINGS
       ? EXTERNAL_INSTANCE_APIS[MARC_TYPES.BIB]
@@ -212,7 +213,6 @@ const QuickMarcEditorContainer = ({
     centralTenantId,
     token,
     locale,
-    isRequestToCentralTenantFromMember,
     setRelatedRecordVersion,
   ]);
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
@@ -1,12 +1,12 @@
 import {
   useState,
   useMemo,
+  useContext,
 } from 'react';
 import {
   useIntl,
   FormattedMessage,
 } from 'react-intl';
-import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import uniq from 'lodash/uniq';
 
@@ -26,6 +26,7 @@ import {
 } from '@folio/stripes/components';
 import { useAuthorityLinkingRules } from '@folio/stripes-marc-components';
 
+import { QuickMarcContext } from '../../../contexts';
 import { useMarcSource } from '../../../queries';
 import { MarcFieldContent } from '../../../common';
 import {
@@ -68,12 +69,11 @@ const LinkButton = ({
 }) => {
   const stripes = useStripes();
   const intl = useIntl();
-  const location = useLocation();
   const [authority, setAuthority] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const callout = useCallout();
+  const { isSharedRef } = useContext(QuickMarcContext);
   const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
-  const isSharedBibRecord = new URLSearchParams(location.search).get('shared') === 'true';
 
   let showSharedFilter = false;
   let showSharedRecordsOnly = false;
@@ -84,7 +84,7 @@ const LinkButton = ({
       showSharedRecordsOnly = true;
     }
   } else if (checkIfUserInMemberTenant(stripes)) {
-    if (isSharedBibRecord) {
+    if (isSharedRef.current) {
       if (action === QUICK_MARC_ACTIONS.EDIT) {
         showSharedRecordsOnly = true;
         pluginTenantId = centralTenantId;

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { createMemoryHistory } from 'history';
 
 import {
   act,
@@ -39,7 +38,7 @@ const mockHandleLinkAuthority = jest.fn();
 const mockHandleUnlinkAuthority = jest.fn();
 
 const renderComponent = (props = {}) => render(
-  <Harness history={props.history}>
+  <Harness quickMarcContext={props.quickMarcContext}>
     <LinkButton
       action={QUICK_MARC_ACTIONS.EDIT}
       handleLinkAuthority={mockHandleLinkAuthority}
@@ -301,10 +300,6 @@ describe('Given LinkButton', () => {
     it('should pass correct props', () => {
       checkIfUserInMemberTenant.mockReturnValue(true);
 
-      const history = createMemoryHistory({
-        initialEntries: [{ search: '?shared=true' }],
-      });
-
       const centralTenantId = 'consortia';
       const initialValues = expect.objectContaining({
         browse: expect.objectContaining({
@@ -323,7 +318,11 @@ describe('Given LinkButton', () => {
         browse: ['shared'],
       };
 
-      renderComponent({ history });
+      renderComponent({
+        quickMarcContext: {
+          isSharedRef: { current: true },
+        },
+      });
 
       expect(Pluggable).toHaveBeenLastCalledWith(expect.objectContaining({
         tenantId: centralTenantId,
@@ -336,10 +335,6 @@ describe('Given LinkButton', () => {
   describe('when member tenant derives a shared bib record', () => {
     it('should pass correct props', () => {
       checkIfUserInMemberTenant.mockReturnValue(true);
-
-      const history = createMemoryHistory({
-        initialEntries: [{ search: '?shared=true' }],
-      });
 
       const initialValues = expect.objectContaining({
         browse: expect.objectContaining({
@@ -356,7 +351,9 @@ describe('Given LinkButton', () => {
 
       renderComponent({
         action: QUICK_MARC_ACTIONS.DERIVE,
-        history,
+        quickMarcContext: {
+          isSharedRef: { current: true },
+        },
       });
 
       expect(Pluggable).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -375,10 +372,6 @@ describe('Given LinkButton', () => {
   `('should pass correct props when member tenant $action a not shared bib record', ({ action }) => {
     checkIfUserInMemberTenant.mockReturnValue(true);
 
-    const history = createMemoryHistory({
-      initialEntries: [{ search: '?shared=false' }],
-    });
-
     const initialValues = expect.objectContaining({
       browse: expect.objectContaining({
         filters: null,
@@ -394,7 +387,9 @@ describe('Given LinkButton', () => {
 
     renderComponent({
       action,
-      history,
+      quickMarcContext: {
+        isSharedRef: { current: false },
+      },
     });
 
     expect(Pluggable).toHaveBeenLastCalledWith(expect.objectContaining({

--- a/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/QuickMarcEditorRows.js
@@ -96,7 +96,6 @@ const QuickMarcEditorRows = ({
   onCheckCentralTenantPerm = noop,
   onInputFocus,
 }) => {
-  const location = useLocation();
   const stripes = useStripes();
   const intl = useIntl();
   const { initialValues } = useFormState();
@@ -105,7 +104,10 @@ const QuickMarcEditorRows = ({
   const newRowRef = useRef(null);
   const rowContentWidth = useRef(null); // for max-width of resizable textareas
   const childCalloutRef = useRef(null);
-  const { validationErrorsRef } = useContext(QuickMarcContext);
+  const {
+    validationErrorsRef,
+    isSharedRef,
+  } = useContext(QuickMarcContext);
 
   const {
     linkAuthority,
@@ -114,7 +116,7 @@ const QuickMarcEditorRows = ({
     autoLinkableBibFields,
   } = useAuthorityLinking({ marcType, action });
 
-  const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(location, stripes, marcType)
+  const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(isSharedRef.current, stripes, marcType)
     && action === QUICK_MARC_ACTIONS.EDIT;
 
   const fixedFieldInitialValues = () => {

--- a/src/QuickMarcEditor/useSaveRecord/useSaveRecord.js
+++ b/src/QuickMarcEditor/useSaveRecord/useSaveRecord.js
@@ -41,13 +41,22 @@ const useSaveRecord = ({
   onClose,
   onSave,
 }) => {
-  const location = useLocation();
   const stripes = useStripes();
 
-  const { action, marcType, initialValues, instance } = useContext(QuickMarcContext);
-  const { linkableBibFields, linkingRules, sourceFiles } = useAuthorityLinking({ marcType, action });
+  const {
+    action,
+    marcType,
+    initialValues,
+    instance,
+    isSharedRef,
+  } = useContext(QuickMarcContext);
+  const {
+    linkableBibFields,
+    linkingRules,
+    sourceFiles,
+  } = useAuthorityLinking({ marcType, action });
 
-  const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(location, stripes, marcType);
+  const isRequestToCentralTenantFromMember = applyCentralTenantInHeaders(isSharedRef.current, stripes, marcType);
   const centralTenantId = stripes.user.user.consortium?.centralTenantId;
   const tenantId = isRequestToCentralTenantFromMember ? centralTenantId : '';
 

--- a/src/QuickMarcEditor/useSaveRecord/useSubmitRecord/useSumbitRecord.js
+++ b/src/QuickMarcEditor/useSaveRecord/useSubmitRecord/useSumbitRecord.js
@@ -60,6 +60,7 @@ const useSubmitRecord = ({
     instance,
     continueAfterSave,
     relatedRecordVersion,
+    setIsShared,
   } = useContext(QuickMarcContext);
 
   const { actualizeLinks } = useAuthorityLinking({ marcType, action });
@@ -87,7 +88,11 @@ const useSubmitRecord = ({
     // when a user creates a new Bib or Authority in a central tenant - it becomes shared
     // so we need to append this parameter to the URL to tell quickMARC it is now a shared record
     if (isInCentralTenant && marcType !== MARC_TYPES.HOLDINGS) {
-      searchParams.append('shared', true);
+      setIsShared(true);
+    }
+
+    if (action === QUICK_MARC_ACTIONS.DERIVE) {
+      setIsShared(false);
     }
 
     const routes = {
@@ -96,13 +101,13 @@ const useSubmitRecord = ({
       [MARC_TYPES.HOLDINGS]: `${basePath}/edit-holdings/${externalId}`,
     };
 
-    await refreshPageData(fieldIds, QUICK_MARC_ACTIONS.EDIT, externalId);
-
-    history.push({
+    await history.push({
       pathname: routes[marcType],
       search: searchParams.toString(),
     });
-  }, [basePath, marcType, location, history, refreshPageData, stripes]);
+
+    await refreshPageData(fieldIds, QUICK_MARC_ACTIONS.EDIT, externalId);
+  }, [basePath, marcType, location, history, refreshPageData, stripes, action, setIsShared]);
 
   const onCreate = useCallback(async (formValues, _api) => {
     const formValuesToProcess = prepareForSubmit(formValues);

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -1200,12 +1200,9 @@ export const hydrateForLinkSuggestions = (marcRecord, marcType, fields) => {
   });
 };
 
-export const applyCentralTenantInHeaders = (location, stripes, marcType) => {
-  const searchParams = new URLSearchParams(location.search);
-  const isSharedRecord = searchParams.get('shared') === 'true';
-
+export const applyCentralTenantInHeaders = (isShared, stripes, marcType) => {
   return (
-    isSharedRecord
+    isShared
     && [MARC_TYPES.BIB, MARC_TYPES.AUTHORITY].includes(marcType)
     && checkIfUserInMemberTenant(stripes)
   );

--- a/src/contexts/QuickMarcContext/QuickMarcContext.js
+++ b/src/contexts/QuickMarcContext/QuickMarcContext.js
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 const QuickMarcContext = createContext();
@@ -25,12 +26,16 @@ const QuickMarcProvider = ({
   marcType,
   basePath,
 }) => {
+  const location = useLocation();
   const [instance, setInstance] = useState(null);
   const [marcRecord, setMarcRecord] = useState(null);
   const [selectedSourceFile, setSelectedSourceFile] = useState(null);
   const [_relatedRecordVersion, setRelatedRecordVersion] = useState();
   const validationErrors = useRef({});
   const continueAfterSave = useRef(false);
+  const isSharedRef = useRef(new URLSearchParams(location.search).get('shared') === 'true');
+
+  const setIsShared = useCallback((_isShared) => { isSharedRef.current = _isShared; }, []);
 
   const setValidationErrors = useCallback((newValidationErrors) => {
     validationErrors.current = newValidationErrors;
@@ -51,6 +56,8 @@ const QuickMarcProvider = ({
     initialValues: marcRecord,
     setMarcRecord,
     basePath,
+    isSharedRef,
+    setIsShared,
   }), [
     selectedSourceFile,
     setSelectedSourceFile,
@@ -66,6 +73,8 @@ const QuickMarcProvider = ({
     marcRecord,
     setMarcRecord,
     basePath,
+    isSharedRef,
+    setIsShared,
   ]);
 
   return (

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.js
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useContext,
   useMemo,
 } from 'react';
 import { useLocation } from 'react-router-dom';
@@ -30,15 +31,16 @@ import {
   UNCONTROLLED_NUMBER,
   QUICK_MARC_ACTIONS,
 } from '../../QuickMarcEditor/constants';
+import { QuickMarcContext } from '../../contexts';
 
 const formatSubfieldCode = (code) => { return code.startsWith('$') ? code : `$${code}`; };
 
 const useAuthorityLinking = ({ tenantId, marcType, action } = {}) => {
   const stripes = useStripes();
-  const location = useLocation();
+  const { isSharedRef } = useContext(QuickMarcContext);
 
   const centralTenantId = stripes.user.user.consortium?.centralTenantId;
-  const isCentralTenantInHeaders = applyCentralTenantInHeaders(location, stripes, marcType)
+  const isCentralTenantInHeaders = applyCentralTenantInHeaders(isSharedRef.current, stripes, marcType)
     && action === QUICK_MARC_ACTIONS.EDIT;
 
   // tenantId for linking functionality must be with the member tenant id when user derives shared record

--- a/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
+++ b/src/hooks/useAuthorityLinking/useAuthorityLinking.test.js
@@ -16,6 +16,7 @@ import {
   bibLeader,
   bibLeaderString,
 } from '../../../test/jest/fixtures/leaders';
+import Harness from '../../../test/jest/helpers/harness';
 
 const mockFetchLinkSuggestions = jest.fn().mockResolvedValue({ fields: [] });
 
@@ -46,7 +47,9 @@ const queryClient = new QueryClient();
 
 const wrapper = ({ children }) => (
   <QueryClientProvider client={queryClient}>
-    {children}
+    <Harness>
+      {children}
+    </Harness>
   </QueryClientProvider>
 );
 

--- a/test/jest/helpers/harness.js
+++ b/test/jest/helpers/harness.js
@@ -29,6 +29,8 @@ const defaultQuickMarcContextValue = {
   setSelectedSourceFile: jest.fn(),
   basePath: '/base-path',
   continueAfterSave: { current: false },
+  isSharedRef: { current: false },
+  setIsShared: jest.fn(),
 };
 
 const QuickMarcProviderMock = ({ ctxValue, children }) => (


### PR DESCRIPTION
## Description
Fixing an issue when deriving a shared MARC Bib record in a member tenant and clicking "Save and keep editing" would close the derived record and show a message that a record is not found. It should instead stay opened and the page title should say "Edit local MARC record".

The issue was caused by quickMARC still being in "shared record" mode after saving a record.
quickMARC needed to be told which mode to use by a `shared` url query parameter, and everywhere that we needed to check which mode we're in - we checked the url.
To fix the issue simply updating the url on save didn't really work because some callbacks still had old "shared record" mode selected and so we sent requests to the wrong tenant.
Instead of the url query param we now store the `isShared` flag in context as a ref, so all callbacks immediately know about the mode change.

## Screenshots


https://github.com/user-attachments/assets/1806b028-5b68-4745-b78f-ad78cbd0835a


## Issues
[UIQM-768](https://folio-org.atlassian.net/browse/UIQM-768)