### PR TITLE
UIQM-816 Keep polling mod-search until it returns a record or we exceed max attempts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [UIQM-807](https://issues.folio.org/browse/UIQM-807) Create/Edit/Derive a MARC bib record: Add an infotip popover to the right of Link Headings button.
 * [UIQM-804](https://issues.folio.org/browse/UIQM-804) include global permissions in package.json base permissions.
 * [UIQM-806](https://issues.folio.org/browse/UIQM-806) *BREAKING* Remove request to mod-quick-marc `status` endpoint and use data from records-editor POST response directly.
+* [UIQM-816](https://issues.folio.org/browse/UIQM-816) Keep polling mod-search until it returns a record or we exceed max attempts.
 
 ## [10.0.4](https://github.com/folio-org/ui-quick-marc/tree/v10.0.4) (2025-07-14)
 

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -226,6 +226,10 @@ const QuickMarcEditorContainer = ({
         linkingRulesResponse,
         fixedFieldSpecResponse,
       ]) => {
+        if (!instanceResponse) {
+          throw new Error();
+        }
+
         let dehydratedMarcRecord;
 
         const isShouldUseInitialValuesProp = initialValuesProp && !isUsingRouter && !isPreEdited;

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -227,7 +227,7 @@ const QuickMarcEditorContainer = ({
         fixedFieldSpecResponse,
       ]) => {
         if (!instanceResponse) {
-          throw new Error();
+          throw new Error('External record not loaded');
         }
 
         let dehydratedMarcRecord;

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.js
@@ -149,6 +149,33 @@ const QuickMarcEditorContainer = ({
     return `${externalRecordPath}/${externalId}`;
   }, [externalRecordPath, marcType, externalId, instanceId, action]);
 
+  // when creating a new record, /records-editor/records returns a 201 status, but that only indicates that
+  // a MARC record has been created. There may be some delay between MARC record creation and when mod-search
+  // completes indexing of the new record so it becomes available in search
+  // this delay becomes apparent when creating a new record via "Save & keep editing" button, when
+  // after creating a record we get an error due to a missing record in mod-search
+  // we can avoid this by making a few attemts to find the new record
+  const retryFetchingExternalRecord = useCallback(async () => {
+    const RETRY_TIMEOUT = 2000;
+    const FETCH_ATTEMPTS = 10;
+    let currentAttempt = 1;
+
+    let externalRecord = null;
+
+    do {
+      externalRecord = await fetchExternalRecord();
+
+      if (externalRecord) {
+        return externalRecord;
+      }
+
+      await new Promise(resolve => setTimeout(resolve, RETRY_TIMEOUT));
+      currentAttempt++;
+    } while (!externalRecord && currentAttempt <= FETCH_ATTEMPTS);
+
+    return null;
+  }, [fetchExternalRecord]);
+
   const loadData = useCallback(async (fieldIds, nextAction, nextExternalId) => {
     const _action = nextAction || action;
     const _externalId = nextExternalId || externalId;
@@ -170,7 +197,7 @@ const QuickMarcEditorContainer = ({
 
     const instancePromise = _action === QUICK_MARC_ACTIONS.CREATE && marcType !== MARC_TYPES.HOLDINGS
       ? Promise.resolve({})
-      : fetchExternalRecord();
+      : retryFetchingExternalRecord();
 
     const marcRecordPromise = _action === QUICK_MARC_ACTIONS.CREATE
       ? Promise.resolve({})
@@ -267,7 +294,7 @@ const QuickMarcEditorContainer = ({
     locale,
     getIsShared,
     stripes,
-    fetchExternalRecord,
+    retryFetchingExternalRecord,
     handleClose,
     mutator,
     formatInitialValues,

--- a/src/QuickMarcEditor/QuickMarcEditorContainer.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditorContainer.test.js
@@ -675,4 +675,42 @@ describe('Given Quick Marc Editor Container', () => {
       await waitFor(() => expect(mockSetPreEditedValues).toHaveBeenCalled());
     });
   });
+
+  describe('when fetchExternalRecord does not return a record on first attempt', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      mockFetchExternalRecord.mockResolvedValue(null);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should keep polling the endpoint until it returns a record', async () => {
+      renderQuickMarcEditorContainer({
+        mutator,
+        quickMarcContext: {
+          instance,
+          action: QUICK_MARC_ACTIONS.EDIT,
+          marcType: MARC_TYPES.BIB,
+          isUsingRouter: false,
+        },
+      });
+
+      expect(screen.getByText('LoadingView')).toBeInTheDocument();
+
+      await jest.advanceTimersByTimeAsync(2000);
+
+      expect(mockFetchExternalRecord).toHaveBeenCalledTimes(2);
+
+      mockFetchExternalRecord.mockResolvedValue({});
+
+      await jest.advanceTimersByTimeAsync(2000);
+
+      expect(mockFetchExternalRecord).toHaveBeenCalledTimes(3);
+
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(screen.queryByText('LoadingView')).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Description
When creating a new record, `/records-editor/records` returns a 201 status, but that only indicates that a MARC record has been created. There may be some delay between MARC record creation and when mod-search completes indexing of the new record so it becomes available in search
This delay becomes apparent when creating a new record via "Save & keep editing" button, when after creating a record we get an error due to a missing record in mod-search
We can avoid this by short-polling mod-search until in returns a record or we reach max number of attempts.

## Issues
[UIQM-816](https://folio-org.atlassian.net/browse/UIQM-816)