### PR TITLE
UIQM-773 Use Central tenant linking rules when user editing Shared MARC bib from Central or Member tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIQM-762](https://issues.folio.org/browse/UIQM-762) Select a MARC authority record - Update auto-populate Advanced search and Browse queries with all controlled subfields.
 * [UIQM-744](https://issues.folio.org/browse/UIQM-744) Remove "Create a" text from the paneheader when creating new authority, bib, and holdings records.
+* [UIQM-773](https://issues.folio.org/browse/UIQM-773) Use Central tenant linking rules when user editing Shared MARC bib from Central or Member tenant.
 
 ## [10.0.2]  (https://github.com/folio-org/ui-quick-marc/tree/v10.0.2) (2025-04-29)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
@@ -113,7 +113,7 @@ const LinkButton = ({
     },
   });
 
-  const { linkingRules } = useAuthorityLinkingRules();
+  const { linkingRules } = useAuthorityLinkingRules({ tenantId: isShared ? centralTenantId : null });
 
   const onLinkRecord = (_authority) => {
     if (_authority.id === authority?.id) {


### PR DESCRIPTION
## Description
When linking an Authority to a shared MARC Bib record - fetch linking rules from the central tenant

## Issues
[UIQM-773](https://folio-org.atlassian.net/browse/UIQM-773)