### PR TITLE
UIQM-771 FE | Support Create/Update action for MARC holdings record on shared Instance from member tenant on ECS environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIQM-762](https://issues.folio.org/browse/UIQM-762) Select a MARC authority record - Update auto-populate Advanced search and Browse queries with all controlled subfields.
 * [UIQM-744](https://issues.folio.org/browse/UIQM-744) Remove "Create a" text from the paneheader when creating new authority, bib, and holdings records.
+* [UIQM-771](https://issues.folio.org/browse/UIQM-771) FE | Support Create/Update action for MARC holdings record on shared Instance from member tenant on ECS environment.
 
 ## [10.0.2]  (https://github.com/folio-org/ui-quick-marc/tree/v10.0.2) (2025-04-29)
 


### PR DESCRIPTION
## Description
Users should be able to create MARC Holdings records in shared Instance records from a member tenant.

## Screenshots

## Issues
[UIQM-771](https://folio-org.atlassian.net/browse/UIQM-771)