### PR TITLE
UIQM-785 only browse by name-title for 600, 610, 611, 700, 710, 711, 800, 810, 811 tags

### DIFF
--- a/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
+++ b/src/QuickMarcEditor/QuickMarcEditorRows/LinkButton/LinkButton.js
@@ -157,7 +157,8 @@ const LinkButton = ({
   }
 
   const initialValues = useMemo(() => {
-    const isNameTitleBrowseTag = tag.match(/[678]\d\d$/);
+    const nameTitleBrowseTags = [600, 610, 611, 700, 710, 711, 800, 810, 811];
+    const isNameTitleBrowseTag = nameTitleBrowseTags.includes(parseInt(tag, 10));
     const { dropdownValue: dropdownValueByTag } = DEFAULT_LOOKUP_OPTIONS[tag];
     const linkableBibSubfields = uniq(linkingRules
       .filter(linkingRule => linkingRule.bibField === tag)


### PR DESCRIPTION
## Description
Only 6XX, 7XX and 8XX fields that should be browsed by Name-title are 600, 610, 611, 700, 710, 711, 800, 810, 811

## Issues
[UIQM-785](https://folio-org.atlassian.net/browse/UIQM-785)