### PR TITLE
UIQM-777 Support validation of MARC Holdings records with location codes that have a whitespace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UIQM-762](https://issues.folio.org/browse/UIQM-762) Select a MARC authority record - Update auto-populate Advanced search and Browse queries with all controlled subfields.
 * [UIQM-744](https://issues.folio.org/browse/UIQM-744) Remove "Create a" text from the paneheader when creating new authority, bib, and holdings records.
 * [UIQM-773](https://issues.folio.org/browse/UIQM-773) Use Central tenant linking rules when user editing Shared MARC bib from Central or Member tenant.
+* [UIQM-777](https://issues.folio.org/browse/UIQM-777) Support validation of MARC Holdings records with location codes that have a whitespace.
 
 ## [10.0.3](https://github.com/folio-org/ui-quick-marc/tree/v10.0.3) (2025-06-30)
 

--- a/src/QuickMarcEditor/QuickMarcEditorRows/LocationField/LocationField.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LocationField/LocationField.js
@@ -29,10 +29,10 @@ const LocationField = ({
 
   const handleSelectLocation = (location) => {
     const permanentLocation = `$b ${location.code}`;
-    const locationSubfield = getLocationValue(input.value);
+    const locationValue = getLocationValue(input.value);
 
-    const newInputValue = locationSubfield
-      ? input.value.replace(locationSubfield, permanentLocation)
+    const newInputValue = locationValue
+      ? input.value.replace(`$b ${locationValue}`, permanentLocation)
       : `${permanentLocation} ${input.value.trim()}`;
 
     input.onChange(newInputValue);

--- a/src/QuickMarcEditor/utils.js
+++ b/src/QuickMarcEditor/utils.js
@@ -555,9 +555,9 @@ export const addNewRecord = (index, state) => {
 };
 
 export const getLocationValue = (value) => {
-  const matches = value?.match(/\$b\s+([^$\s]+\/?)+/) || [];
+  const fieldContent = new MarcFieldContent(value);
 
-  return matches[0] || '';
+  return fieldContent.$b?.[0] || '';
 };
 
 export const checkIsEmptyContent = (field) => {

--- a/src/QuickMarcEditor/utils.test.js
+++ b/src/QuickMarcEditor/utils.test.js
@@ -1522,7 +1522,7 @@ describe('QuickMarcEditor utils', () => {
   describe('getLocationValue', () => {
     describe('when has matches', () => {
       it('should return matched location value', () => {
-        expect(utils.getLocationValue('$b KU/CC/DI/A $t 3 $h M3')).toEqual('$b KU/CC/DI/A');
+        expect(utils.getLocationValue('$b KU/CC/DI/A $t 3 $h M3')).toEqual('KU/CC/DI/A');
       });
     });
 

--- a/src/hooks/useValidation/validators.js
+++ b/src/hooks/useValidation/validators.js
@@ -315,7 +315,7 @@ export const validateLocation = ({ marcRecords, locations }, rule) => {
   const fields = marcRecords.filter(record => record.tag === rule.tag);
 
   const failingFields = fields.filter(field => {
-    const [, locationValue] = getLocationValue(field.content)?.replace(/\s+/, ' ').split(' ') || '';
+    const locationValue = getLocationValue(field.content);
 
     const locationExists = Boolean(locations.find(location => location.code === locationValue));
 

--- a/src/hooks/useValidation/validators.test.js
+++ b/src/hooks/useValidation/validators.test.js
@@ -13,6 +13,8 @@ const locations = [{
   code: 'VA/LI/D',
 }, {
   code: 'LO/CA/TI/ON',
+}, {
+  code: 'WITH SPACE',
 }];
 
 describe('validators', () => {
@@ -574,6 +576,17 @@ describe('validators', () => {
       const marcRecords = [{
         tag: '852',
         content: '$b VA/LI/D',
+      }];
+
+      validators.validateLocation({ marcRecords, locations }, rule);
+
+      expect(rule.message).not.toHaveBeenCalled();
+    });
+
+    it('should not return an error when field contains a whitespace', () => {
+      const marcRecords = [{
+        tag: '852',
+        content: '$b WITH SPACE',
       }];
 
       validators.validateLocation({ marcRecords, locations }, rule);


### PR DESCRIPTION
## Description
When creating a MARC Holdings record using a location that has a white space in it's code - validation failed due to "location does not exist" error.
Issue was caused by `getLocationValue` util that used a regex that didn't account for white spaces in location code values.
Instead we should use `MarcFieldContent` object that correctly parses subfield values that have white spaces.

## Screenshots

https://github.com/user-attachments/assets/ab3cbf2b-d52b-4d3e-8cd9-c3f85a191d2d

## Issues
[UIQM-777](https://folio-org.atlassian.net/browse/UIQM-777)