### PR TITLE
UIQM-773 use member tenant linking rules when deriving a shared bib record (follow-up)

### DIFF
--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
@@ -113,7 +113,12 @@ const LinkButton = ({
     },
   });
 
-  const { linkingRules } = useAuthorityLinkingRules({ tenantId: isShared ? centralTenantId : null });
+  // override tenant to central tenant id only when editing a shared MARC Bib record
+  // in all other cases current tenant is what we need to use
+  // when creating or deriving a MARC record we need to use current tenant's linking rules
+  // regardless of if it's a shared record or no
+  const linkingRulesTenantId = action === QUICK_MARC_ACTIONS.EDIT && isShared ? centralTenantId : null;
+  const { linkingRules } = useAuthorityLinkingRules({ tenantId: linkingRulesTenantId });
 
   const onLinkRecord = (_authority) => {
     if (_authority.id === authority?.id) {


### PR DESCRIPTION
## Description
Fetch linking rules from central tenant only when editing a shared MARC Bib record.
When deriving a shared MARC Bib record or creating a new MARC Bib record we should fetch linking rules from a current member tenant, because a created record will be a local MARC Bib record.

## Issues
[UIQM-773](https://folio-org.atlassian.net/browse/UIQM-773)