### PR TITLE
UIQM-825 Show correct error toast when editing a record deleted by an other user.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [11.1.0] (IN PROGRESS)
 
+* [UIQM-825](https://issues.folio.org/browse/UIQM-825) Show correct error toast when editing a record deleted by another user.
+
 ## [11.0.1](https://github.com/folio-org/ui-quick-marc/tree/v11.0.1) (2026-05-20)
 
 * [UIQM-818](https://issues.folio.org/browse/UIQM-818) Update the label of the new option for position 25 of the 008 field in a MARC bibliographic record.

--- a/src/QuickMarcEditor/QuickMarcEditor.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.js
@@ -555,7 +555,7 @@ const QuickMarcEditor = ({
       return;
     } else if (httpError.code === 'ILLEGAL_FIXED_LENGTH_CONTROL_FIELD') {
       messageId = 'ui-quick-marc.record.save.error.illegalFixedLength';
-    } else if (httpError.httpStatus === 404) {
+    } else if (httpError.code === 'NOT_FOUND') {
       messageId = 'ui-quick-marc.record.save.error.notFound';
     } else {
       messageId = 'ui-quick-marc.record.save.error.generic';

--- a/src/QuickMarcEditor/QuickMarcEditor.test.js
+++ b/src/QuickMarcEditor/QuickMarcEditor.test.js
@@ -750,6 +750,44 @@ describe('Given QuickMarcEditor', () => {
     });
   });
 
+  describe('when there is an httpError', () => {
+    describe('when it is a NOT_FOUND code', () => {
+      it('should show a correct toast message', () => {
+        renderQuickMarcEditor({
+          httpError: {
+            code: 'NOT_FOUND',
+          },
+        });
+
+        expect(mockShowCallout).toHaveBeenCalledWith({ messageId: 'ui-quick-marc.record.save.error.notFound', type: 'error' });
+      });
+    });
+
+    describe('when it is a ILLEGAL_FIXED_LENGTH_CONTROL_FIELD code', () => {
+      it('should show a correct toast message', () => {
+        renderQuickMarcEditor({
+          httpError: {
+            code: 'ILLEGAL_FIXED_LENGTH_CONTROL_FIELD',
+          },
+        });
+
+        expect(mockShowCallout).toHaveBeenCalledWith({ messageId: 'ui-quick-marc.record.save.error.illegalFixedLength', type: 'error' });
+      });
+    });
+
+    describe('when it is an unknown code', () => {
+      it('should show a generic toast message', () => {
+        renderQuickMarcEditor({
+          httpError: {
+            code: 'SOME_UNKNOWN_CODE',
+          },
+        });
+
+        expect(mockShowCallout).toHaveBeenCalledWith({ messageId: 'ui-quick-marc.record.save.error.generic', type: 'error' });
+      });
+    });
+  });
+
   describe('when there are deleted fields', () => {
     it('should display ConfirmationModal', async () => {
       const {


### PR DESCRIPTION
## Description
Show correct error toast when editing a record deleted by an other user.
BE error response has changed, so we need to update handling on UI

## Issues
[UIQM-825](https://folio-org.atlassian.net/browse/UIQM-825)