### PR TITLE
UIQM-818 Update the label of the new option for position 25 of the 008 field in a MARC bibliographic record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-quick-marc
 
+## [11.1.0] (IN PROGRESS)
+
+* [UIQM-818](https://issues.folio.org/browse/UIQM-818) Update the label of the new option for position 25 of the 008 field in a MARC bibliographic record.
+
 ## [11.0.0](https://github.com/folio-org/ui-quick-marc/tree/v11.0.0) (2026-04-17)
 
 * [UIQM-762](https://issues.folio.org/browse/UIQM-762) Select a MARC authority record - Update auto-populate Advanced search and Browse queries with all controlled subfields.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/quick-marc",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Quick MARC editor",
   "main": "index.js",
   "repository": "",

--- a/translations/ui-quick-marc/en.json
+++ b/translations/ui-quick-marc/en.json
@@ -751,6 +751,7 @@
   "record.fixedField.Atlas": "Atlas",
   "record.fixedField.Separate supplement to another work": "Separate supplement to another work",
   "record.fixedField.Bound as part of another work": "Bound as part of another work",
+  "record.fixedField.Remote sensing image": "Remote sensing image",
   "record.fixedField.No specified special format characteristics": "No specified special format characteristics",
   "record.fixedField.Manuscript": "Manuscript",
   "record.fixedField.Picture card, post card": "Picture card, post card",


### PR DESCRIPTION
## Description
Update the label of the new option for position 25 of the 008 field in a MARC bibliographic record

## Issues
[UIQM-818](https://folio-org.atlassian.net/browse/UIQM-818)